### PR TITLE
[Scheduler] LPS-88710

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/messaging/CheckEntryMessageListener.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/messaging/CheckEntryMessageListener.java
@@ -20,12 +20,12 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.util.PropsValues;
 
@@ -33,7 +33,6 @@ import java.util.Date;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -42,14 +41,22 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
 	service = {
 		CheckEntryMessageListener.class,
-		ClusterMasterTokenTransitionListener.class
+		ClusterMasterTokenTransitionListener.class,
+		SchedulerEventMessageListener.class
 	}
 )
 public class CheckEntryMessageListener
 	extends BaseMessageListener
-	implements ClusterMasterTokenTransitionListener {
+	implements ClusterMasterTokenTransitionListener,
+			   SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Override
 	public void masterTokenAcquired() {
@@ -70,16 +77,7 @@ public class CheckEntryMessageListener
 			className, className, null, null,
 			PropsValues.ANNOUNCEMENTS_ENTRY_CHECK_INTERVAL, TimeUnit.MINUTE);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -107,9 +105,7 @@ public class CheckEntryMessageListener
 	private ModuleServiceLifecycle _moduleServiceLifecycle;
 
 	private Date _previousEndDate;
-
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/CheckAssetEntryMessageListener.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/CheckAssetEntryMessageListener.java
@@ -20,18 +20,18 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -45,11 +45,20 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.asset.publisher.web.internal.configuration.AssetPublisherWebConfiguration",
-	immediate = true, service = {}
+	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = SchedulerEventMessageListener.class
 )
-public class CheckAssetEntryMessageListener extends BaseMessageListener {
+public class CheckAssetEntryMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
+	@Modified
 	protected void activate(Map<String, Object> properties) {
 		AssetPublisherWebConfiguration assetPublisherWebConfiguration =
 			ConfigurableUtil.createConfigurable(
@@ -63,16 +72,7 @@ public class CheckAssetEntryMessageListener extends BaseMessageListener {
 			className, className, null, null,
 			assetPublisherWebConfiguration.checkInterval(), TimeUnit.HOUR);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -86,8 +86,7 @@ public class CheckAssetEntryMessageListener extends BaseMessageListener {
 	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;
 
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/messaging/CheckEntryMessageListener.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/messaging/CheckEntryMessageListener.java
@@ -21,18 +21,17 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -41,9 +40,19 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.blogs.configuration.BlogsConfiguration",
-	immediate = true, service = CheckEntryMessageListener.class
+	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		CheckEntryMessageListener.class, SchedulerEventMessageListener.class
+	}
 )
-public class CheckEntryMessageListener extends BaseMessageListener {
+public class CheckEntryMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	@Modified
@@ -59,16 +68,7 @@ public class CheckEntryMessageListener extends BaseMessageListener {
 			className, className, null, null,
 			_blogsConfiguration.entryCheckInterval(), TimeUnit.MINUTE);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -84,8 +84,7 @@ public class CheckEntryMessageListener extends BaseMessageListener {
 	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;
 
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/messaging/LinkbackMessageListener.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/messaging/LinkbackMessageListener.java
@@ -21,19 +21,18 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.linkback.LinkbackProducerUtil;
 
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -43,9 +42,19 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.blogs.configuration.BlogsConfiguration",
-	immediate = true, service = LinkbackMessageListener.class
+	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		LinkbackMessageListener.class, SchedulerEventMessageListener.class
+	}
 )
-public class LinkbackMessageListener extends BaseMessageListener {
+public class LinkbackMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	@Modified
@@ -61,16 +70,7 @@ public class LinkbackMessageListener extends BaseMessageListener {
 			className, className, null, null,
 			_blogsConfiguration.linkbackJobInterval(), TimeUnit.MINUTE);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -88,8 +88,7 @@ public class LinkbackMessageListener extends BaseMessageListener {
 	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;
 
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/messaging/CheckBookingsMessageListener.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/messaging/CheckBookingsMessageListener.java
@@ -20,24 +20,35 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Fabio Pezzutto
  * @author Eduardo Lundgren
  */
-@Component(immediate = true, service = CheckBookingsMessageListener.class)
-public class CheckBookingsMessageListener extends BaseMessageListener {
+@Component(
+	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		CheckBookingsMessageListener.class, SchedulerEventMessageListener.class
+	}
+)
+public class CheckBookingsMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	protected void activate() {
@@ -51,16 +62,7 @@ public class CheckBookingsMessageListener extends BaseMessageListener {
 				CALENDAR_NOTIFICATION_CHECK_INTERVAL,
 			TimeUnit.MINUTE);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -74,8 +76,7 @@ public class CheckBookingsMessageListener extends BaseMessageListener {
 	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;
 
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/messaging/TempFileEntriesMessageListener.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/messaging/TempFileEntriesMessageListener.java
@@ -29,19 +29,18 @@ import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.RepositoryProvider;
 import com.liferay.portal.kernel.repository.UndeployedExternalRepositoryException;
 import com.liferay.portal.kernel.repository.capabilities.TemporaryFileEntriesCapability;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -50,9 +49,20 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.document.library.configuration.DLConfiguration",
-	immediate = true, service = TempFileEntriesMessageListener.class
+	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		SchedulerEventMessageListener.class,
+		TempFileEntriesMessageListener.class
+	}
 )
-public class TempFileEntriesMessageListener extends BaseMessageListener {
+public class TempFileEntriesMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	@Modified
@@ -69,16 +79,7 @@ public class TempFileEntriesMessageListener extends BaseMessageListener {
 			_dlConfiguration.temporaryFileEntriesCheckInterval(),
 			TimeUnit.HOUR);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	protected void deleteExpiredTemporaryFileEntries(Repository repository) {
@@ -152,20 +153,13 @@ public class TempFileEntriesMessageListener extends BaseMessageListener {
 		_repositoryProvider = repositoryProvider;
 	}
 
-	@Reference(unbind = "-")
-	protected void setSchedulerEngineHelper(
-		SchedulerEngineHelper schedulerEngineHelper) {
-
-		_schedulerEngineHelper = schedulerEngineHelper;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		TempFileEntriesMessageListener.class);
 
 	private volatile DLConfiguration _dlConfiguration;
 	private RepositoryLocalService _repositoryLocalService;
 	private RepositoryProvider _repositoryProvider;
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/BasePublisherMessageListener.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/BasePublisherMessageListener.java
@@ -17,10 +17,9 @@ package com.liferay.exportimport.internal.messaging;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.messaging.BaseMessageStatusMessageListener;
-import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -56,15 +55,15 @@ public abstract class BasePublisherMessageListener
 		Dictionary<String, Object> properties =
 			componentContext.getProperties();
 
-		SchedulerEventMessageListenerWrapper
-			schedulerEventMessageListenerWrapper =
-				new SchedulerEventMessageListenerWrapper();
+		SchedulerEventMessageListenerAdapter
+			schedulerEventMessageListenerAdapter =
+				new SchedulerEventMessageListenerAdapter();
 
-		schedulerEventMessageListenerWrapper.setMessageListener(this);
+		schedulerEventMessageListenerAdapter.setMessageListener(this);
 
 		serviceRegistration = bundleContext.registerService(
-			MessageListener.class, schedulerEventMessageListenerWrapper,
-			properties);
+			SchedulerEventMessageListenerAdapter.class,
+			schedulerEventMessageListenerAdapter, properties);
 	}
 
 	protected void initThreadLocals(
@@ -129,6 +128,7 @@ public abstract class BasePublisherMessageListener
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
-	protected ServiceRegistration<MessageListener> serviceRegistration;
+	protected ServiceRegistration<SchedulerEventMessageListenerAdapter>
+		serviceRegistration;
 
 }

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/CheckSystemEventMessageListener.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/CheckSystemEventMessageListener.java
@@ -18,25 +18,37 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
 import com.liferay.portal.util.PropsValues;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Akos Thurzo
  */
-@Component(immediate = true, service = CheckSystemEventMessageListener.class)
-public class CheckSystemEventMessageListener extends BaseMessageListener {
+@Component(
+	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		CheckSystemEventMessageListener.class,
+		SchedulerEventMessageListener.class
+	}
+)
+public class CheckSystemEventMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	protected void activate() {
@@ -48,16 +60,7 @@ public class CheckSystemEventMessageListener extends BaseMessageListener {
 			className, className, null, null,
 			PropsValues.STAGING_SYSTEM_EVENT_CHECK_INTERVAL, TimeUnit.HOUR);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -71,20 +74,13 @@ public class CheckSystemEventMessageListener extends BaseMessageListener {
 	}
 
 	@Reference(unbind = "-")
-	protected void setSchedulerEngineHelper(
-		SchedulerEngineHelper schedulerEngineHelper) {
-
-		_schedulerEngineHelper = schedulerEngineHelper;
-	}
-
-	@Reference(unbind = "-")
 	protected void setSystemEventLocalService(
 		SystemEventLocalService systemEventLocalService) {
 
 		_systemEventLocalService = systemEventLocalService;
 	}
 
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 	private SystemEventLocalService _systemEventLocalService;
 
 	@Reference

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/LayoutsLocalPublisherMessageListener.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/LayoutsLocalPublisherMessageListener.java
@@ -48,6 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"destination.name=" + DestinationNames.LAYOUTS_LOCAL_PUBLISHER,
+		"event.listener.classname=com.liferay.exportimport.internal.messaging.LayoutsLocalPublisherMessageListener",
 		"message.status.destination.name=" + DestinationNames.MESSAGE_BUS_MESSAGE_STATUS
 	},
 	service = LayoutsLocalPublisherMessageListener.class

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/LayoutsRemotePublisherMessageListener.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/LayoutsRemotePublisherMessageListener.java
@@ -50,6 +50,7 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"destination.name=" + DestinationNames.LAYOUTS_REMOTE_PUBLISHER,
+		"event.listener.classname=com.liferay.exportimport.internal.messaging.LayoutsRemotePublisherMessageListener",
 		"message.status.destination.name=" + DestinationNames.MESSAGE_BUS_MESSAGE_STATUS
 	},
 	service = LayoutsRemotePublisherMessageListener.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/messaging/DraftExportImportConfigurationMessageListener.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/messaging/DraftExportImportConfigurationMessageListener.java
@@ -36,12 +36,12 @@ import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -51,7 +51,6 @@ import java.util.List;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -60,10 +59,19 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	immediate = true,
-	service = DraftExportImportConfigurationMessageListener.class
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		DraftExportImportConfigurationMessageListener.class,
+		SchedulerEventMessageListener.class
+	}
 )
 public class DraftExportImportConfigurationMessageListener
-	extends BaseMessageListener {
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	protected void activate() {
@@ -77,11 +85,7 @@ public class DraftExportImportConfigurationMessageListener
 				DRAFT_EXPORT_IMPORT_CONFIGURATION_CHECK_INTERVAL,
 			TimeUnit.HOUR);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	protected void addCommonCriterions(DynamicQuery dynamicQuery) {
@@ -99,11 +103,6 @@ public class DraftExportImportConfigurationMessageListener
 		Property statusProperty = PropertyFactoryUtil.forName("status");
 
 		dynamicQuery.add(statusProperty.eq(WorkflowConstants.STATUS_DRAFT));
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
 	}
 
 	@Override
@@ -259,18 +258,11 @@ public class DraftExportImportConfigurationMessageListener
 		ModuleServiceLifecycle moduleServiceLifecycle) {
 	}
 
-	@Reference(unbind = "-")
-	protected void setSchedulerEngineHelper(
-		SchedulerEngineHelper schedulerEngineHelper) {
-
-		_schedulerEngineHelper = schedulerEngineHelper;
-	}
-
 	private BackgroundTaskLocalService _backgroundTaskLocalService;
 	private ExportImportConfigurationLocalService
 		_exportImportConfigurationLocalService;
 	private GroupLocalService _groupLocalService;
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/messaging/CheckArticleMessageListener.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/messaging/CheckArticleMessageListener.java
@@ -21,19 +21,18 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -45,9 +44,18 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	configurationPid = "com.liferay.journal.configuration.JournalServiceConfiguration",
 	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true,
-	service = CheckArticleMessageListener.class
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		CheckArticleMessageListener.class, SchedulerEventMessageListener.class
+	}
 )
