### PR TITLE
LPS-87327

### DIFF
--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -566,7 +566,6 @@ add-registration-property=Add Registration Property
 add-response=Add Response
 add-role=Add Role
 add-row=Add Row
-add-sample-data=Add Sample Data
 add-screenshot=Add Screenshot
 add-service=Add Service
 add-site=Add Site

--- a/portal-impl/src/content/Language_ar.properties
+++ b/portal-impl/src/content/Language_ar.properties
@@ -560,7 +560,6 @@ add-registration-property=إضافة خاصية التسجيل
 add-response=إضافة رد
 add-role=أضف دور
 add-row=أضف سطر
-add-sample-data=إضافة نموذج بيانات (Automatic Translation)
 add-screenshot=إضافة لقطة الشاشة
 add-service=أضف خدمة
 add-site=أضف مجتمع

--- a/portal-impl/src/content/Language_bg.properties
+++ b/portal-impl/src/content/Language_bg.properties
@@ -560,7 +560,6 @@ add-registration-property=Добавяне на регистрационна н�
 add-response=Добавяне на отговор
 add-role=Добавяне на роля
 add-row=Добавяне на ред
-add-sample-data=Добавяне на примерни данни (Automatic Translation)
 add-screenshot=Добавяне на снимка на екрана
 add-service=Добавяне на услуга
 add-site=Добавяне на сайт

--- a/portal-impl/src/content/Language_ca.properties
+++ b/portal-impl/src/content/Language_ca.properties
@@ -565,7 +565,6 @@ add-registration-property=Afegeix una propietat de registre
 add-response=Afegeix una resposta
 add-role=Afegeix un rol
 add-row=Afegeix una fila
-add-sample-data=Afegeix dades d'exemple
 add-screenshot=Afegeix una captura de pantalla
 add-service=Afegeix un servei
 add-site=Afegeix un lloc web

--- a/portal-impl/src/content/Language_cs.properties
+++ b/portal-impl/src/content/Language_cs.properties
@@ -560,7 +560,6 @@ add-registration-property=Přidat položku registrace
 add-response=Přidat odpověď
 add-role=Přidat roli
 add-row=Přidat řádek
-add-sample-data=Přidat vzorová data
 add-screenshot=Přidat snímek obrazovky
 add-service=Přidat službu
 add-site=Přidat web

--- a/portal-impl/src/content/Language_da.properties
+++ b/portal-impl/src/content/Language_da.properties
@@ -560,7 +560,6 @@ add-registration-property=Tilføj Registration Property
 add-response=Tilføj Response
 add-role=Tilføj Rolle
 add-row=Tilføj Row
-add-sample-data=Add Sample Data (Automatic Copy)
 add-screenshot=Tilføj Screenshot
 add-service=Tilføj Service
 add-site=Tilføj websted

--- a/portal-impl/src/content/Language_de.properties
+++ b/portal-impl/src/content/Language_de.properties
@@ -565,7 +565,6 @@ add-registration-property=Registrierungseigenschaft hinzufügen
 add-response=Antwort hinzufügen
 add-role=Rolle hinzufügen
 add-row=Zeile hinzufügen
-add-sample-data=Beispieldaten hinzufügen
 add-screenshot=Bildschirmfoto hinzufügen
 add-service=Service hinzufügen
 add-site=Site hinzufügen

--- a/portal-impl/src/content/Language_el.properties
+++ b/portal-impl/src/content/Language_el.properties
@@ -560,7 +560,6 @@ add-registration-property=Προσθήκη ιδιότητας εγγραφής
 add-response=Προσθήκη απάντησης
 add-role=Προσθήκη ρόλου
 add-row=Προσθήκη σειράς
-add-sample-data=Προσθέστε το δείγμα δεδομένων (Automatic Translation)
 add-screenshot=Προσθήκη screenshot
 add-service=Προσθήκη υπηρεσίας
 add-site=Προσθήκη site

