### PR TITLE
LPS-96692

### DIFF
--- a/modules/apps/counter/counter-test/bnd.bnd
+++ b/modules/apps/counter/counter-test/bnd.bnd
@@ -1,3 +1,4 @@
 Bundle-Name: Liferay Counter Test
 Bundle-SymbolicName: com.liferay.counter.test
 Bundle-Version: 1.0.0
+-includeresource: @hsqldb-[0-9]*.jar

--- a/modules/apps/counter/counter-test/bnd.bnd
+++ b/modules/apps/counter/counter-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Counter Test
+Bundle-SymbolicName: com.liferay.counter.test
+Bundle-Version: 1.0.0

--- a/modules/apps/counter/counter-test/build.gradle
+++ b/modules/apps/counter/counter-test/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testIntegrationCompile group: "org.hsqldb", name: "hsqldb", version: "2.3.3"
+	testIntegrationCompile project(":core:petra:petra-concurrent")
 	testIntegrationCompile project(":core:petra:petra-process")
 	testIntegrationCompile project(":core:petra:petra-reflect")
 	testIntegrationCompile project(":core:petra:petra-string")

--- a/modules/apps/counter/counter-test/build.gradle
+++ b/modules/apps/counter/counter-test/build.gradle
@@ -1,7 +1,10 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile group: "org.hsqldb", name: "hsqldb", version: "2.3.3"
 	testIntegrationCompile project(":core:petra:petra-process")
