### PR TITLE
LPS-76257 Return a correct map of container runtime options

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
@@ -769,6 +769,15 @@ public class PortletImpl extends PortletBaseImpl {
 	}
 
 	/**
+	 * Returns the container runtime options at the portlet level.
+	 *
+	 * @return the container runtime options at the portlet level
+	 */
+	public Map<String, String[]> getContainerRuntimeOptions() {
+		return _containerRuntimeOptions;
+	}
+
+	/**
 	 * Returns the servlet context name of the portlet.
 	 *
 	 * @return the servlet context name of the portlet
@@ -4201,6 +4210,12 @@ public class PortletImpl extends PortletBaseImpl {
 	 * The configuration action class of the portlet.
 	 */
 	private String _configurationActionClass;
+
+	/**
+	 * Map of the container runtime options at the portlet level.
+	 */
+	private final Map<String, String[]> _containerRuntimeOptions =
+		new HashMap<>();
 
 	/**
 	 * The name of the category of the Control Panel where this portlet will be

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -2369,6 +2369,27 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		portletModel.setPublicRenderParameters(publicRenderParameters);
 
+		for (Element containerRuntimeOptionElement :
+				portletElement.elements("container-runtime-option")) {
+
+			String name = GetterUtil.getString(
+				containerRuntimeOptionElement.elementText("name"));
+
+			List<String> values = new ArrayList<>();
+
+			for (Element valueElement :
+					containerRuntimeOptionElement.elements("value")) {
+
+				values.add(valueElement.getTextTrim());
+			}
+
+			Map<String, String[]> containerRuntimeOptions =
+				((PortletImpl)portletModel).getContainerRuntimeOptions();
+
+			containerRuntimeOptions.put(
+				name, values.toArray(new String[values.size()]));
+		}
+
 		portletsMap.put(portletId, portletModel);
 	}
 

--- a/portal-impl/src/com/liferay/portlet/PortletConfigImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletConfigImpl.java
@@ -25,10 +25,12 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.model.impl.PortletImpl;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -74,7 +76,15 @@ public class PortletConfigImpl implements LiferayPortletConfig {
 
 	@Override
 	public Map<String, String[]> getContainerRuntimeOptions() {
-		return _portletApp.getContainerRuntimeOptions();
+		Map<String, String[]> containerRuntimeOptions = new HashMap<>();
+
+		containerRuntimeOptions.putAll(
+			_portletApp.getContainerRuntimeOptions());
+
+		containerRuntimeOptions.putAll(
+			((PortletImpl)_portlet).getContainerRuntimeOptions());
+
+		return containerRuntimeOptions;
 	}
 
 	@Override


### PR DESCRIPTION
@dantewang 

This one is aimed to resolve the issue described in https://issues.liferay.com/browse/LPS-76257.

According to Portlet Spec 3.0, Ch 8.4,

> The portlet can define additional runtime behavior in the portlet.xml on either the portlet application level or the portlet level with the container-runtime-option element. Runtime options that are defined on the application level should be applied to all portlets in the portlet application. Runtime options that are defined on the portlet level should be applied for this portlet only and override any runtime options defined on the application level with the same name.

Liferay doesn't read `<container-runtime-option>` defined at the portlet level at all. Liferay only reads those defined at the portlet app level.