### PR TITLE
LPS-64414 No need deploy sample-sql-builder when build-sample-sql tar…

### DIFF
--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -6,7 +6,7 @@
 	<target name="build-sample-sql">
 		<gradle-execute
 			dir="../modules/util/portal-tools-sample-sql-builder"
-			task="deploy"
+			task="jar"
 		/>
 
 		<path id="sample.sql.builder.classpath">


### PR DESCRIPTION
If used the task 'deploy' , during the process of warm up database, the WARN (as below)will appeared when portal startup.

17:15:20,271 WARN  [fileinstall-/root/portal-work/osgi/portal][org_apache_felix_fileinstall:102] Error while starting bundle: file:/root/portal-work/osgi/portal/com.liferay.portal.tools.sample.sql.builder.jar 
org.osgi.framework.BundleException: Could not resolve module: com.liferay.portal.tools.sample.sql.builder [128]
  Unresolved requirement: Import-Package: com.liferay.portal.freemarker; version="[1.0.0,2.0.0)"

        at org.eclipse.osgi.container.Module.start(Module.java:429)
        at org.eclipse.osgi.internal.framework.EquinoxBundle.start(EquinoxBundle.java:402)
        at org.apache.felix.fileinstall.internal.DirectoryWatcher.startBundle(DirectoryWatcher.java:1252)
        at org.apache.felix.fileinstall.internal.DirectoryWatcher.startBundles(DirectoryWatcher.java:1224)
        at org.apache.felix.fileinstall.internal.DirectoryWatcher.doProcess(DirectoryWatcher.java:512)
        at org.apache.felix.fileinstall.internal.DirectoryWatcher.process(DirectoryWatcher.java:361)
        at org.apache.felix.fileinstall.internal.DirectoryWatcher.run(DirectoryWatcher.java:313)