+	testIntegrationCompile project(":core:petra:petra-reflect")
+	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":core:registry-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/counter/counter-test/build.gradle
+++ b/modules/apps/counter/counter-test/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testIntegrationCompile project(":core:petra:petra-process")
+	testIntegrationCompile project(":core:registry-api")
+	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.test.rule.ClassTestRule;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.HypersonicServerClassTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.InitUtil;

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.test.rule.ClassTestRule;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.InitUtil;
@@ -171,7 +172,9 @@ public class CounterLocalServiceTest {
 		for (int i = 0; i < _PROCESS_COUNT; i++) {
 			ProcessCallable<Long[]> processCallable =
 				new IncrementProcessCallable(
-					"Increment Process-" + i, _COUNTER_NAME, _INCREMENT_COUNT);
+					"Increment Process-" + i,
+					SystemProperties.get("catalina.base"), _COUNTER_NAME,
+					_INCREMENT_COUNT);
 
 			ProcessChannel<Long[]> processChannel = _processExecutor.execute(
 				processConfig, processCallable);
@@ -215,9 +218,11 @@ public class CounterLocalServiceTest {
 		implements ProcessCallable<Long[]> {
 
 		public IncrementProcessCallable(
-			String processName, String counterName, int incrementCount) {
+			String processName, String catalinaBase, String counterName,
+			int incrementCount) {
 
 			_processName = processName;
+			_catalinaBase = catalinaBase;
 			_counterName = counterName;
 			_incrementCount = incrementCount;
 		}
@@ -229,7 +234,7 @@ public class CounterLocalServiceTest {
 			System.setProperty(
 				PropsKeys.COUNTER_INCREMENT + "." + _counterName, "1");
 
-			System.setProperty("catalina.base", ".");
+			System.setProperty("catalina.base", _catalinaBase);
 
 			// C3PO
 
@@ -280,6 +285,7 @@ public class CounterLocalServiceTest {
 
 		private static final long serialVersionUID = 1L;
 
+		private final String _catalinaBase;
 		private final String _counterName;
 		private final int _incrementCount;
 		private final String _processName;

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
@@ -130,7 +130,8 @@ public class CounterLocalServiceTest {
 		arguments.add("-Dsun.zip.disableMemoryMapping=true");
 
 		for (String property :
-				HypersonicServerClassTestRule.INSTANCE.getJdbcProperties()) {
+				HypersonicServerClassTestRule.INSTANCE.
+					getTestServerJdbcProperties()) {
 
 			arguments.add("-D" + property);
 		}

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
@@ -148,21 +148,16 @@ public class CounterLocalServiceTest {
 
 		URL url = codeSource.getLocation();
 
-		StringBundler sb = new StringBundler(3);
-
-		sb.append(url.getPath());
-
-		sb.append(File.pathSeparator);
-
-		sb.append(portalProcessConfig.getRuntimeClassPath());
-
 		ProcessConfig.Builder builder = new ProcessConfig.Builder();
 
 		builder.setArguments(arguments);
 		builder.setBootstrapClassPath(
 			portalProcessConfig.getBootstrapClassPath());
 		builder.setReactClassLoader(PortalClassLoaderUtil.getClassLoader());
-		builder.setRuntimeClassPath(sb.toString());
+		builder.setRuntimeClassPath(
+			StringBundler.concat(
+				url.getPath(), File.pathSeparator,
+				portalProcessConfig.getRuntimeClassPath()));
 
 		ProcessConfig processConfig = builder.build();
 

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.ClassTestRule;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -205,7 +204,8 @@ public class CounterLocalServiceTest {
 		}
 	}
 
-	private static final String _COUNTER_NAME = StringUtil.randomString();
+	private static final String _COUNTER_NAME =
+		CounterLocalServiceTest.class.getName();
 
 	private static final int _INCREMENT_COUNT = 10000;
 

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
@@ -148,6 +148,8 @@ public class CounterLocalServiceTest {
 
 		URL url = codeSource.getLocation();
 
+		File file = new File(url.toURI());
+
 		ProcessConfig.Builder builder = new ProcessConfig.Builder();
 
 		builder.setArguments(arguments);
@@ -156,7 +158,7 @@ public class CounterLocalServiceTest {
 		builder.setReactClassLoader(PortalClassLoaderUtil.getClassLoader());
 		builder.setRuntimeClassPath(
 			StringBundler.concat(
-				url.getPath(), File.pathSeparator,
+				file.getPath(), File.pathSeparator,
 				portalProcessConfig.getRuntimeClassPath()));
 
 		ProcessConfig processConfig = builder.build();

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
@@ -12,8 +12,9 @@
  * details.
  */
 
-package com.liferay.counter.service;
+package com.liferay.counter.test;
 
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.petra.process.ClassPathUtil;
 import com.liferay.portal.cache.key.SimpleCacheKeyGenerator;
@@ -53,10 +54,12 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.Description;
+import org.junit.runner.RunWith;
 
 /**
  * @author Shuyang Zhou
  */
+@RunWith(Arquillian.class)
 public class CounterLocalServiceTest {
 
 	@ClassRule

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/CounterLocalServiceTest.java
@@ -230,7 +230,6 @@ public class CounterLocalServiceTest {
 				PropsKeys.COUNTER_INCREMENT + "." + _counterName, "1");
 
 			System.setProperty("catalina.base", ".");
-			System.setProperty("external-properties", "portal-test.properties");
 
 			// C3PO
 

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
@@ -64,13 +64,14 @@ public class HypersonicServerClassTestRule extends ClassTestRule<Server> {
 	public void afterClass(Description description, Server server)
 		throws Exception {
 
-		Properties properties = new Properties();
-
-		properties.put("password", "");
-		properties.put("user", "sa");
-
 		try (Connection connection = JDBCDriver.getConnection(
-				DATABASE_URL_BASE + _DATABASE_NAME, properties);
+				DATABASE_URL_BASE + _DATABASE_NAME,
+				new Properties() {
+					{
+						put("password", "");
+						put("user", "sa");
+					}
+				});
 			Statement statement = connection.createStatement()) {
 
 			statement.execute("SHUTDOWN COMPACT");
@@ -123,13 +124,14 @@ public class HypersonicServerClassTestRule extends ClassTestRule<Server> {
 
 		};
 
-		Properties properties = new Properties();
-
-		properties.put("password", "");
-		properties.put("user", "sa");
-
 		try (Connection connection = JDBCDriver.getConnection(
-				PropsValues.JDBC_DEFAULT_URL, properties);
+				PropsValues.JDBC_DEFAULT_URL,
+				new Properties() {
+					{
+						put("password", "");
+						put("user", "sa");
+					}
+				});
 			Statement statement = connection.createStatement()) {
 
 			statement.execute(

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
@@ -34,12 +34,12 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.Statement;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -64,8 +64,13 @@ public class HypersonicServerClassTestRule extends ClassTestRule<Server> {
 	public void afterClass(Description description, Server server)
 		throws Exception {
 
-		try (Connection connection = DriverManager.getConnection(
-				DATABASE_URL_BASE + _DATABASE_NAME, "sa", "");
+		Properties properties = new Properties();
+
+		properties.put("password", "");
+		properties.put("user", "sa");
+
+		try (Connection connection = JDBCDriver.getConnection(
+				DATABASE_URL_BASE + _DATABASE_NAME, properties);
 			Statement statement = connection.createStatement()) {
 
 			statement.execute("SHUTDOWN COMPACT");
@@ -118,8 +123,13 @@ public class HypersonicServerClassTestRule extends ClassTestRule<Server> {
 
 		};
 
-		try (Connection connection = DriverManager.getConnection(
-				PropsValues.JDBC_DEFAULT_URL, "sa", "");
+		Properties properties = new Properties();
+
+		properties.put("password", "");
+		properties.put("user", "sa");
+
+		try (Connection connection = JDBCDriver.getConnection(
+				PropsValues.JDBC_DEFAULT_URL, properties);
 			Statement statement = connection.createStatement()) {
 
 			statement.execute(

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
@@ -16,6 +16,8 @@ package com.liferay.counter.test;
 
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.io.unsync.UnsyncPrintWriter;
 import com.liferay.portal.kernel.test.rule.ClassTestRule;
 import com.liferay.portal.kernel.util.Props;
@@ -124,20 +126,11 @@ public class HypersonicServerClassTestRule extends ClassTestRule<Server> {
 
 		};
 
-		try (Connection connection = JDBCDriver.getConnection(
-				PropsValues.JDBC_DEFAULT_URL,
-				new Properties() {
-					{
-						put("password", "");
-						put("user", "sa");
-					}
-				});
-			Statement statement = connection.createStatement()) {
+		DB db = DBManagerUtil.getDB();
 
-			statement.execute(
-				"BACKUP DATABASE TO '" + _HYPERSONIC_TEMP_DIR_NAME +
-					"' BLOCKING AS FILES");
-		}
+		db.runSQL(
+			"BACKUP DATABASE TO '" + _HYPERSONIC_TEMP_DIR_NAME +
+				"' BLOCKING AS FILES");
 
 		server.setErrWriter(
 			new UnsyncPrintWriter(

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
@@ -170,19 +170,6 @@ public class HypersonicServerClassTestRule extends ClassTestRule<Server> {
 		return Collections.emptyList();
 	}
 
-	protected void copyFile(
-			String fileName, Path fromFolderPath, Path toFolderPath)
-		throws IOException {
-
-		Path filePath = fromFolderPath.resolve(fileName);
-
-		if (Files.exists(filePath)) {
-			Files.createDirectories(toFolderPath);
-
-			Files.copy(filePath, toFolderPath.resolve(fileName));
-		}
-	}
-
 	@Override
 	protected org.junit.runners.model.Statement createClassStatement(
 		org.junit.runners.model.Statement statement, Description description) {

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.test.rule;
+package com.liferay.counter.test;
 
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.CharPool;

--- a/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
+++ b/modules/apps/counter/counter-test/src/testIntegration/java/com/liferay/counter/test/HypersonicServerClassTestRule.java
@@ -78,7 +78,7 @@ public class HypersonicServerClassTestRule extends ClassTestRule<Server> {
 
 		server.stop();
 
-		deleteFolder(Paths.get(_HYPERSONIC_TEMP_DIR_NAME));
+		_deleteFolder(Paths.get(_HYPERSONIC_TEMP_DIR_NAME));
 	}
 
 	@Override
@@ -181,7 +181,10 @@ public class HypersonicServerClassTestRule extends ClassTestRule<Server> {
 		return super.createClassStatement(statement, description);
 	}
 
-	protected void deleteFolder(Path folderPath) throws IOException {
+	private HypersonicServerClassTestRule() {
+	}
+
+	private void _deleteFolder(Path folderPath) throws IOException {
 		if (!Files.exists(folderPath)) {
 			return;
 		}
@@ -215,9 +218,6 @@ public class HypersonicServerClassTestRule extends ClassTestRule<Server> {
 				}
 
 			});
-	}
-
-	private HypersonicServerClassTestRule() {
 	}
 
 	private static final String _DATABASE_NAME;

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/AggregateTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/AggregateTestRule.java
@@ -63,7 +63,6 @@ public class AggregateTestRule implements TestRule {
 		CodeCoverageAssertor.class.getName(), NewEnvTestRule.class.getName(),
 		AssumeTestRule.class.getName(),
 		"com.liferay.portal.test.rule.LiferayIntegrationTestRule",
-		"com.liferay.portal.test.rule.HypersonicServerClassTestRule",
 		"com.liferay.portal.test.rule.PersistenceTestRule",
 		"com.liferay.portal.test.rule.TransactionalTestRule",
 		SynchronousDestinationTestRule.class.getName(),


### PR DESCRIPTION
@dantewang, based on the requirement from https://github.com/tinatian/liferay-portal/pull/1477#discussion_r311670586, I merge the change to https://github.com/dantewang/liferay-portal/commit/8811da03dec28f971e2fda8faef9cc5b03b05815. I also check the properties in portal-text.properties. They are not related with the test. There are two properties aren't existed in portal.properties (they were used in 6.2) as the followings. 

lucene.merge.scheduler=org.apache.lucene.index.SerialMergeScheduler
lucene.store.type=ram