### PR TITLE
Check whether the contentType needs to throw IllegalStateException

### DIFF
--- a/portal-impl/src/com/liferay/portlet/ClientDataRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/ClientDataRequestImpl.java
@@ -49,12 +49,16 @@ public abstract class ClientDataRequestImpl
 
 	@Override
 	public InputStream getPortletInputStream() throws IOException {
+		_checkContentType();
+
 		return getHttpServletRequest().getInputStream();
 	}
 
 	@Override
 	public BufferedReader getReader()
 		throws IOException, UnsupportedEncodingException {
+
+		_checkContentType();
 
 		_calledGetReader = true;
 
@@ -70,6 +74,20 @@ public abstract class ClientDataRequestImpl
 		}
 
 		getHttpServletRequest().setCharacterEncoding(enc);
+	}
+
+	private void _checkContentType() {
+		String method = getMethod();
+
+		if (method.equals("POST")) {
+			String contentType = getContentType();
+
+			if ((contentType == null) ||
+				contentType.equals("application/x-www-form-urlencoded")) {
+
+				throw new IllegalStateException();
+			}
+		}
 	}
 
 	private boolean _calledGetReader;


### PR DESCRIPTION
Test case V2RequestTests_ClientDataRequest_ApiAction_getPortletInputStream3:x Details: Method getPortletInputStream(): Throws IllegalStateException if the request has HTTP POST data of type application/x-www-form-urlencoded. Method did not throw Exception

Test case V2RequestTests_ClientDataRequest_ApiAction_getReader3: Details: Method getReader(): Throws IllegalStateException if the request has HTTP POST data of type application/x-www-form-urlencoded. Method did not throw Exception

Test case V2RequestTests_ClientDataRequest_ApiResource_getPortletInputStream3:x Details: Method getPortletInputStream(): Throws IllegalStateException if the request has HTTP POST data of type application/x-www-form-urlencoded. Method did not throw Exception

Test case V2RequestTests_ClientDataRequest_ApiResource_getReader3: Details:x Method getReader(): Throws IllegalStateException if the request has HTTP POST data of type application/x-www-form-urlencoded. Method did not throw Exception

The same cause led to these four failures. In class `ClientDataRequestImpl`, the method `getPortletInputStream()` and `getReader()` should check the content type.