### PR TITLE
LPS-86461

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseReplacePortletId.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseReplacePortletId.java
@@ -76,47 +76,9 @@ public abstract class BaseReplacePortletId extends BaseUpgradePortletId {
 		super.doUpgrade();
 	}
 
-	protected boolean hasPortlet(String portletId) throws SQLException {
-		return hasRow(
-			"select count(*) from Portlet where portletId = ?", portletId);
-	}
-
 	protected boolean hasResourceAction(String name) throws SQLException {
 		return hasRow(
 			"select count(*) from ResourceAction where name = ?", name);
-	}
-
-	protected boolean hasResourcePermission(String name) throws SQLException {
-		return hasRow(
-			"select count(*) from ResourcePermission where name = ?", name);
-	}
-
-	protected boolean hasRow(String sql, String value) throws SQLException {
-		try (PreparedStatement ps = connection.prepareStatement(sql)) {
-			ps.setString(1, value);
-
-			try (ResultSet rs = ps.executeQuery()) {
-				if (rs.next()) {
-					int count = rs.getInt(1);
-
-					if (count > 0) {
-						return true;
-					}
-				}
-
-				return false;
-			}
-		}
-	}
-
-	@Override
-	protected void updatePortletId(
-			String oldRootPortletId, String newRootPortletId)
-		throws Exception {
-
-		if (!hasPortlet(newRootPortletId)) {
-			super.updatePortletId(oldRootPortletId, newRootPortletId);
-		}
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java
@@ -172,6 +172,34 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 		return new String[0];
 	}
 
+	protected boolean hasPortlet(String portletId) throws SQLException {
+		return hasRow(
+			"select count(*) from Portlet where portletId = ?", portletId);
+	}
+
+	protected boolean hasResourcePermission(String name) throws SQLException {
+		return hasRow(
+			"select count(*) from ResourcePermission where name = ?", name);
+	}
+
+	protected boolean hasRow(String sql, String value) throws SQLException {
+		try (PreparedStatement ps = connection.prepareStatement(sql)) {
+			ps.setString(1, value);
+
+			try (ResultSet rs = ps.executeQuery()) {
+				if (rs.next()) {
+					int count = rs.getInt(1);
+
+					if (count > 0) {
+						return true;
+					}
+				}
+
+				return false;
+			}
+		}
+	}
+
 	protected void updateGroup(long groupId, String typeSettings)
 		throws Exception {
 
@@ -413,6 +441,13 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 			String oldRootPortletId, String newRootPortletId)
 		throws Exception {
 
+		if (hasPortlet(newRootPortletId)) {
+			runSQL(
+				StringBundler.concat(
+					"delete from Portlet where portletId = '", newRootPortletId,
+					"'"));
+		}
+
 		runSQL(
 			StringBundler.concat(
 				"update Portlet set portletId = '", newRootPortletId,
@@ -490,6 +525,14 @@ public abstract class BaseUpgradePortletId extends UpgradeProcess {
 		}
 
 		if (updateName) {
+			if (hasResourcePermission(newRootPortletId)) {
+				runSQL(
+					StringBundler.concat(
+						"delete from ResourcePermission where name = '",
+						newRootPortletId, "' and primKey != '",
+						newRootPortletId, "'"));
+			}
+
 			runSQL(
 				StringBundler.concat(
 					"update ResourcePermission set primKey = '",


### PR DESCRIPTION
Hi @dantewang,

For the code fragment (https://github.com/yuhai/liferay-portal/blob/ebad2b9ea81d766a118458f1081c77c632927699/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletId.java#L532-L534), 
"primKey != newRootPortletId" means not delete related initPortletDefaultPermissions. And this is only existed on 7.0. Please refer to https://github.com/yuhai/liferay-portal/blob/LPS-86461/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java#L185. We may not delete the datas.

Please check the related ci:test from https://github.com/yuhai/liferay-portal/pull/113

Thanks,
Hai