--- a/portal-impl/src/content/Language_en.properties
+++ b/portal-impl/src/content/Language_en.properties
@@ -566,7 +566,6 @@ add-registration-property=Add Registration Property
 add-response=Add Response
 add-role=Add Role
 add-row=Add Row
-add-sample-data=Add Sample Data
 add-screenshot=Add Screenshot
 add-service=Add Service
 add-site=Add Site

--- a/portal-impl/src/content/Language_es.properties
+++ b/portal-impl/src/content/Language_es.properties
@@ -565,7 +565,6 @@ add-registration-property=Añadir propiedad de registro
 add-response=Añadir respuesta
 add-role=Añadir rol
 add-row=Añadir fila
-add-sample-data=Añadir datos de ejemplo
 add-screenshot=Añadir captura de pantalla
 add-service=Añadir servicio
 add-site=Añadir Sitio web

--- a/portal-impl/src/content/Language_et.properties
+++ b/portal-impl/src/content/Language_et.properties
@@ -560,7 +560,6 @@ add-registration-property=Lisa registreerimise omadus
 add-response=Lisa vastus
 add-role=Lisa roll
 add-row=Lisa rida
-add-sample-data=Näidisandmete lisamine (Automatic Translation)
 add-screenshot=Lisa ekraanipilt
 add-service=Lisa teenus
 add-site=Lisa sait

--- a/portal-impl/src/content/Language_eu.properties
+++ b/portal-impl/src/content/Language_eu.properties
@@ -560,7 +560,6 @@ add-registration-property=Gehitu erregistratze propietatea
 add-response=Gehitu erantzuna
 add-role=Gehitu rola
 add-row=Gehitu errenkada
-add-sample-data=Add Sample Data (Automatic Copy)
 add-screenshot=Gehitu pantaila irudia
 add-service=Gehitu zerbitzua
 add-site=Gehitu gunea

--- a/portal-impl/src/content/Language_fa.properties
+++ b/portal-impl/src/content/Language_fa.properties
@@ -560,7 +560,6 @@ add-registration-property=افزودن مشخصه‌ی ثبت‌نام
 add-response=افزودن پاسخ
 add-role=افزودن نقش
 add-row=افزودن سطر
-add-sample-data=افزودن داده های نمونه
 add-screenshot=افزودن تصویر نمونه
 add-service=افزودن سرویس
 add-site=افزودن سایت

--- a/portal-impl/src/content/Language_fi.properties
+++ b/portal-impl/src/content/Language_fi.properties
@@ -560,7 +560,6 @@ add-registration-property=Lisää rekisteröintiominaisuus
 add-response=Lisää vastaus
 add-role=Lisää rooli
 add-row=Lisää rivi
-add-sample-data=Lisää näytetiedot
 add-screenshot=Lisää kuvakaappaus
 add-service=Lisää palvelu
 add-site=Lisää sivusto

--- a/portal-impl/src/content/Language_fr.properties
+++ b/portal-impl/src/content/Language_fr.properties
@@ -565,7 +565,6 @@ add-registration-property=Ajoutez la propriété d'enregistrement
 add-response=Ajoutez la réponse
 add-role=Ajouter un rôle
 add-row=Ajouter une rangée
-add-sample-data=Ajouter des données d'exemple
 add-screenshot=Ajouter une capture d'écran
 add-service=Ajouter un service
 add-site=Ajoutez l'emplacement

--- a/portal-impl/src/content/Language_gl.properties
+++ b/portal-impl/src/content/Language_gl.properties
@@ -560,7 +560,6 @@ add-registration-property=Engadir propiedade de rexistro
 add-response=Engadir resposta
 add-role=Engadir rol
 add-row=Engadir fila
-add-sample-data=Add Sample Data (Automatic Copy)
 add-screenshot=Engadir captura de pantalla
 add-service=Engadir servizo
 add-site=Engadir sitio

