### PR TITLE
LPS-102219

### DIFF
--- a/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/bnd/util/ConfigurableUtil.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/bnd/util/ConfigurableUtil.java
@@ -20,6 +20,7 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.CharPool;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import java.util.Dictionary;
@@ -67,9 +68,15 @@ public class ConfigurableUtil {
 				byte[] snapshotClassData = _generateSnapshotClassData(
 					interfaceClass, snapshotClassName);
 
-				snapshotClass = (Class<T>)_defineClassMethod.invoke(
-					classLoader, snapshotClassName, snapshotClassData, 0,
-					snapshotClassData.length);
+				try {
+					snapshotClass = (Class<T>)_defineClassMethod.invoke(
+						classLoader, snapshotClassName, snapshotClassData, 0,
+						snapshotClassData.length);
+				}
+				catch (InvocationTargetException ite) {
+					snapshotClass = (Class<T>)classLoader.loadClass(
+						snapshotClassName);
+				}
 			}
 
 			Constructor<T> snapshotClassConstructor =

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/test/java/com/liferay/portal/configuration/metatype/bnd/util/ConfigurableUtilTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/test/java/com/liferay/portal/configuration/metatype/bnd/util/ConfigurableUtilTest.java
@@ -30,7 +30,6 @@ import java.lang.reflect.Field;
 
 import java.util.Collections;
 import java.util.Dictionary;
-import java.util.concurrent.FutureTask;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -100,11 +99,12 @@ public class ConfigurableUtilTest {
 	public void testCreateConfigurablewithDefinedSnapshotClass()
 		throws Exception {
 
-		FutureTask<Void> futureTask1 = _createFutureTask();
-
-		_startThread(futureTask1, "thread1");
-
-		futureTask1.get();
+		_assertTestConfiguration(
+			ConfigurableUtil.createConfigurable(
+				TestConfiguration.class,
+				Collections.singletonMap(
+					"testReqiredString", "testReqiredString")),
+			"testReqiredString");
 
 		Field field = ReflectionUtil.getDeclaredField(
 			ConfigurableUtil.class, "_findLoadedClassMethod");
@@ -116,11 +116,12 @@ public class ConfigurableUtilTest {
 			ReflectionUtil.getDeclaredMethod(
 				ClassLoader.class, "findBootstrapClass", String.class));
 
-		FutureTask<Void> futureTask2 = _createFutureTask();
-
-		_startThread(futureTask2, "thread2");
-
-		futureTask2.get();
+		_assertTestConfiguration(
+			ConfigurableUtil.createConfigurable(
+				TestConfiguration.class,
+				Collections.singletonMap(
+					"testReqiredString", "testReqiredString")),
+			"testReqiredString");
 
 		field.set(null, value);
 	}
@@ -192,26 +193,6 @@ public class ConfigurableUtilTest {
 		TestClass testClass = testConfiguration.testClass();
 
 		Assert.assertEquals("test.class", testClass.getName());
-	}
-
-	private FutureTask<Void> _createFutureTask() {
-		return new FutureTask<>(
-			() -> {
-				_assertTestConfiguration(
-					ConfigurableUtil.createConfigurable(
-						TestConfiguration.class,
-						Collections.singletonMap(
-							"testReqiredString", "testReqiredString")),
-					"testReqiredString");
-
-				return null;
-			});
-	}
-
-	private void _startThread(FutureTask<Void> futureTask, String threadName) {
-		Thread thread = new Thread(futureTask, threadName);
-
-		thread.start();
 	}
 
 	private void _testBigString(int length) {


### PR DESCRIPTION
@dantewang, the issue happens when two thread define class at the same time.

In unit test, I use one thread to simulate the case (when the second thread executes at https://github.com/dantewang/liferay-portal/blob/5426a744671cb4dc9f9798e8a1325888dc253bd4/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/bnd/util/ConfigurableUtil.java#L64 and the first thread had defined the class), I need to let snapshotClass=null to throw the exception for the fix.

Ci test was passed, please refer to from https://github.com/yuhai/liferay-portal/pull/171