### PR TITLE
LPS-32527 UnsyncPrintWriter.reset() should release super lock to reduce ...

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/io/unsync/UnsyncPrintWriter.java
+++ b/portal-service/src/com/liferay/portal/kernel/io/unsync/UnsyncPrintWriter.java
@@ -308,6 +308,7 @@ public class UnsyncPrintWriter extends PrintWriter {
 		_writer = writer;
 
 		out = _writer;
+		lock = _writer;
 	}
 
 	@Override


### PR DESCRIPTION
...memory footprint