--- a/portal-impl/src/content/Language_hi_IN.properties
+++ b/portal-impl/src/content/Language_hi_IN.properties
@@ -560,7 +560,6 @@ add-registration-property=रेजिस्ट्रेशन प्रॉप�
 add-response=प्रतिक्रिया जोड़ें
 add-role=Role जोड़ें
 add-row=Row जोड़ें
-add-sample-data=नमूना डेटा जोड़ें (Automatic Translation)
 add-screenshot=स्क्रीनशॉट जोड़ें
 add-service=सर्विस जोड़ें
 add-site=साइट जोड़ें

--- a/portal-impl/src/content/Language_hr.properties
+++ b/portal-impl/src/content/Language_hr.properties
@@ -560,7 +560,6 @@ add-registration-property=Dodaj svojstvo registracije
 add-response=Dodaj odgovor
 add-role=Dodaj ulogu
 add-row=Dodaj redak
-add-sample-data=Dodaj uzorak podataka
 add-screenshot=Dodaj snimku zaslona
 add-service=Dodaj uslugu
 add-site=Dodaj web sjedište

--- a/portal-impl/src/content/Language_hu.properties
+++ b/portal-impl/src/content/Language_hu.properties
@@ -565,7 +565,6 @@ add-registration-property=Új regisztrációs tulajdonság
 add-response=Új válasz
 add-role=Új szerepkör
 add-row=Új sor
-add-sample-data=Példa adat hozzáadása
 add-screenshot=Új képernyőkép
 add-service=Új szolgáltatás
 add-site=Új webhely

--- a/portal-impl/src/content/Language_in.properties
+++ b/portal-impl/src/content/Language_in.properties
@@ -560,7 +560,6 @@ add-registration-property=Tambahkan Registrasi Properti
 add-response=Menambahkan Respon
 add-role=Menambahkan Peran
 add-row=Menambahkan Baris
-add-sample-data=Tambahkan Data sampel (Automatic Translation)
 add-screenshot=Menambahkan Screenshot
 add-service=Tambahkan Layanan
 add-site=Tambahkan Situs

--- a/portal-impl/src/content/Language_it.properties
+++ b/portal-impl/src/content/Language_it.properties
@@ -563,7 +563,6 @@ add-registration-property=Aggiungi Proprietà Iscrizione
 add-response=Aggiungi Risposta
 add-role=Aggiungi Ruolo
 add-row=Aggiungi Riga
-add-sample-data=Aggiungi Dati di Esempio
 add-screenshot=Aggiungi Screenshot
 add-service=Aggiungi Servizio
 add-site=Aggiungi Sito

--- a/portal-impl/src/content/Language_iw.properties
+++ b/portal-impl/src/content/Language_iw.properties
@@ -560,7 +560,6 @@ add-registration-property=הוסף תכונת הרשמה
 add-response=הוסף תגובה
 add-role=הוסף תפקיד
 add-row=הוסף שורה
-add-sample-data=הוסף נתונים לדוגמה
 add-screenshot=הוסף צילום מסך
 add-service=הוסף שירות
 add-site=הוסף אתר

--- a/portal-impl/src/content/Language_ja.properties
+++ b/portal-impl/src/content/Language_ja.properties
@@ -563,7 +563,6 @@ add-registration-property=登録プロパティを追加する
 add-response=返信を追加する
 add-role=ロールを追加する
 add-row=行を追加する
-add-sample-data=サンプルデータを追加する
 add-screenshot=スクリーンショットを追加する
 add-service=サービスを追加する
 add-site=サイトを追加する

--- a/portal-impl/src/content/Language_ko.properties
+++ b/portal-impl/src/content/Language_ko.properties
@@ -560,7 +560,6 @@ add-registration-property=등록 재산을 추가하십시오
 add-response=응답을 추가하십시오
 add-role=역할을 추가하십시요
 add-row=줄을 추가하십시요
-add-sample-data=샘플 데이터 추가 (Automatic Translation)
 add-screenshot=Screenshot을 추가하십시요
 add-service=서비스를 추가하십시요
 add-site=위치를 추가하십시오

