### PR TITLE
LPS-83768

### DIFF
--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskImpl.java
@@ -116,6 +116,11 @@ public class BackgroundTaskImpl implements BackgroundTask {
 	}
 
 	@Override
+	public Date getModifiedDate() {
+		return _backgroundTask.getModifiedDate();
+	}
+
+	@Override
 	public String getName() {
 		return _backgroundTask.getName();
 	}

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portal.background.task.internal;
 
 import com.liferay.background.task.kernel.util.comparator.BackgroundTaskCompletionDateComparator;
 import com.liferay.background.task.kernel.util.comparator.BackgroundTaskCreateDateComparator;
+import com.liferay.background.task.kernel.util.comparator.BackgroundTaskModifiedDateComparator;
 import com.liferay.background.task.kernel.util.comparator.BackgroundTaskNameComparator;
 import com.liferay.portal.background.task.internal.messaging.BackgroundTaskMessageListener;
 import com.liferay.portal.background.task.internal.messaging.BackgroundTaskQueuingMessageListener;
@@ -719,6 +720,13 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 
 			return new com.liferay.portal.background.task.internal.comparator.
 				BackgroundTaskCreateDateComparator(
+					orderByComparator.isAscending());
+		}
+		else if (orderByComparator instanceof
+					BackgroundTaskModifiedDateComparator) {
+
+			return new com.liferay.portal.background.task.internal.comparator.
+				BackgroundTaskModifiedDateComparator(
 					orderByComparator.isAscending());
 		}
 		else if (orderByComparator instanceof BackgroundTaskNameComparator) {

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/comparator/BackgroundTaskModifiedDateComparator.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/comparator/BackgroundTaskModifiedDateComparator.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.background.task.internal.comparator;
+
+import com.liferay.portal.background.task.model.BackgroundTask;
+import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.OrderByComparator;
+
+/**
+ * @author Hai Yu
+ */
+public class BackgroundTaskModifiedDateComparator
+	extends OrderByComparator<BackgroundTask> {
+
+	public static final String ORDER_BY_ASC = "BackgroundTask.modifiedDate ASC";
+
+	public static final String ORDER_BY_DESC =
+		"BackgroundTask.modifiedDate DESC";
+
+	public static final String[] ORDER_BY_FIELDS = {"modifiedDate"};
+
+	public BackgroundTaskModifiedDateComparator() {
+		this(false);
+	}
+
+	public BackgroundTaskModifiedDateComparator(boolean ascending) {
+		_ascending = ascending;
+	}
+
+	@Override
+	public int compare(
+		BackgroundTask backgroundTask1, BackgroundTask backgroundTask2) {
+
+		int value = DateUtil.compareTo(
+			backgroundTask1.getModifiedDate(),
+			backgroundTask2.getModifiedDate());
+
+		if (_ascending) {
+			return value;
+		}
+
+		return -value;
+	}
+
+	@Override
+	public String getOrderBy() {
+		if (_ascending) {
+			return ORDER_BY_ASC;
+		}
+
+		return ORDER_BY_DESC;
+	}
+
+	@Override
+	public String[] getOrderByFields() {
+		return ORDER_BY_FIELDS;
+	}
+
+	@Override
+	public boolean isAscending() {
+		return _ascending;
+	}
+
+	private final boolean _ascending;
+
+}

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
@@ -21,7 +21,10 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
+import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBusUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.Validator;
 
 /**
@@ -94,8 +97,19 @@ public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 			return;
 		}
 
-		_backgroundTaskManager.resumeBackgroundTask(
+		ServiceContext serviceContext = new ServiceContext();
+
+		backgroundTask = _backgroundTaskManager.amendBackgroundTask(
+			backgroundTask.getBackgroundTaskId(), null,
+			BackgroundTaskConstants.STATUS_NEW, serviceContext);
+
+		Message message = new Message();
+
+		message.put(
+			BackgroundTaskConstants.BACKGROUND_TASK_ID,
 			backgroundTask.getBackgroundTaskId());
+
+		MessageBusUtil.sendMessage(DestinationNames.BACKGROUND_TASK, message);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.background.task.internal.messaging;
 
+import com.liferay.background.task.kernel.util.comparator.BackgroundTaskModifiedDateComparator;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskLockHelperUtil;
@@ -85,7 +86,8 @@ public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 
 		BackgroundTask backgroundTask =
 			_backgroundTaskManager.fetchFirstBackgroundTask(
-				taskExecutorClassName, BackgroundTaskConstants.STATUS_QUEUED);
+				taskExecutorClassName, BackgroundTaskConstants.STATUS_QUEUED,
+				new BackgroundTaskModifiedDateComparator(true));
 
 		if (backgroundTask == null) {
 			if (_log.isDebugEnabled()) {

--- a/portal-kernel/src/com/liferay/background/task/kernel/util/comparator/BackgroundTaskModifiedDateComparator.java
+++ b/portal-kernel/src/com/liferay/background/task/kernel/util/comparator/BackgroundTaskModifiedDateComparator.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.background.task.kernel.util.comparator;
+
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.OrderByComparator;
+
+/**
+ * @author Hai Yu
+ */
+public class BackgroundTaskModifiedDateComparator
+	extends OrderByComparator<BackgroundTask> {
+
+	public static final String ORDER_BY_ASC = "BackgroundTask.modifiedDate ASC";
+
+	public static final String ORDER_BY_DESC =
+		"BackgroundTask.modifiedDate DESC";
+
+	public static final String[] ORDER_BY_FIELDS = {"modifiedDate"};
+
+	public BackgroundTaskModifiedDateComparator() {
+		this(false);
+	}
+
+	public BackgroundTaskModifiedDateComparator(boolean ascending) {
+		_ascending = ascending;
+	}
+
+	@Override
+	public int compare(
+		BackgroundTask backgroundTask1, BackgroundTask backgroundTask2) {
+
+		int value = DateUtil.compareTo(
+			backgroundTask1.getModifiedDate(),
+			backgroundTask2.getModifiedDate());
+
+		if (_ascending) {
+			return value;
+		}
+
+		return -value;
+	}
+
+	@Override
+	public String getOrderBy() {
+		if (_ascending) {
+			return ORDER_BY_ASC;
+		}
+
+		return ORDER_BY_DESC;
+	}
+
+	@Override
+	public String[] getOrderByFields() {
+		return ORDER_BY_FIELDS;
+	}
+
+	@Override
+	public boolean isAscending() {
+		return _ascending;
+	}
+
+	private final boolean _ascending;
+
+}

--- a/portal-kernel/src/com/liferay/background/task/kernel/util/comparator/packageinfo
+++ b/portal-kernel/src/com/liferay/background/task/kernel/util/comparator/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/BackgroundTask.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/BackgroundTask.java
@@ -59,6 +59,8 @@ public interface BackgroundTask {
 
 	public BaseModel<?> getModel();
 
+	public Date getModifiedDate();
+
 	public String getName();
 
 	public String getServletContextNames();

--- a/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 8.0.0


### PR DESCRIPTION
Hi @dantewang 

The issue happens when reindex more than one company. When reindx assetEntry of company1 is not finished , another BACKGROUND_TASK thread2 to reindex assetEntry of company2, thread2 will get DuplicateLockException and put the backgroundtask to STATUS_QUEUED. 

When different BACKGROUND_TASK threads send messages to BACKGROUND_TASK_STATUS destination, in BackgroundTaskQueuingMessageListener, it will has chance to send same message to start two BACKGROUND_TASK threads and execute the same task.

Please refer to ci:test result from https://github.com/yuhai/liferay-portal/pull/111

Thanks,
Hai