### PR TITLE
LPS-95571 REPLACE function can't use for TEXT data type in Sybase.

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_3/UpgradeLayoutTemplateId.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_3/UpgradeLayoutTemplateId.java
@@ -15,6 +15,9 @@
 package com.liferay.layout.admin.web.internal.upgrade.v_1_0_3;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
 /**
@@ -28,12 +31,23 @@ public class UpgradeLayoutTemplateId extends UpgradeProcess {
 	}
 
 	protected void updateLayoutTemplateId() throws Exception {
-		String sql = StringBundler.concat(
-			"update Layout set typeSettings = REPLACE(typeSettings, ",
-			"'layout-template-id=1_2_1_columns\n', ",
-			"'layout-template-id=1_2_1_columns_i\n')");
+		DB db = DBManagerUtil.getDB();
 
-		runSQL(sql);
+		if (db.getDBType() == DBType.SYBASE) {
+			runSQL(
+				StringBundler.concat(
+					"update Layout set typeSettings = ",
+					"REPLACE(CAST_TEXT(typeSettings), ",
+					"'layout-template-id=1_2_1_columns\n', ",
+					"'layout-template-id=1_2_1_columns_i\n')"));
+		}
+		else {
+			runSQL(
+				StringBundler.concat(
+					"update Layout set typeSettings = REPLACE(typeSettings, ",
+					"'layout-template-id=1_2_1_columns\n', ",
+					"'layout-template-id=1_2_1_columns_i\n')"));
+		}
 	}
 
 }


### PR DESCRIPTION
@dantewang, refer to the below content from http://infocenter-archive.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc38151.1270/html/iqref/CHDFIBIJ.htm

> string_expr1 is the source string, or the string expression to be searched, expressed as CHAR, VARCHAR, UNICHAR, UNIVARCHAR, VARBINARY, or BINARY data type.

REPLACE function can't use for TEXT data type in Sybase.