--- a/portal-impl/src/content/Language_lo.properties
+++ b/portal-impl/src/content/Language_lo.properties
@@ -560,7 +560,6 @@ add-registration-property=ເພີ່ມສະຖານທີ່ການລົ
 add-response=ເພີ່ມການຕອບ
 add-role=ເພີ່ມລະບຽບ
 add-row=ເພີ່ມແຖວ
-add-sample-data=Add Sample Data (Automatic Copy)
 add-screenshot=ເພີ່ມການຖ່າຍຮູບໜ້າຈໍ
 add-service=ເພີ່ມການບໍລິການ
 add-site=ເພີ່ມໄຊທ໌

--- a/portal-impl/src/content/Language_lt.properties
+++ b/portal-impl/src/content/Language_lt.properties
@@ -560,7 +560,6 @@ add-registration-property=Pridėti registracijos nuosavybės (Automatic Translat
 add-response=Pridėti atsakymą (Automatic Translation)
 add-role=Pridėti vaidmuo (Automatic Translation)
 add-row=Pridėti eilutę (Automatic Translation)
-add-sample-data=Pridėti duomenų pavyzdžiai (Automatic Translation)
 add-screenshot=Pridėti ekrano kopiją (Automatic Translation)
 add-service=Pridėti paslaugą (Automatic Translation)
 add-site=Pridėti svetainę (Automatic Translation)

--- a/portal-impl/src/content/Language_nb.properties
+++ b/portal-impl/src/content/Language_nb.properties
@@ -560,7 +560,6 @@ add-registration-property=Legg til registreringsegenskap
 add-response=Legg til respons
 add-role=Legg til rolle
 add-row=Legg til rad
-add-sample-data=Legg til eksempeldata
 add-screenshot=Legg til skjermbilde
 add-service=Legg til tjenste
 add-site=Legg til nettsted

--- a/portal-impl/src/content/Language_nl.properties
+++ b/portal-impl/src/content/Language_nl.properties
@@ -566,7 +566,6 @@ add-registration-property=Registratie-eigenschap toevoegen
 add-response=Antwoord toevoegen
 add-role=Rol toevoegen
 add-row=Rij toevoegen
-add-sample-data=Voorbeelddata toevoegen
 add-screenshot=Schermafdruk toevoegen
 add-service=Service toevoegen
 add-site=Site toevoegen

--- a/portal-impl/src/content/Language_nl_BE.properties
+++ b/portal-impl/src/content/Language_nl_BE.properties
@@ -566,7 +566,6 @@ add-registration-property=Registratie-eigenschap toevoegen
 add-response=Antwoord toevoegen
 add-role=Rol toevoegen
 add-row=Rij toevoegen
-add-sample-data=Voorbeeldgegevens toevoegen (Automatic Translation)
 add-screenshot=Screenshot toevoegen
 add-service=Service toevoegen
 add-site=Website toevoegen

--- a/portal-impl/src/content/Language_pl.properties
+++ b/portal-impl/src/content/Language_pl.properties
@@ -560,7 +560,6 @@ add-registration-property=Dodaj właściwość rejestracji
 add-response=Dodaj odpowiedź
 add-role=Dodaj rolę
 add-row=Dodaj wiersz
-add-sample-data=Dodaj przykładowe dane
 add-screenshot=Dodaj zrzut ekranu
 add-service=Dodaj usługę
 add-site=Dodaj witrynę

--- a/portal-impl/src/content/Language_pt_BR.properties
+++ b/portal-impl/src/content/Language_pt_BR.properties
@@ -560,7 +560,6 @@ add-registration-property=Adicionar a Propriedade de Registo
 add-response=Adicionar Resposta
 add-role=Adicionar Papel
 add-row=Adicionar Linha
-add-sample-data=Adicionar Dados de Amostra
 add-screenshot=Adicionar Captura de Tela
 add-service=Adicionar Serviço
 add-site=Adicionar Site

--- a/portal-impl/src/content/Language_pt_PT.properties
+++ b/portal-impl/src/content/Language_pt_PT.properties
@@ -565,7 +565,6 @@ add-registration-property=Adicionar Propriedade de Registo
 add-response=Adicionar Resposta
 add-role=Adicionar Role
 add-row=Adicionar Linha
-add-sample-data=Adicionar Dados de Exemplo
 add-screenshot=Adicionar Captura de Ecrã
 add-service=Adicionar Serviço
 add-site=Adicionar Site

--- a/portal-impl/src/content/Language_ro.properties
+++ b/portal-impl/src/content/Language_ro.properties
@@ -560,7 +560,6 @@ add-registration-property=Adaugă Proprietate Inregistrare
 add-response=Adaugă Răspuns
 add-role=Adaugă Rol
 add-row=Adaugă Rând
-add-sample-data=Adauga date eşantion (Automatic Translation)
 add-screenshot=Adaugă Poză de Ecran
 add-service=Adaugă Serviciu
 add-site=Adaugă Site

--- a/portal-impl/src/content/Language_ru.properties
+++ b/portal-impl/src/content/Language_ru.properties
@@ -560,7 +560,6 @@ add-registration-property=Добавить свойство регистраци
 add-response=Добавить ответ
 add-role=Добавить роль
 add-row=Добавить строку
-add-sample-data=Добавить пример
 add-screenshot=Добавить снимок экрана
 add-service=Добавить сервис
 add-site=Добавить сайт

--- a/portal-impl/src/content/Language_sk.properties
+++ b/portal-impl/src/content/Language_sk.properties
@@ -560,7 +560,6 @@ add-registration-property=Pridať vlastnosť registrácie
 add-response=Pridať odpoveď
 add-role=Pridať rolu
 add-row=Pridať riadok
-add-sample-data=Pridať vzorové údaje
 add-screenshot=Pridať screenshot
 add-service=Pridať službu
 add-site=Pridať sídlo

--- a/portal-impl/src/content/Language_sl.properties
+++ b/portal-impl/src/content/Language_sl.properties
@@ -560,7 +560,6 @@ add-registration-property=Dodaj lastnost za registracijo
 add-response=Dodaj odgovor
 add-role=Dodaj vlogo
 add-row=Dodaj vrstico
-add-sample-data=Dodajanje vzorčnih podatkov (Automatic Translation)
 add-screenshot=Dodaj posnetek zaslona
 add-service=Dodaj servis
 add-site=Dodaj (spletno) mesto

--- a/portal-impl/src/content/Language_sr_RS.properties
+++ b/portal-impl/src/content/Language_sr_RS.properties
@@ -560,7 +560,6 @@ add-registration-property=Додај Регистрацију Својства
 add-response=Додај Одговор
 add-role=Додај Улогу
 add-row=Додај Ред
-add-sample-data=Add Sample Data (Automatic Copy)
 add-screenshot=Додај Слику Екрана
 add-service=Додај Сервис
 add-site=Додај Сајт

--- a/portal-impl/src/content/Language_sr_RS_latin.properties
+++ b/portal-impl/src/content/Language_sr_RS_latin.properties
@@ -560,7 +560,6 @@ add-registration-property=Dodaj Registraciju Svojstva
 add-response=Dodaj Odgovor
 add-role=Dodaj Ulogu
 add-row=Dodaj Red
-add-sample-data=Add Sample Data (Automatic Copy)
 add-screenshot=Dodaj Sliku Ekrana
 add-service=Dodaj Servis
 add-site=Dodaj Sajt

--- a/portal-impl/src/content/Language_sv.properties
+++ b/portal-impl/src/content/Language_sv.properties
@@ -560,7 +560,6 @@ add-registration-property=Lägg till egenskap för registrering
 add-response=Lägg till svar
 add-role=Lägg till roll
 add-row=Lägg till rad
-add-sample-data=Add Sample Data (Automatic Copy)
 add-screenshot=Lägg till skärmbild
 add-service=Lägg till tjänst
 add-site=Lägg till sajt

--- a/portal-impl/src/content/Language_th.properties
+++ b/portal-impl/src/content/Language_th.properties
@@ -560,7 +560,6 @@ add-registration-property=เพิ่มคุณสมบัติลงทะ
 add-response=เพิ่มการตอบสนอง (Automatic Translation)
 add-role=เพิ่มบทบาท (Automatic Translation)
 add-row=เพิ่มแถว (Automatic Translation)
-add-sample-data=เพิ่มข้อมูลตัวอย่าง (Automatic Translation)
 add-screenshot=เพิ่มภาพหน้าจอ (Automatic Translation)
 add-service=เพิ่มบริการ (Automatic Translation)
 add-site=เพิ่มเว็บไซต์ (Automatic Translation)

--- a/portal-impl/src/content/Language_tr.properties
+++ b/portal-impl/src/content/Language_tr.properties
@@ -560,7 +560,6 @@ add-registration-property=Kayıt Özelliği Ekle
 add-response=Cevap Ekle
 add-role=Rol Ekle
 add-row=Satır Ekle
-add-sample-data=Örnek verileri ekleyin (Automatic Translation)
 add-screenshot=Ekran Resmi Ekle
 add-service=Servis Ekle
 add-site=Site Ekle

--- a/portal-impl/src/content/Language_uk.properties
+++ b/portal-impl/src/content/Language_uk.properties
@@ -560,7 +560,6 @@ add-registration-property=Добавити властивість реєстра
 add-response=Добавити відповідь
 add-role=Добавити роль
 add-row=Добавити строфу
-add-sample-data=Додати зразок даних (Automatic Translation)
 add-screenshot=Добавити знимку екрану
 add-service=Добавити сервіс
 add-site=Добавити світлину

--- a/portal-impl/src/content/Language_vi.properties
+++ b/portal-impl/src/content/Language_vi.properties
@@ -560,7 +560,6 @@ add-registration-property=Thêm đăng ký sở hữu
 add-response=Thêm phản hồi
 add-role=Thêm vai trò
 add-row=Thêm hàng
-add-sample-data=Thêm dữ liệu mẫu
 add-screenshot=Thêm màn hình đại diện
 add-service=Thêm dịch vụ
 add-site=Thêm trang thông tin

--- a/portal-impl/src/content/Language_zh_CN.properties
+++ b/portal-impl/src/content/Language_zh_CN.properties
@@ -563,7 +563,6 @@ add-registration-property=添加注册属性
 add-response=添加回复
 add-role=添加角色
 add-row=添加行
-add-sample-data=添加样本数据
 add-screenshot=添加屏幕截图
 add-service=添加服务
 add-site=添加站点

--- a/portal-impl/src/content/Language_zh_TW.properties
+++ b/portal-impl/src/content/Language_zh_TW.properties
@@ -561,7 +561,6 @@ add-registration-property=增加註冊屬性
 add-response=增加反應
 add-role=增加角色
 add-row=增加列
-add-sample-data=增加範例資料
 add-screenshot=增加螢幕擷圖
 add-service=增加服務
 add-site=增加站台

--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -89,8 +89,6 @@
 										<aui:button name="changeLanguageButton" value="change" />
 									</div>
 								</aui:field-wrapper>
-
-								<aui:input label="add-sample-data" name='<%= "properties--" + PropsKeys.SETUP_WIZARD_ADD_SAMPLE_DATA + "--" %>' type="checkbox" value="<%= true %>" />
 							</aui:fieldset>
 
 							<aui:fieldset cssClass="col-md-6">


### PR DESCRIPTION
Hi @dantewang,

The issue is however we check and uncheck the "Add Sample Data" in UI, it doesn't take effect after restart.

On 6.2, in setup_wizard.jsp, after we click "finish configuration", it will add sample data if checked.
On 7.0, LPS-54660 changed the behavior. The property "setup.wizard.add.sample.data" only takes effect when connects a new database on startup. It is not related with setup_wizard page. (LPS-85523 documented the property in portal.properties).

Thanks,
Hai