### PR TITLE
LPS-X Remove all values for the specified key if the value is null

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
@@ -517,8 +517,14 @@ public class PortletURLImpl
 
 	@Override
 	public void setParameter(String name, String[] values, boolean append) {
-		if ((name == null) || (values == null)) {
+		if (name == null) {
 			throw new IllegalArgumentException();
+		}
+
+		if (values == null) {
+			_params.remove(name);
+
+			return;
 		}
 
 		for (String value : values) {


### PR DESCRIPTION
There are 3 failures:
`V2URLTests_BaseURL_ApiRenderActurl_setParameterB7`
`V2URLTests_BaseURL_ApiRenderRenurl_setParameterB7`
`V2URLTests_BaseURL_ApiRenderResurl_setParameterB7`

Details: Method setParameter(String, String[]): If the value is null, all values for the specified key are removed. java.lang.IllegalArgumentExceptionjava.lang.IllegalArgumentException
     [java] at com.liferay.portlet.PortletURLImpl.setParameter(PortletURLImpl.java:524)
     [java] at com.liferay.portlet.PortletURLImpl.setParameter(PortletURLImpl.java:518)
     [java] at javax.portlet.tck.portlets.URLTests_BaseURL_ApiRenderResurl.render(URLTests_BaseURL_ApiRenderResurl.java:623)
     [java] at com.liferay.portlet.FilterChainImpl.doFilter(FilterChainImpl.java:103)
     [java] at com.liferay.portlet.ScriptDataPortletFilter.doFilter(ScriptDataPortletFilter.java:57)
     [java] at com.liferay.portlet.FilterChainImpl.doFilter(FilterChainImpl.java:100)
     [java] at com.liferay.portal.kernel.portlet.PortletFilterUtil.doFilter(PortletFilterUtil.java:64)
     [java] at com.liferay.portal.kernel.servlet.PortletServlet.service(PortletServlet.java:108)
     [java] at javax.servlet.http.HttpServlet.service(HttpServlet.java:729)
……

Chapter：A.3.2