### PR TITLE
LPS-88710

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/BasePublisherMessageListener.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/BasePublisherMessageListener.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.messaging.BaseMessageStatusMessageListener;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
@@ -61,7 +62,14 @@ public abstract class BasePublisherMessageListener
 			schedulerEventMessageListenerWrapper =
 				new SchedulerEventMessageListenerWrapper();
 
-		schedulerEventMessageListenerWrapper.setMessageListener(this);
+		SchedulerEventMessageListenerAdapter
+			schedulerEventMessageListenerAdapter =
+				new SchedulerEventMessageListenerAdapter();
+
+		schedulerEventMessageListenerAdapter.setMessageListener(this);
+
+		schedulerEventMessageListenerWrapper.setSchedulerEventMessageListener(
+			schedulerEventMessageListenerAdapter);
 
 		serviceRegistration = bundleContext.registerService(
 			MessageListener.class, schedulerEventMessageListenerWrapper,

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.scheduler.StorageTypeAware;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerState;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
@@ -582,7 +583,12 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 						_bundleContext.getService(
 							serviceRegistration.getReference());
 
-			schedulerEventMessageListenerWrapper.setSchedulerEntry(
+			SchedulerEventMessageListenerAdapter
+				schedulerEventMessageListenerAdapter =
+					(SchedulerEventMessageListenerAdapter)
+						schedulerEventMessageListenerWrapper.getSchedulerEventMessageListener();
+
+			schedulerEventMessageListenerAdapter.setSchedulerEntry(
 				schedulerEntry);
 
 			serviceRegistration.setProperties(properties);
@@ -594,10 +600,17 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 			schedulerEventMessageListenerWrapper =
 				new SchedulerEventMessageListenerWrapper();
 
-		schedulerEventMessageListenerWrapper.setMessageListener(
+		SchedulerEventMessageListenerAdapter
+			schedulerEventMessageListenerAdapter =
+				new SchedulerEventMessageListenerAdapter();
+
+		schedulerEventMessageListenerAdapter.setMessageListener(
 			messageListener);
 
-		schedulerEventMessageListenerWrapper.setSchedulerEntry(schedulerEntry);
+		schedulerEventMessageListenerAdapter.setSchedulerEntry(schedulerEntry);
+
+		schedulerEventMessageListenerWrapper.setSchedulerEventMessageListener(
+			schedulerEventMessageListenerAdapter);
 
 		serviceRegistration = _bundleContext.registerService(
 			SchedulerEventMessageListener.class,

--- a/modules/apps/portal-scheduler/source-formatter.properties
+++ b/modules/apps/portal-scheduler/source-formatter.properties
@@ -1,0 +1,9 @@
+##
+## Exclusions
+##
+## See https://github.com/liferay/liferay-portal/blob/master/source-formatter.properties
+## for available properties.
+##
+
+    line.length.excludes=\
+        modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java@589

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/messaging/KaleoWorkflowMessagingConfigurator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/messaging/KaleoWorkflowMessagingConfigurator.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.messaging.proxy.ProxyMessageListener;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.workflow.WorkflowDefinitionManager;
@@ -154,8 +155,15 @@ public class KaleoWorkflowMessagingConfigurator {
 			schedulerEventMessageListenerWrapper =
 				new SchedulerEventMessageListenerWrapper();
 
-		schedulerEventMessageListenerWrapper.setMessageListener(
+		SchedulerEventMessageListenerAdapter
+			schedulerEventMessageListenerAdapter =
+				new SchedulerEventMessageListenerAdapter();
+
+		schedulerEventMessageListenerAdapter.setMessageListener(
 			_timerMessageListener);
+
+		schedulerEventMessageListenerWrapper.setSchedulerEventMessageListener(
+			schedulerEventMessageListenerAdapter);
 
 		Dictionary<String, Object> properties = new HashMapDictionary<>();
 

--- a/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
+++ b/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.portlet.PortletLayoutListener;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.OpenSearch;
@@ -626,6 +627,10 @@ public class PortletBagFactory {
 				schedulerEventMessageListenerWrapper =
 					new SchedulerEventMessageListenerWrapper();
 
+			SchedulerEventMessageListenerAdapter
+				schedulerEventMessageListenerAdapter =
+					new SchedulerEventMessageListenerAdapter();
+
 			com.liferay.portal.kernel.messaging.MessageListener
 				messageListener =
 					(com.liferay.portal.kernel.messaging.MessageListener)
@@ -633,11 +638,14 @@ public class PortletBagFactory {
 							_classLoader,
 							schedulerEntry.getEventListenerClass());
 
-			schedulerEventMessageListenerWrapper.setMessageListener(
+			schedulerEventMessageListenerAdapter.setMessageListener(
 				messageListener);
 
-			schedulerEventMessageListenerWrapper.setSchedulerEntry(
+			schedulerEventMessageListenerAdapter.setSchedulerEntry(
 				schedulerEntry);
+
+			schedulerEventMessageListenerWrapper.setSchedulerEventMessageListener(
+				schedulerEventMessageListenerAdapter);
 
 			ServiceRegistration<?> serviceRegistration =
 				registry.registerService(

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerAdapter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerAdapter.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.scheduler.messaging;
+
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.messaging.MessageListenerException;
+import com.liferay.portal.kernel.scheduler.SchedulerEntry;
+
+/**
+ * @author Hai Yu
+ */
+public class SchedulerEventMessageListenerAdapter
+	implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
+
+	@Override
+	public void receive(Message message) throws MessageListenerException {
+		_messageListener.receive(message);
+	}
+
+	public void setMessageListener(MessageListener messageListener) {
+		_messageListener = messageListener;
+	}
+
+	public void setSchedulerEntry(SchedulerEntry schedulerEntry) {
+		_schedulerEntry = schedulerEntry;
+	}
+
+	private MessageListener _messageListener;
+	private SchedulerEntry _schedulerEntry;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerWrapper.java
@@ -47,7 +47,11 @@ public class SchedulerEventMessageListenerWrapper
 
 	@Override
 	public SchedulerEntry getSchedulerEntry() {
-		return _schedulerEntry;
+		return _schedulerEventMessageListener.getSchedulerEntry();
+	}
+
+	public SchedulerEventMessageListener getSchedulerEventMessageListener() {
+		return _schedulerEventMessageListener;
 	}
 
 	@Override
@@ -58,7 +62,9 @@ public class SchedulerEventMessageListenerWrapper
 		String groupName = message.getString(SchedulerEngine.GROUP_NAME);
 
 		if (destinationName.equals(DestinationNames.SCHEDULER_DISPATCH)) {
-			Trigger trigger = _schedulerEntry.getTrigger();
+			SchedulerEntry schedulerEntry = getSchedulerEntry();
+
+			Trigger trigger = schedulerEntry.getTrigger();
 
 			if (!jobName.equals(trigger.getJobName()) ||
 				!groupName.equals(trigger.getGroupName())) {
@@ -116,12 +122,26 @@ public class SchedulerEventMessageListenerWrapper
 		_jobName = jobName;
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
 	public void setMessageListener(MessageListener messageListener) {
 		_messageListener = messageListener;
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
 	public void setSchedulerEntry(SchedulerEntry schedulerEntry) {
 		_schedulerEntry = schedulerEntry;
+	}
+
+	public void setSchedulerEventMessageListener(
+		SchedulerEventMessageListener schedulerEventMessageListener) {
+
+		_schedulerEventMessageListener = schedulerEventMessageListener;
 	}
 
 	protected void handleException(Message message, Exception exception) {
@@ -138,7 +158,7 @@ public class SchedulerEventMessageListenerWrapper
 		throws MessageListenerException {
 
 		try {
-			_messageListener.receive(message);
+			_schedulerEventMessageListener.receive(message);
 		}
 		catch (Exception e) {
 			handleException(message, e);
@@ -218,7 +238,21 @@ public class SchedulerEventMessageListenerWrapper
 	private String _jobName;
 
 	private final Lock _lock = new ReentrantLock();
+
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
+	@SuppressWarnings("unused")
 	private MessageListener _messageListener;
+
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
+	@SuppressWarnings("unused")
 	private volatile SchedulerEntry _schedulerEntry;
+
+	private SchedulerEventMessageListener _schedulerEventMessageListener;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerWrapperTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerWrapperTest.java
@@ -73,8 +73,15 @@ public class SchedulerEventMessageListenerWrapperTest {
 			schedulerEventMessageListenerWrapper =
 				new SchedulerEventMessageListenerWrapper();
 
-		schedulerEventMessageListenerWrapper.setMessageListener(
+		SchedulerEventMessageListenerAdapter
+			schedulerEventMessageListenerAdapter =
+				new SchedulerEventMessageListenerAdapter();
+
+		schedulerEventMessageListenerAdapter.setMessageListener(
 			_testMessageListener);
+
+		schedulerEventMessageListenerWrapper.setSchedulerEventMessageListener(
+			schedulerEventMessageListenerAdapter);
 
 		FutureTask<Void> futureTask1 = _startThread(
 			schedulerEventMessageListenerWrapper, "Thread1", _testMessage1);
@@ -115,8 +122,15 @@ public class SchedulerEventMessageListenerWrapperTest {
 			schedulerEventMessageListenerWrapper =
 				new SchedulerEventMessageListenerWrapper();
 
-		schedulerEventMessageListenerWrapper.setMessageListener(
+		SchedulerEventMessageListenerAdapter
+			schedulerEventMessageListenerAdapter =
+				new SchedulerEventMessageListenerAdapter();
+
+		schedulerEventMessageListenerAdapter.setMessageListener(
 			_testMessageListener);
+
+		schedulerEventMessageListenerWrapper.setSchedulerEventMessageListener(
+			schedulerEventMessageListenerAdapter);
 
 		Registry registry = RegistryUtil.getRegistry();
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -97,6 +97,7 @@
         portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java@332,\
         portal-impl/src/com/liferay/portal/util/PortalImpl.java@553,\
         portal-impl/src/com/liferay/portal/util/PropsValues.java,\
+        portal-impl/src/com/liferay/portlet/PortletBagFactory.java@647,\
         portal-kernel/src/com/liferay/portal/kernel/model/ListTypeConstants.java@53,\
         portal-kernel/src/com/liferay/portal/kernel/model/ListTypeConstants.java@72,\
         portal-kernel/src/com/liferay/portal/kernel/model/ListTypeConstants.java@105,\


### PR DESCRIPTION
Hi @dantewang 

The PR is based on https://github.com/dantewang/liferay-portal/pull/990.

I want to explain one thing. 
If we register SchedulerEventMessageListenerAdapter as SchedulerEventMessageListener service later, The SchedulerEventMessageListenerWrapper.getSchedulerEventMessageListener() method may be removed.

Thanks,
Hai