### PR TITLE
LPS-94560 Avoid print warn log when use HYPERSONIC database.

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_0_0/test/UpgradeResourcePermissionTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_0_0/test/UpgradeResourcePermissionTest.java
@@ -16,6 +16,7 @@ package com.liferay.portal.upgrade.v7_0_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.portal.dao.db.BaseDB;
 import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
@@ -27,6 +28,10 @@ import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.model.impl.ResourcePermissionImpl;
+import com.liferay.portal.test.rule.ExpectedDBType;
+import com.liferay.portal.test.rule.ExpectedLog;
+import com.liferay.portal.test.rule.ExpectedLogs;
+import com.liferay.portal.test.rule.ExpectedType;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeResourcePermission;
@@ -67,6 +72,31 @@ public class UpgradeResourcePermissionTest extends UpgradeResourcePermission {
 		}
 	}
 
+	@ExpectedLogs(
+		expectedLogs = {
+			@ExpectedLog(
+				expectedDBType = ExpectedDBType.HYPERSONIC,
+				expectedLog = "object name already exists:",
+				expectedType = ExpectedType.PREFIX
+			),
+			@ExpectedLog(
+				expectedDBType = ExpectedDBType.ORACLE,
+				expectedLog = "ORA-00955: name is already used by an existing object",
+				expectedType = ExpectedType.PREFIX
+			),
+			@ExpectedLog(
+				expectedDBType = ExpectedDBType.POSTGRESQL,
+				expectedLog = "ERROR: relation \"ix_d5f1e2a2\" already exists",
+				expectedType = ExpectedType.PREFIX
+			),
+			@ExpectedLog(
+				expectedDBType = ExpectedDBType.SYBASE,
+				expectedLog = "There is already an index on table 'ResourcePermission' named 'IX_D5F1E2A2'",
+				expectedType = ExpectedType.PREFIX
+			)
+		},
+		level = "WARN", loggerClass = BaseDB.class
+	)
 	@Test
 	public void testUpgrade() throws Exception {
 		String primKey1 = "123";


### PR DESCRIPTION
Hi @dantewang,

Please refer to the test result from https://github.com/yuhai/liferay-portal/pull/135. It looks good for now.
I will run ci:test:backend in this PR.

Thanks,
Hai