-public class CheckArticleMessageListener extends BaseMessageListener {
+public class CheckArticleMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	@Modified
@@ -64,16 +72,7 @@ public class CheckArticleMessageListener extends BaseMessageListener {
 			className, className, null, null,
 			journalServiceConfiguration.checkInterval(), TimeUnit.MINUTE);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -93,15 +92,8 @@ public class CheckArticleMessageListener extends BaseMessageListener {
 		ModuleServiceLifecycle moduleServiceLifecycle) {
 	}
 
-	@Reference(unbind = "-")
-	protected void setSchedulerEngineHelper(
-		SchedulerEngineHelper schedulerEngineHelper) {
-
-		_schedulerEngineHelper = schedulerEngineHelper;
-	}
-
 	private JournalArticleLocalService _journalArticleLocalService;
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/messaging/ExpireBanMessageListener.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/messaging/ExpireBanMessageListener.java
@@ -21,18 +21,17 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -42,9 +41,19 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.message.boards.configuration.MBConfiguration",
-	immediate = true, service = ExpireBanMessageListener.class
+	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		ExpireBanMessageListener.class, SchedulerEventMessageListener.class
+	}
 )
-public class ExpireBanMessageListener extends BaseMessageListener {
+public class ExpireBanMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	@Modified
@@ -60,16 +69,7 @@ public class ExpireBanMessageListener extends BaseMessageListener {
 			className, className, null, null,
 			_mbConfiguration.expireBanJobInterval(), TimeUnit.MINUTE);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -87,16 +87,9 @@ public class ExpireBanMessageListener extends BaseMessageListener {
 		ModuleServiceLifecycle moduleServiceLifecycle) {
 	}
 
-	@Reference(unbind = "-")
-	protected void setSchedulerEngineHelper(
-		SchedulerEngineHelper schedulerEngineHelper) {
-
-		_schedulerEngineHelper = schedulerEngineHelper;
-	}
-
 	private MBBanLocalService _mbBanLocalService;
 	private volatile MBConfiguration _mbConfiguration;
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/portal-scheduler/portal-scheduler/build.gradle
+++ b/modules/apps/portal-scheduler/portal-scheduler/build.gradle
@@ -13,4 +13,6 @@ dependencies {
 	compileOnly project(":apps:static:portal:portal-profile-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
+
+	testCompile project(":core:registry-api")
 }

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -562,6 +562,10 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 		_schedulerEngine.pause(jobName, groupName, storageType);
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
 	@Override
 	public void register(
 		MessageListener messageListener, SchedulerEntry schedulerEntry,
@@ -673,6 +677,10 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 		_schedulerEngine.suppressError(jobName, groupName, storageType);
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
 	@Override
 	public void unregister(MessageListener messageListener) {
 		Class<?> messageListenerClass = messageListener.getClass();

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.scheduler.StorageTypeAware;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerState;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
@@ -576,13 +577,13 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 			_serviceRegistrations.get(messageListenerClass.getName());
 
 		if (serviceRegistration != null) {
-			SchedulerEventMessageListenerWrapper
-				schedulerEventMessageListenerWrapper =
-					(SchedulerEventMessageListenerWrapper)
+			SchedulerEventMessageListenerAdapter
+				schedulerEventMessageListenerAdapter =
+					(SchedulerEventMessageListenerAdapter)
 						_bundleContext.getService(
 							serviceRegistration.getReference());
 
-			schedulerEventMessageListenerWrapper.setSchedulerEntry(
+			schedulerEventMessageListenerAdapter.setSchedulerEntry(
 				schedulerEntry);
 
 			serviceRegistration.setProperties(properties);
@@ -590,18 +591,17 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 			return;
 		}
 
-		SchedulerEventMessageListenerWrapper
-			schedulerEventMessageListenerWrapper =
-				new SchedulerEventMessageListenerWrapper();
+		SchedulerEventMessageListenerAdapter
+			schedulerEventMessageListenerAdapter =
+				new SchedulerEventMessageListenerAdapter();
 
-		schedulerEventMessageListenerWrapper.setMessageListener(
+		schedulerEventMessageListenerAdapter.setMessageListener(
 			messageListener);
-
-		schedulerEventMessageListenerWrapper.setSchedulerEntry(schedulerEntry);
+		schedulerEventMessageListenerAdapter.setSchedulerEntry(schedulerEntry);
 
 		serviceRegistration = _bundleContext.registerService(
 			SchedulerEventMessageListener.class,
-			schedulerEventMessageListenerWrapper, properties);
+			schedulerEventMessageListenerAdapter, properties);
 
 		_serviceRegistrations.put(
 			messageListenerClass.getName(), serviceRegistration);
@@ -984,8 +984,9 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 							(SchedulerEventMessageListenerWrapper)
 								messageListener;
 
-					schedulerEventMessageListenerWrapper.setSchedulerEntry(
-						schedulerEntry);
+					schedulerEventMessageListenerWrapper.
+						setSchedulerEventMessageListener(
+							schedulerEventMessageListener);
 
 					return null;
 				}
@@ -995,8 +996,16 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 
 				properties.put("destination.name", destinationName);
 
+				SchedulerEventMessageListenerWrapper
+					schedulerEventMessageListenerWrapper =
+						new SchedulerEventMessageListenerWrapper();
+
+				schedulerEventMessageListenerWrapper.
+					setSchedulerEventMessageListener(
+						schedulerEventMessageListener);
+
 				serviceRegistration = bundleContext.registerService(
-					MessageListener.class, schedulerEventMessageListener,
+					MessageListener.class, schedulerEventMessageListenerWrapper,
 					properties);
 
 				_messageListenerServiceRegistrations.put(

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -45,7 +45,6 @@ import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerState;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
-import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
@@ -55,6 +54,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.scheduler.internal.configuration.SchedulerEngineHelperConfiguration;
+import com.liferay.portal.scheduler.internal.messaging.SchedulerEventMessageListenerWrapper;
 import com.liferay.portal.scheduler.internal.messaging.config.ScriptingMessageListener;
 
 import java.util.ArrayList;

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/messaging/SchedulerEventMessageListenerAdapterRegistrar.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/messaging/SchedulerEventMessageListenerAdapterRegistrar.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.scheduler.internal.messaging;
+
+import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * @author Hai Yu
+ */
+@Component(immediate = true, service = {})
+public class SchedulerEventMessageListenerAdapterRegistrar {
+
+	@Activate
+	public void activate(ComponentContext componentContext) {
+		_serviceTracker = ServiceTrackerFactory.open(
+			componentContext.getBundleContext(),
+			SchedulerEventMessageListenerAdapter.class,
+			new SchedulerEventMessageListenerServiceTrackerCustomizer());
+	}
+
+	@Deactivate
+	public void deactivate() {
+		if (_serviceTracker != null) {
+			_serviceTracker.close();
+		}
+	}
+
+	private ServiceTracker
+		<SchedulerEventMessageListenerAdapter,
+		 SchedulerEventMessageListenerAdapter> _serviceTracker;
+
+	private class SchedulerEventMessageListenerServiceTrackerCustomizer
+		implements ServiceTrackerCustomizer
+			<SchedulerEventMessageListenerAdapter,
+			 SchedulerEventMessageListenerAdapter> {
+
+		@Override
+		public SchedulerEventMessageListenerAdapter addingService(
+			ServiceReference<SchedulerEventMessageListenerAdapter>
+				serviceReference) {
+
+			Bundle bundle = serviceReference.getBundle();
+
+			BundleContext bundleContext = bundle.getBundleContext();
+
+			SchedulerEventMessageListenerAdapter
+				schedulerEventMessageListenerAdapter = bundleContext.getService(
+					serviceReference);
+
+			Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+			properties.put(
+				"destination.name",
+				(String)serviceReference.getProperty("destination.name"));
+
+			SchedulerEventMessageListenerWrapper
+				schedulerEventMessageListenerWrapper =
+					new SchedulerEventMessageListenerWrapper();
+
+			schedulerEventMessageListenerWrapper.
+				setSchedulerEventMessageListener(
+					schedulerEventMessageListenerAdapter);
+
+			ServiceRegistration<MessageListener> serviceRegistration =
+				bundleContext.registerService(
+					MessageListener.class, schedulerEventMessageListenerWrapper,
+					properties);
+
+			_serviceRegistrations.put(
+				(String)serviceReference.getProperty(
+					"event.listener.classname"),
+				serviceRegistration);
+
+			return schedulerEventMessageListenerAdapter;
+		}
+
+		@Override
+		public void modifiedService(
+			ServiceReference<SchedulerEventMessageListenerAdapter>
+				serviceReference,
+			SchedulerEventMessageListenerAdapter
+				schedulerEventMessageListenerAdapter) {
+		}
+
+		@Override
+		public void removedService(
+			ServiceReference<SchedulerEventMessageListenerAdapter>
+				serviceReference,
+			SchedulerEventMessageListenerAdapter
+				schedulerEventMessageListenerAdapter) {
+
+			Bundle bundle = serviceReference.getBundle();
+
+			BundleContext bundleContext = bundle.getBundleContext();
+
+			bundleContext.ungetService(serviceReference);
+
+			ServiceRegistration<MessageListener> serviceRegistration =
+				_serviceRegistrations.remove(
+					(String)serviceReference.getProperty(
+						"event.listener.classname"));
+
+			serviceRegistration.unregister();
+		}
+
+		private final Map<String, ServiceRegistration<MessageListener>>
+			_serviceRegistrations = new ConcurrentHashMap<>();
+
+	}
+
+}

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/messaging/SchedulerEventMessageListenerAdapterRegistrar.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/messaging/SchedulerEventMessageListenerAdapterRegistrar.java
@@ -17,7 +17,6 @@ package com.liferay.portal.scheduler.internal.messaging;
 import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
-import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 
 import java.util.Dictionary;

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/messaging/SchedulerEventMessageListenerWrapper.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/messaging/SchedulerEventMessageListenerWrapper.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.kernel.scheduler.messaging;
+package com.liferay.portal.scheduler.internal.messaging;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.scheduler.SchedulerException;
 import com.liferay.portal.kernel.scheduler.StorageType;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerState;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -40,12 +41,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * @author     Shuyang Zhou
- * @deprecated As of Mueller (7.2.x), replaced by {@link
- * com.liferay.portal.scheduler.internal.messaging.
- * SchedulerEventMessageListenerWrapper}
+ * @author Shuyang Zhou
  */
-@Deprecated
 public class SchedulerEventMessageListenerWrapper
 	implements SchedulerEventMessageListener {
 

--- a/modules/apps/portal-scheduler/portal-scheduler/src/test/java/com/liferay/portal/scheduler/internal/messaging/SchedulerEventMessageListenerWrapperTest.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/test/java/com/liferay/portal/scheduler/internal/messaging/SchedulerEventMessageListenerWrapperTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.scheduler.internal.messaging;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
 import com.liferay.portal.kernel.test.rule.NewEnv;
 import com.liferay.portal.kernel.test.rule.NewEnvTestRule;
 import com.liferay.portal.kernel.test.util.PropsTestUtil;
@@ -69,12 +70,19 @@ public class SchedulerEventMessageListenerWrapperTest {
 		PropsTestUtil.setProps(
 			PropsKeys.SCHEDULER_EVENT_MESSAGE_LISTENER_LOCK_TIMEOUT, "0");
 
+		SchedulerEventMessageListenerAdapter
+			schedulerEventMessageListenerAdapter =
+				new SchedulerEventMessageListenerAdapter();
+
+		schedulerEventMessageListenerAdapter.setMessageListener(
+			_testMessageListener);
+
 		SchedulerEventMessageListenerWrapper
 			schedulerEventMessageListenerWrapper =
 				new SchedulerEventMessageListenerWrapper();
 
-		schedulerEventMessageListenerWrapper.setMessageListener(
-			_testMessageListener);
+		schedulerEventMessageListenerWrapper.setSchedulerEventMessageListener(
+			schedulerEventMessageListenerAdapter);
 
 		FutureTask<Void> futureTask1 = _createFutureTask(
 			schedulerEventMessageListenerWrapper, _testMessage1);
@@ -114,12 +122,19 @@ public class SchedulerEventMessageListenerWrapperTest {
 		PropsTestUtil.setProps(
 			PropsKeys.SCHEDULER_EVENT_MESSAGE_LISTENER_LOCK_TIMEOUT, "1000");
 
+		SchedulerEventMessageListenerAdapter
+			schedulerEventMessageListenerAdapter =
+				new SchedulerEventMessageListenerAdapter();
+
+		schedulerEventMessageListenerAdapter.setMessageListener(
+			_testMessageListener);
+
 		SchedulerEventMessageListenerWrapper
 			schedulerEventMessageListenerWrapper =
 				new SchedulerEventMessageListenerWrapper();
 
-		schedulerEventMessageListenerWrapper.setMessageListener(
-			_testMessageListener);
+		schedulerEventMessageListenerWrapper.setSchedulerEventMessageListener(
+			schedulerEventMessageListenerAdapter);
 
 		Registry registry = RegistryUtil.getRegistry();
 
@@ -170,12 +185,19 @@ public class SchedulerEventMessageListenerWrapperTest {
 			PropsKeys.SCHEDULER_EVENT_MESSAGE_LISTENER_LOCK_TIMEOUT,
 			String.valueOf(Integer.MAX_VALUE));
 
+		SchedulerEventMessageListenerAdapter
+			schedulerEventMessageListenerAdapter =
+				new SchedulerEventMessageListenerAdapter();
+
+		schedulerEventMessageListenerAdapter.setMessageListener(
+			_testMessageListener);
+
 		SchedulerEventMessageListenerWrapper
 			schedulerEventMessageListenerWrapper =
 				new SchedulerEventMessageListenerWrapper();
 
-		schedulerEventMessageListenerWrapper.setMessageListener(
-			_testMessageListener);
+		schedulerEventMessageListenerWrapper.setSchedulerEventMessageListener(
+			schedulerEventMessageListenerAdapter);
 
 		FutureTask<Void> futureTask1 = _createFutureTask(
 			schedulerEventMessageListenerWrapper, _testMessage1);

--- a/modules/apps/portal-scheduler/portal-scheduler/src/test/java/com/liferay/portal/scheduler/internal/messaging/SchedulerEventMessageListenerWrapperTest.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/test/java/com/liferay/portal/scheduler/internal/messaging/SchedulerEventMessageListenerWrapperTest.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.kernel.scheduler.messaging;
+package com.liferay.portal.scheduler.internal.messaging;
 
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/persistence/listener/UserImportMessageListener.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/persistence/listener/UserImportMessageListener.java
@@ -23,12 +23,12 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.security.ldap.configuration.ConfigurationProvider;
 import com.liferay.portal.security.ldap.exportimport.LDAPUserImporter;
@@ -40,7 +40,6 @@ import java.util.List;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferencePolicy;
@@ -51,13 +50,23 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
  */
 @Component(
 	immediate = true,
-	property = "model.class.name=com.liferay.portal.security.ldap.exportimport.configuration.LDAPImportConfiguration",
+	property = {
+		"destination.name=" + LDAPDestinationNames.SCHEDULED_USER_LDAP_IMPORT,
+		"model.class.name=com.liferay.portal.security.ldap.exportimport.configuration.LDAPImportConfiguration"
+	},
 	service = {
-		ConfigurationModelListener.class, UserImportMessageListener.class
+		ConfigurationModelListener.class, SchedulerEventMessageListener.class,
+		UserImportMessageListener.class
 	}
 )
 public class UserImportMessageListener
-	extends BaseMessageListener implements ConfigurationModelListener {
+	extends BaseMessageListener
+	implements ConfigurationModelListener, SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Override
 	public void onAfterSave(String pid, Dictionary<String, Object> properties) {
@@ -78,11 +87,6 @@ public class UserImportMessageListener
 			_ldapImportConfigurationProvider.getConfiguration(0L);
 
 		_updateDefaultImportInterval(ldapImportConfiguration.importInterval());
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
 	}
 
 	@Override
@@ -161,13 +165,6 @@ public class UserImportMessageListener
 		_ldapImportConfigurationProvider = ldapImportConfigurationProvider;
 	}
 
-	@Reference(unbind = "-")
-	protected void setSchedulerEngineHelper(
-		SchedulerEngineHelper schedulerEngineHelper) {
-
-		_schedulerEngineHelper = schedulerEngineHelper;
-	}
-
 	private void _updateDefaultImportInterval(int interval) {
 		if (_log.isDebugEnabled()) {
 			_log.debug(
@@ -182,12 +179,7 @@ public class UserImportMessageListener
 		Trigger trigger = _triggerFactory.createTrigger(
 			className, className, null, null, interval, TimeUnit.MINUTE);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry,
-			LDAPDestinationNames.SCHEDULED_USER_LDAP_IMPORT);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -203,7 +195,7 @@ public class UserImportMessageListener
 	)
 	private volatile LDAPUserImporter _ldapUserImporter;
 
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/AbortedMultipartUploadCleaner.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/AbortedMultipartUploadCleaner.java
@@ -22,12 +22,13 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageListener;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -35,11 +36,13 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
 import java.util.Date;
+import java.util.Dictionary;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -65,7 +68,7 @@ public class AbortedMultipartUploadCleaner {
 					"(&(", Constants.OBJECTCLASS, "=", Store.class.getName(),
 					")(store.type=", S3Store.class.getName(), "))")),
 			new S3StoreServiceTrackerCustomizer(
-				bundleContext, _schedulerEngineHelper, _triggerFactory));
+				bundleContext, _triggerFactory));
 	}
 
 	@Deactivate
@@ -73,16 +76,18 @@ public class AbortedMultipartUploadCleaner {
 		_serviceTracker.close();
 	}
 
-	@Reference(unbind = "-")
-	private SchedulerEngineHelper _schedulerEngineHelper;
-
 	private ServiceTracker<S3Store, MessageListener> _serviceTracker;
 
 	@Reference(unbind = "-")
 	private TriggerFactory _triggerFactory;
 
 	private static class AbortedMultipartUploadMessageListener
-		extends BaseMessageListener {
+		extends BaseMessageListener implements SchedulerEventMessageListener {
+
+		@Override
+		public SchedulerEntry getSchedulerEntry() {
+			return _schedulerEntry;
+		}
 
 		@Override
 		protected void doReceive(Message message) throws Exception {
@@ -92,8 +97,11 @@ public class AbortedMultipartUploadCleaner {
 				_s3Store.getBucketName(), _computeStartDate());
 		}
 
-		private AbortedMultipartUploadMessageListener(S3Store s3Store) {
+		private AbortedMultipartUploadMessageListener(
+			S3Store s3Store, SchedulerEntry schedulerEntry) {
+
 			_s3Store = s3Store;
+			_schedulerEntry = schedulerEntry;
 		}
 
 		private Date _computeStartDate() {
@@ -112,6 +120,7 @@ public class AbortedMultipartUploadCleaner {
 		}
 
 		private final S3Store _s3Store;
+		private final SchedulerEntry _schedulerEntry;
 
 	}
 
@@ -121,10 +130,6 @@ public class AbortedMultipartUploadCleaner {
 		@Override
 		public MessageListener addingService(
 			ServiceReference<S3Store> serviceReference) {
-
-			MessageListener messageListener =
-				new AbortedMultipartUploadMessageListener(
-					_bundleContext.getService(serviceReference));
 
 			Class<?> clazz = getClass();
 
@@ -136,11 +141,21 @@ public class AbortedMultipartUploadCleaner {
 			SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
 				className, trigger);
 
-			_schedulerEngineHelper.register(
-				messageListener, schedulerEntry,
-				DestinationNames.SCHEDULER_DISPATCH);
+			SchedulerEventMessageListener schedulerEventMessageListener =
+				new AbortedMultipartUploadMessageListener(
+					_bundleContext.getService(serviceReference),
+					schedulerEntry);
 
-			return messageListener;
+			Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+			properties.put(
+				"destination.name", DestinationNames.SCHEDULER_DISPATCH);
+
+			_serviceRegistration = _bundleContext.registerService(
+				SchedulerEventMessageListener.class,
+				schedulerEventMessageListener, properties);
+
+			return schedulerEventMessageListener;
 		}
 
 		@Override
@@ -154,21 +169,19 @@ public class AbortedMultipartUploadCleaner {
 			ServiceReference<S3Store> serviceReference,
 			MessageListener messageListener) {
 
-			_schedulerEngineHelper.unregister(messageListener);
+			_serviceRegistration.unregister();
 		}
 
 		private S3StoreServiceTrackerCustomizer(
-			BundleContext bundleContext,
-			SchedulerEngineHelper schedulerEngineHelper,
-			TriggerFactory triggerFactory) {
+			BundleContext bundleContext, TriggerFactory triggerFactory) {
 
 			_bundleContext = bundleContext;
-			_schedulerEngineHelper = schedulerEngineHelper;
 			_triggerFactory = triggerFactory;
 		}
 
 		private final BundleContext _bundleContext;
-		private final SchedulerEngineHelper _schedulerEngineHelper;
+		private ServiceRegistration<SchedulerEventMessageListener>
+			_serviceRegistration;
 		private final TriggerFactory _triggerFactory;
 
 	}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/messaging/KaleoWorkflowMessagingConfigurator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/messaging/KaleoWorkflowMessagingConfigurator.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.messaging.proxy.ProxyMessageListener;
-import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.workflow.WorkflowDefinitionManager;
 import com.liferay.portal.kernel.workflow.WorkflowEngineManager;
@@ -150,11 +150,11 @@ public class KaleoWorkflowMessagingConfigurator {
 	}
 
 	protected void registerSchedulerEventMessageListener() {
-		SchedulerEventMessageListenerWrapper
-			schedulerEventMessageListenerWrapper =
-				new SchedulerEventMessageListenerWrapper();
+		SchedulerEventMessageListenerAdapter
+			schedulerEventMessageListenerAdapter =
+				new SchedulerEventMessageListenerAdapter();
 
-		schedulerEventMessageListenerWrapper.setMessageListener(
+		schedulerEventMessageListenerAdapter.setMessageListener(
 			_timerMessageListener);
 
 		Dictionary<String, Object> properties = new HashMapDictionary<>();
@@ -162,10 +162,14 @@ public class KaleoWorkflowMessagingConfigurator {
 		properties.put(
 			"destination.name", KaleoRuntimeDestinationNames.WORKFLOW_TIMER);
 
+		Class<?> clazz = _timerMessageListener.getClass();
+
+		properties.put("event.listener.classname", clazz.getName());
+
 		_schedulerEventMessageListenerServiceRegistration =
 			_bundleContext.registerService(
-				MessageListener.class, schedulerEventMessageListenerWrapper,
-				properties);
+				SchedulerEventMessageListenerAdapter.class,
+				schedulerEventMessageListenerAdapter, properties);
 	}
 
 	protected void registerWorkflowDefinitionLinkDestination() {
@@ -327,7 +331,7 @@ public class KaleoWorkflowMessagingConfigurator {
 
 	private final Map<String, MessageListener> _proxyMessageListeners =
 		new HashMap<>();
-	private ServiceRegistration<MessageListener>
+	private ServiceRegistration<SchedulerEventMessageListenerAdapter>
 		_schedulerEventMessageListenerServiceRegistration;
 	private final Map<String, ServiceRegistration<Destination>>
 		_serviceRegistrations = new HashMap<>();

--- a/modules/apps/portal/portal-pop-notifications/src/main/java/com/liferay/portal/pop/notifications/internal/messaging/POPNotificationsMessageListener.java
+++ b/modules/apps/portal/portal-pop-notifications/src/main/java/com/liferay/portal/pop/notifications/internal/messaging/POPNotificationsMessageListener.java
@@ -24,12 +24,12 @@ import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.pop.MessageListener;
 import com.liferay.portal.kernel.pop.MessageListenerException;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -50,7 +50,6 @@ import javax.mail.internet.InternetAddress;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -60,8 +59,21 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 /**
  * @author Brian Wing Shun Chan
  */
-@Component(immediate = true, service = POPNotificationsMessageListener.class)
-public class POPNotificationsMessageListener extends BaseMessageListener {
+@Component(
+	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		POPNotificationsMessageListener.class,
+		SchedulerEventMessageListener.class
+	}
+)
+public class POPNotificationsMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	@Modified
@@ -74,11 +86,7 @@ public class POPNotificationsMessageListener extends BaseMessageListener {
 			Trigger trigger = _triggerFactory.createTrigger(
 				className, className, null, null, 1, TimeUnit.MINUTE);
 
-			SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-				className, trigger);
-
-			_schedulerEngineHelper.register(
-				this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
+			_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 		}
 	}
 
@@ -93,13 +101,6 @@ public class POPNotificationsMessageListener extends BaseMessageListener {
 			new MessageListenerWrapper(messageListener);
 
 		_messageListenerWrappers.put(messageListener, messageListenerWrapper);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		if (PropsValues.POP_SERVER_NOTIFICATIONS_ENABLED) {
-			_schedulerEngineHelper.unregister(this);
-		}
 	}
 
 	@Override
@@ -249,19 +250,12 @@ public class POPNotificationsMessageListener extends BaseMessageListener {
 		ModuleServiceLifecycle moduleServiceLifecycle) {
 	}
 
-	@Reference(unbind = "-")
-	protected void setSchedulerEngineHelper(
-		SchedulerEngineHelper schedulerEngineHelper) {
-
-		_schedulerEngineHelper = schedulerEngineHelper;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		POPNotificationsMessageListener.class);
 
 	private final Map<MessageListener, MessageListenerWrapper>
 		_messageListenerWrappers = new ConcurrentHashMap<>();
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/recent-documents/recent-documents-web/src/main/java/com/liferay/recent/documents/web/internal/messaging/RecentDocumentsMessageListener.java
+++ b/modules/apps/recent-documents/recent-documents-web/src/main/java/com/liferay/recent/documents/web/internal/messaging/RecentDocumentsMessageListener.java
@@ -20,12 +20,12 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.recent.documents.web.internal.configuration.RecentDocumentsConfiguration;
 
@@ -34,7 +34,6 @@ import java.util.Map;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -44,9 +43,19 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	configurationPid = "com.liferay.recent.documents.web.internal.configuration.RecentDocumentsConfiguration",
 	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true,
-	service = RecentDocumentsMessageListener.class
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		RecentDocumentsMessageListener.class,
+		SchedulerEventMessageListener.class
+	}
 )
-public class RecentDocumentsMessageListener extends BaseMessageListener {
+public class RecentDocumentsMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	protected void activate(Map<String, Object> properties) {
@@ -63,16 +72,7 @@ public class RecentDocumentsMessageListener extends BaseMessageListener {
 			recentDocumentsConfiguration.checkFileRanksInterval(),
 			TimeUnit.MINUTE);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -82,8 +82,6 @@ public class RecentDocumentsMessageListener extends BaseMessageListener {
 
 	@Modified
 	protected void modified(Map<String, Object> properties) {
-		deactivate();
-
 		activate(properties);
 	}
 
@@ -98,8 +96,7 @@ public class RecentDocumentsMessageListener extends BaseMessageListener {
 	@Reference
 	private Props _props;
 
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/messaging/CheckIndividualSegmentsMessageListener.java
+++ b/modules/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/messaging/CheckIndividualSegmentsMessageListener.java
@@ -18,12 +18,12 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.segments.asah.connector.internal.configuration.SegmentsAsahConfiguration;
 
 import java.util.Map;
@@ -31,7 +31,6 @@ import java.util.Map;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -41,10 +40,19 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	configurationPid = "com.liferay.segments.asah.connector.internal.configuration.SegmentsAsahConfiguration",
 	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true,
-	service = CheckIndividualSegmentsMessageListener.class
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		CheckIndividualSegmentsMessageListener.class,
+		SchedulerEventMessageListener.class
+	}
 )
 public class CheckIndividualSegmentsMessageListener
-	extends BaseMessageListener {
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	@Modified
@@ -59,16 +67,7 @@ public class CheckIndividualSegmentsMessageListener
 			clazz.getName(), clazz.getName(), null, null,
 			segmentsAsahConfiguration.checkInterval(), TimeUnit.MINUTE);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			clazz.getName(), trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(clazz.getName(), trigger);
 	}
 
 	@Override
@@ -83,15 +82,8 @@ public class CheckIndividualSegmentsMessageListener
 		_individualSegmentsChecker = individualSegmentsChecker;
 	}
 
-	@Reference(unbind = "-")
-	protected void setSchedulerEngineHelper(
-		SchedulerEngineHelper schedulerEngineHelper) {
-
-		_schedulerEngineHelper = schedulerEngineHelper;
-	}
-
 	private IndividualSegmentsChecker _individualSegmentsChecker;
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/messaging/PluginRepositoriesMessageListener.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/messaging/PluginRepositoriesMessageListener.java
@@ -20,11 +20,11 @@ import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.search.SearchEngineHelperUtil;
 import com.liferay.portal.plugin.PluginPackageUtil;
 import com.liferay.server.admin.web.internal.configuration.PluginRepositoriesConfiguration;
@@ -34,7 +34,6 @@ import java.util.Map;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -45,9 +44,19 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	configurationPid = "com.liferay.server.admin.web.internal.configuration.PluginRepositoriesConfiguration",
 	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true,
-	service = PluginRepositoriesMessageListener.class
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		PluginRepositoriesMessageListener.class,
+		SchedulerEventMessageListener.class
+	}
 )
-public class PluginRepositoriesMessageListener extends BaseMessageListener {
+public class PluginRepositoriesMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	@Modified
@@ -69,16 +78,7 @@ public class PluginRepositoriesMessageListener extends BaseMessageListener {
 			pluginRepositoriesConfiguration.interval(),
 			pluginRepositoriesConfiguration.timeUnit());
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -93,14 +93,7 @@ public class PluginRepositoriesMessageListener extends BaseMessageListener {
 		ModuleServiceLifecycle moduleServiceLifecycle) {
 	}
 
-	@Reference(unbind = "-")
-	protected void setSchedulerEngineHelper(
-		SchedulerEngineHelper schedulerEngineHelper) {
-
-		_schedulerEngineHelper = schedulerEngineHelper;
-	}
-
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/messaging/DeleteExpiredSharingEntriesMessageListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/messaging/DeleteExpiredSharingEntriesMessageListener.java
@@ -18,12 +18,12 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.sharing.internal.configuration.SharingSystemConfiguration;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
@@ -31,7 +31,6 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -40,10 +39,20 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.sharing.internal.configuration.SharingSystemConfiguration",
-	immediate = true, service = DeleteExpiredSharingEntriesMessageListener.class
+	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		DeleteExpiredSharingEntriesMessageListener.class,
+		SchedulerEventMessageListener.class
+	}
 )
 public class DeleteExpiredSharingEntriesMessageListener
-	extends BaseMessageListener {
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	@Modified
@@ -60,16 +69,7 @@ public class DeleteExpiredSharingEntriesMessageListener
 			_sharingSystemConfiguration.expiredSharingEntriesCheckInterval(),
 			TimeUnit.MINUTE);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -77,8 +77,7 @@ public class DeleteExpiredSharingEntriesMessageListener
 		_sharingEntryLocalService.deleteExpiredEntries();
 	}
 
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 
 	@Reference
 	private SharingEntryLocalService _sharingEntryLocalService;

--- a/modules/apps/subscription/subscription-web/src/main/java/com/liferay/subscription/web/internal/messaging/DeleteExpiredTicketsMessageListener.java
+++ b/modules/apps/subscription/subscription-web/src/main/java/com/liferay/subscription/web/internal/messaging/DeleteExpiredTicketsMessageListener.java
@@ -22,12 +22,12 @@ import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.subscription.model.Subscription;
@@ -38,7 +38,6 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -47,9 +46,17 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.subscription.web.internal.configuration.SubscriptionConfiguration",
-	immediate = true, service = {}
+	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = SchedulerEventMessageListener.class
 )
-public class DeleteExpiredTicketsMessageListener extends BaseMessageListener {
+public class DeleteExpiredTicketsMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	@Modified
@@ -66,16 +73,7 @@ public class DeleteExpiredTicketsMessageListener extends BaseMessageListener {
 			_subscriptionConfiguration.deleteExpiredTicketsInterval(),
 			TimeUnit.HOUR);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -111,9 +109,7 @@ public class DeleteExpiredTicketsMessageListener extends BaseMessageListener {
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
 
-	@Reference
-	private SchedulerEngineHelper _schedulerEngineHelper;
-
+	private SchedulerEntry _schedulerEntry;
 	private volatile SubscriptionConfiguration _subscriptionConfiguration;
 
 	@Reference

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/messaging/SyncMaintenanceMessageListener.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/internal/messaging/SyncMaintenanceMessageListener.java
@@ -24,12 +24,12 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.sync.service.SyncDLFileVersionDiffLocalService;
 import com.liferay.sync.service.SyncDLObjectLocalService;
@@ -37,17 +37,29 @@ import com.liferay.sync.service.internal.configuration.SyncServiceConfigurationV
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Dennis Ju
  */
-@Component(immediate = true, service = SyncMaintenanceMessageListener.class)
-public class SyncMaintenanceMessageListener extends BaseMessageListener {
+@Component(
+	immediate = true,
+	property = "destination.name=" + SyncMaintenanceMessageListener.DESTINATION_NAME,
+	service = {
+		SchedulerEventMessageListener.class,
+		SyncMaintenanceMessageListener.class
+	}
+)
+public class SyncMaintenanceMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
 
 	public static final String DESTINATION_NAME =
 		"liferay/sync_maintenance_processor";
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	protected void activate() {
@@ -58,15 +70,7 @@ public class SyncMaintenanceMessageListener extends BaseMessageListener {
 		Trigger trigger = _triggerFactory.createTrigger(
 			className, className, null, null, 1, TimeUnit.HOUR);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(this, schedulerEntry, DESTINATION_NAME);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -123,13 +127,6 @@ public class SyncMaintenanceMessageListener extends BaseMessageListener {
 	}
 
 	@Reference(unbind = "-")
-	protected void setSchedulerEngineHelper(
-		SchedulerEngineHelper schedulerEngineHelper) {
-
-		_schedulerEngineHelper = schedulerEngineHelper;
-	}
-
-	@Reference(unbind = "-")
 	protected void setSyncDLFileVersionDiffLocalService(
 		SyncDLFileVersionDiffLocalService syncDLFileVersionDiffLocalService) {
 
@@ -147,7 +144,7 @@ public class SyncMaintenanceMessageListener extends BaseMessageListener {
 		SyncMaintenanceMessageListener.class);
 
 	private DLSyncEventLocalService _dlSyncEventLocalService;
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 	private SyncDLFileVersionDiffLocalService
 		_syncDLFileVersionDiffLocalService;
 	private SyncDLObjectLocalService _syncDLObjectLocalService;

--- a/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/messaging/CheckEntryMessageListener.java
+++ b/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/messaging/CheckEntryMessageListener.java
@@ -18,18 +18,17 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.trash.service.TrashEntryLocalService;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -41,8 +40,20 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Eudaldo Alonso
  */
-@Component(immediate = true, service = CheckEntryMessageListener.class)
-public class CheckEntryMessageListener extends BaseMessageListener {
+@Component(
+	immediate = true,
+	property = "destination.name=" + DestinationNames.SCHEDULER_DISPATCH,
+	service = {
+		CheckEntryMessageListener.class, SchedulerEventMessageListener.class
+	}
+)
+public class CheckEntryMessageListener
+	extends BaseMessageListener implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
 
 	@Activate
 	protected void activate() {
@@ -54,16 +65,7 @@ public class CheckEntryMessageListener extends BaseMessageListener {
 			className, className, null, null,
 			PropsValues.TRASH_ENTRY_CHECK_INTERVAL, TimeUnit.MINUTE);
 
-		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
-			className, trigger);
-
-		_schedulerEngineHelper.register(
-			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_schedulerEngineHelper.unregister(this);
+		_schedulerEntry = new SchedulerEntryImpl(className, trigger);
 	}
 
 	@Override
@@ -77,20 +79,13 @@ public class CheckEntryMessageListener extends BaseMessageListener {
 	}
 
 	@Reference(unbind = "-")
-	protected void setSchedulerEngineHelper(
-		SchedulerEngineHelper schedulerEngineHelper) {
-
-		_schedulerEngineHelper = schedulerEngineHelper;
-	}
-
-	@Reference(unbind = "-")
 	protected void setTrashEntryLocalService(
 		TrashEntryLocalService trashEntryLocalService) {
 
 		_trashEntryLocalService = trashEntryLocalService;
 	}
 
-	private SchedulerEngineHelper _schedulerEngineHelper;
+	private SchedulerEntry _schedulerEntry;
 	private TrashEntryLocalService _trashEntryLocalService;
 
 	@Reference

--- a/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
+++ b/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
@@ -41,7 +41,7 @@ import com.liferay.portal.kernel.portlet.PortletLayoutListener;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.scheduler.SchedulerEntry;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
-import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
+import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerAdapter;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.OpenSearch;
 import com.liferay.portal.kernel.security.permission.propagator.PermissionPropagator;
@@ -622,9 +622,9 @@ public class PortletBagFactory {
 		throws Exception {
 
 		for (SchedulerEntry schedulerEntry : portlet.getSchedulerEntries()) {
-			SchedulerEventMessageListenerWrapper
-				schedulerEventMessageListenerWrapper =
-					new SchedulerEventMessageListenerWrapper();
+			SchedulerEventMessageListenerAdapter
+				schedulerEventMessageListenerAdapter =
+					new SchedulerEventMessageListenerAdapter();
 
 			com.liferay.portal.kernel.messaging.MessageListener
 				messageListener =
@@ -633,16 +633,16 @@ public class PortletBagFactory {
 							_classLoader,
 							schedulerEntry.getEventListenerClass());
 
-			schedulerEventMessageListenerWrapper.setMessageListener(
+			schedulerEventMessageListenerAdapter.setMessageListener(
 				messageListener);
 
-			schedulerEventMessageListenerWrapper.setSchedulerEntry(
+			schedulerEventMessageListenerAdapter.setSchedulerEntry(
 				schedulerEntry);
 
 			ServiceRegistration<?> serviceRegistration =
 				registry.registerService(
 					SchedulerEventMessageListener.class,
-					schedulerEventMessageListenerWrapper, properties);
+					schedulerEventMessageListenerAdapter, properties);
 
 			serviceRegistrations.add(serviceRegistration);
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/SchedulerEngineHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/SchedulerEngineHelper.java
@@ -116,6 +116,10 @@ public interface SchedulerEngineHelper {
 	public void pause(String jobName, String groupName, StorageType storageType)
 		throws SchedulerException;
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
 	public void register(
 		MessageListener messageListener, SchedulerEntry schedulerEntry,
 		String destinationName);
@@ -145,6 +149,10 @@ public interface SchedulerEngineHelper {
 			String jobName, String groupName, StorageType storageType)
 		throws SchedulerException;
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
 	public void unregister(MessageListener messageListener);
 
 	public void unschedule(

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/SchedulerEngineHelperUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/SchedulerEngineHelperUtil.java
@@ -225,6 +225,10 @@ public class SchedulerEngineHelperUtil {
 		_getSchedulerEngineHelper().pause(jobName, groupName, storageType);
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
 	public static void register(
 		MessageListener messageListener, SchedulerEntry schedulerEntry,
 		String destinationName) {
@@ -282,6 +286,10 @@ public class SchedulerEngineHelperUtil {
 			jobName, groupName, storageType);
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
 	public static void unregister(MessageListener messageListener) {
 		_getSchedulerEngineHelper().unregister(messageListener);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerAdapter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerAdapter.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.scheduler.messaging;
+
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.messaging.MessageListenerException;
+import com.liferay.portal.kernel.scheduler.SchedulerEntry;
+
+/**
+ * @author Hai Yu
+ */
+public class SchedulerEventMessageListenerAdapter
+	implements SchedulerEventMessageListener {
+
+	@Override
+	public SchedulerEntry getSchedulerEntry() {
+		return _schedulerEntry;
+	}
+
+	@Override
+	public void receive(Message message) throws MessageListenerException {
+		_messageListener.receive(message);
+	}
+
+	public void setMessageListener(MessageListener messageListener) {
+		_messageListener = messageListener;
+	}
+
+	public void setSchedulerEntry(SchedulerEntry schedulerEntry) {
+		_schedulerEntry = schedulerEntry;
+	}
+
+	private MessageListener _messageListener;
+	private SchedulerEntry _schedulerEntry;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerWrapper.java
@@ -47,7 +47,11 @@ public class SchedulerEventMessageListenerWrapper
 
 	@Override
 	public SchedulerEntry getSchedulerEntry() {
-		return _schedulerEntry;
+		return _schedulerEventMessageListener.getSchedulerEntry();
+	}
+
+	public SchedulerEventMessageListener getSchedulerEventMessageListener() {
+		return _schedulerEventMessageListener;
 	}
 
 	@Override
@@ -58,7 +62,9 @@ public class SchedulerEventMessageListenerWrapper
 		String groupName = message.getString(SchedulerEngine.GROUP_NAME);
 
 		if (destinationName.equals(DestinationNames.SCHEDULER_DISPATCH)) {
-			Trigger trigger = _schedulerEntry.getTrigger();
+			SchedulerEntry schedulerEntry = getSchedulerEntry();
+
+			Trigger trigger = schedulerEntry.getTrigger();
 
 			if (!jobName.equals(trigger.getJobName()) ||
 				!groupName.equals(trigger.getGroupName())) {
@@ -102,12 +108,26 @@ public class SchedulerEventMessageListenerWrapper
 		}
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
 	public void setMessageListener(MessageListener messageListener) {
 		_messageListener = messageListener;
 	}
 
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
 	public void setSchedulerEntry(SchedulerEntry schedulerEntry) {
 		_schedulerEntry = schedulerEntry;
+	}
+
+	public void setSchedulerEventMessageListener(
+		SchedulerEventMessageListener schedulerEventMessageListener) {
+
+		_schedulerEventMessageListener = schedulerEventMessageListener;
 	}
 
 	protected void handleException(Message message, Exception exception) {
@@ -124,7 +144,7 @@ public class SchedulerEventMessageListenerWrapper
 		throws MessageListenerException {
 
 		try {
-			_messageListener.receive(message);
+			_schedulerEventMessageListener.receive(message);
 		}
 		catch (Exception e) {
 			handleException(message, e);
@@ -190,7 +210,21 @@ public class SchedulerEventMessageListenerWrapper
 		SchedulerEventMessageListenerWrapper.class);
 
 	private final Lock _lock = new ReentrantLock();
+
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
+	@SuppressWarnings("unused")
 	private MessageListener _messageListener;
+
+	/**
+	 * @deprecated As of Mueller (7.2.x), with no direct replacement
+	 */
+	@Deprecated
+	@SuppressWarnings("unused")
 	private volatile SchedulerEntry _schedulerEntry;
+
+	private SchedulerEventMessageListener _schedulerEventMessageListener;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0


### PR DESCRIPTION
@dantewang 

The current change divide two points.

1. MessageListener and Scheduler together. SchedulerEventMessageListenerServiceTrackerCustomizer take cares this.
2. MessageListener without Scheduler: SchedulerEventMessageListenerAdapterRegistrar takes care it.

I have done the below tests and they are passed:
1. New mode: *messageListener as SchedulerEventMessageListener service publish.
2. Old mode:  Test schedulerEngineHelper.register() way.
3. Test create Scheduler by manual, publish one scheduler event when publish to live.

I will test "the war development" next Tuesday.