### PR TITLE
LPS-76502 The instance of Header can not be created when the argument…

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/MetaInfoCacheServletResponse.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/MetaInfoCacheServletResponse.java
@@ -514,13 +514,15 @@ public class MetaInfoCacheServletResponse extends HttpServletResponseWrapper {
 			return;
 		}
 
-		Set<Header> values = new HashSet<>();
+		if (value != null) {
+			Set<Header> values = new HashSet<>();
 
-		_metaData._headers.put(name, values);
+			_metaData._headers.put(name, values);
 
-		Header header = new Header(value);
+			Header header = new Header(value);
 
-		values.add(header);
+			values.add(header);
+		}
 
 		super.setHeader(name, value);
 	}


### PR DESCRIPTION
@dantewang 

Test result:
The test case V2EnvironmentTests_CacheControl_ApiResource_setETag3 fails because of a selenium error.
At the same time, this selenium error will lead to 4 other failures. The test cases are as follows:
V2EnvironmentTests_CacheControl_ApiResource_setUseCachedContent1
V2EnvironmentTests_CacheControl_ApiResource_setUseCachedContent2
V2EnvironmentTests_CacheControl_ApiResource_useCachedContent1
V2EnvironmentTests_CacheControl_ApiResource_useCachedContent2
Background:
When create a instance of Header(com.liferay.portal.kernel.servlet.Header), the argument can't be null. The IllegalArgumentException will be throw If the argument is null. 
In Liferay, we did not check whether the argument was null.