### PR TITLE
LPS-76257 Read <container-runtime-option> defined at the portlet level(Using name space)

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -2369,6 +2369,30 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		portletModel.setPublicRenderParameters(publicRenderParameters);
 
+		Map<String, String[]> containerRuntimeOptions =
+			portletApp.getContainerRuntimeOptions();
+
+		String portletLevelPrefix = "PortletLevel_" + portletName;
+
+		for (Element containerRuntimeOptionElement :
+				portletElement.elements("container-runtime-option")) {
+
+			String name = GetterUtil.getString(
+				containerRuntimeOptionElement.elementText("name"));
+
+			List<String> values = new ArrayList<>();
+
+			for (Element valueElement :
+					containerRuntimeOptionElement.elements("value")) {
+
+				values.add(valueElement.getTextTrim());
+			}
+
+			containerRuntimeOptions.put(
+				portletLevelPrefix + name,
+				values.toArray(new String[values.size()]));
+		}
+
 		portletsMap.put(portletId, portletModel);
 	}
 

--- a/portal-impl/src/com/liferay/portlet/PortletConfigImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletConfigImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.Validator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -74,7 +75,29 @@ public class PortletConfigImpl implements LiferayPortletConfig {
 
 	@Override
 	public Map<String, String[]> getContainerRuntimeOptions() {
-		return _portletApp.getContainerRuntimeOptions();
+		Map<String, String[]> portletAppContainerRuntimeOptions =
+			_portletApp.getContainerRuntimeOptions();
+
+		Map<String, String[]> containerRuntimeOptions = new HashMap<>();
+
+		for (String name : portletAppContainerRuntimeOptions.keySet()) {
+			if (!name.startsWith("PortletLevel_")) {
+				containerRuntimeOptions.put(
+					name, portletAppContainerRuntimeOptions.get(name));
+			}
+		}
+
+		String portletLevelPrefix = "PortletLevel_" + _portletName;
+
+		for (String name : portletAppContainerRuntimeOptions.keySet()) {
+			if (name.startsWith(portletLevelPrefix)) {
+				containerRuntimeOptions.put(
+					name.substring(portletLevelPrefix.length()),
+					portletAppContainerRuntimeOptions.get(name));
+			}
+		}
+
+		return Collections.unmodifiableMap(containerRuntimeOptions);
 	}
 
 	@Override


### PR DESCRIPTION
@dantewang 

This one is aimed to resolve the issue described in https://issues.liferay.com/browse/LPS-76257.

According to Portlet Spec 3.0, Ch 8.4,

> The portlet can define additional runtime behavior in the portlet.xml on either the portlet application level or the portlet level with the container-runtime-option element. Runtime options that are defined on the application level should be applied to all portlets in the portlet application. Runtime options that are defined on the portlet level should be applied for this portlet only and override any runtime options defined on the application level with the same name.

Liferay doesn't read <container-runtime-option> defined at the portlet level at all. Liferay only reads those defined at the portlet app level.