### PR TITLE
LPS-89497

### DIFF
--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/activator/ConfigurationPersistenceImplBundleActivator.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/activator/ConfigurationPersistenceImplBundleActivator.java
@@ -80,7 +80,7 @@ public class ConfigurationPersistenceImplBundleActivator
 			bundleContext.registerService(
 				ConfigurationUpgradeStepFactory.class,
 				new ConfigurationUpgradeStepFactoryImpl(
-					_configurationPersistenceManager),
+					bundleContext, _configurationPersistenceManager),
 				null);
 	}
 

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
@@ -58,10 +58,10 @@ public class ConfigurationUpgradeStepFactoryImpl
 					_persistenceManager.store(newPid, dictionary);
 
 					_persistenceManager.delete(oldPid);
-				}
 
-				_renameConfigurationFile(oldPid, newPid, "cfg");
-				_renameConfigurationFile(oldPid, newPid, "config");
+					_renameConfigurationFile(oldPid, newPid, "cfg");
+					_renameConfigurationFile(oldPid, newPid, "config");
+				}
 			}
 			catch (IOException ioe) {
 				throw new UpgradeException(ioe);

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
@@ -15,11 +15,13 @@
 package com.liferay.portal.configuration.persistence.internal.upgrade;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.persistence.upgrade.ConfigurationUpgradeStepFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
@@ -31,6 +33,11 @@ import java.util.Dictionary;
 
 import org.apache.felix.cm.PersistenceManager;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
 /**
  * @author Preston Crary
  */
@@ -38,8 +45,9 @@ public class ConfigurationUpgradeStepFactoryImpl
 	implements ConfigurationUpgradeStepFactory {
 
 	public ConfigurationUpgradeStepFactoryImpl(
-		PersistenceManager persistenceManager) {
+		BundleContext bundleContext, PersistenceManager persistenceManager) {
 
+		_bundleContext = bundleContext;
 		_persistenceManager = persistenceManager;
 	}
 
@@ -61,6 +69,91 @@ public class ConfigurationUpgradeStepFactoryImpl
 
 					_renameConfigurationFile(oldPid, newPid, "cfg");
 					_renameConfigurationFile(oldPid, newPid, "config");
+				}
+				else {
+					ServiceReference<ConfigurationAdmin> serviceReference =
+						_bundleContext.getServiceReference(
+							ConfigurationAdmin.class);
+
+					ConfigurationAdmin configurationAdmin =
+						_bundleContext.getService(serviceReference);
+
+					String filter = StringBundler.concat(
+						StringPool.OPEN_PARENTHESIS,
+						ConfigurationAdmin.SERVICE_FACTORYPID, StringPool.EQUAL,
+						oldPid, StringPool.CLOSE_PARENTHESIS);
+
+					try {
+						Configuration[] configurations =
+							configurationAdmin.listConfigurations(filter);
+
+						if ((configurations == null) ||
+							(configurations.length == 0)) {
+
+							if (_log.isWarnEnabled()) {
+								_log.warn(
+									StringBundler.concat(
+										"Unable to upgrade ", oldPid,
+										" because no associated configuration ",
+										"exists"));
+							}
+
+							return;
+						}
+
+						for (Configuration configuration : configurations) {
+							Dictionary<String, String> dictionary =
+								_persistenceManager.load(
+									configuration.getPid());
+
+							dictionary.put("service.factoryPid", newPid);
+
+							String oldServicePid = dictionary.get(
+								"service.pid");
+
+							String newServicePid = StringUtil.replace(
+								oldServicePid, oldPid, newPid);
+
+							dictionary.put("service.pid", newServicePid);
+
+							String oldFileName = dictionary.get(
+								"felix.fileinstall.filename");
+
+							String newFileName = StringUtil.replace(
+								oldFileName, oldPid, newPid);
+
+							dictionary.put(
+								"felix.fileinstall.filename", newFileName);
+
+							_persistenceManager.store(
+								newServicePid, dictionary);
+
+							_persistenceManager.delete(oldServicePid);
+
+							_renameConfigurationFile(
+								oldFileName.substring(
+									oldFileName.lastIndexOf('/') + 1,
+									oldFileName.lastIndexOf('.')),
+								newFileName.substring(
+									newFileName.lastIndexOf('/') + 1,
+									newFileName.lastIndexOf('.')),
+								"cfg");
+							_renameConfigurationFile(
+								oldFileName.substring(
+									oldFileName.lastIndexOf('/') + 1,
+									oldFileName.lastIndexOf('.')),
+								newFileName.substring(
+									newFileName.lastIndexOf('/') + 1,
+									newFileName.lastIndexOf('.')),
+								"config");
+						}
+					}
+					catch (Exception e) {
+						throw new UpgradeException(e);
+					}
+					finally {
+						_bundleContext.ungetService(serviceReference);
+					}
 				}
 			}
 			catch (IOException ioe) {
@@ -105,6 +198,7 @@ public class ConfigurationUpgradeStepFactoryImpl
 	private static final Log _log = LogFactoryUtil.getLog(
 		ConfigurationUpgradeStepFactoryImpl.class);
 
+	private final BundleContext _bundleContext;
 	private final PersistenceManager _persistenceManager;
 
 }

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
@@ -58,8 +58,6 @@ public class ConfigurationUpgradeStepFactoryImpl
 					Dictionary<String, String> dictionary =
 						_persistenceManager.load(oldPid);
 
-					dictionary.remove("service.pid");
-
 					dictionary.put("service.pid", newPid);
 
 					_persistenceManager.store(newPid, dictionary);

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/ConfigurationUpgradeStepFactoryImpl.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
-import java.io.IOException;
 
 import java.nio.file.Files;
 
@@ -148,23 +147,20 @@ public class ConfigurationUpgradeStepFactoryImpl
 								"config");
 						}
 					}
-					catch (Exception e) {
-						throw new UpgradeException(e);
-					}
 					finally {
 						_bundleContext.ungetService(serviceReference);
 					}
 				}
 			}
-			catch (IOException ioe) {
-				throw new UpgradeException(ioe);
+			catch (Exception e) {
+				throw new UpgradeException(e);
 			}
 		};
 	}
 
 	private void _renameConfigurationFile(
 			String oldPid, String newPid, String extension)
-		throws IOException {
+		throws Exception {
 
 		File oldConfigFile = new File(
 			StringBundler.concat(

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-test/build.gradle
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay", name: "org.apache.felix.configadmin", version: "1.9.8.LIFERAY-PATCHED-3"
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:static:osgi:osgi-util")

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/ConfigurationUpgradeStepFactoryTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/ConfigurationUpgradeStepFactoryTest.java
@@ -58,36 +58,21 @@ public class ConfigurationUpgradeStepFactoryTest {
 
 	@Test
 	public void testCreateUpgradeStep() throws Exception {
-		String oldPid = "test.old.pid";
-		String newPid = "test.new.pid";
-
 		Configuration configuration = _configurationAdmin.getConfiguration(
-			oldPid);
+			_OLD_PID);
 
-		Assert.assertTrue(_persistenceManager.exists(oldPid));
+		Assert.assertTrue(_persistenceManager.exists(_OLD_PID));
 
 		UpgradeStep upgradeStep =
-			_configurationUpgradeStepFactory.createUpgradeStep(oldPid, newPid);
+			_configurationUpgradeStepFactory.createUpgradeStep(
+				_OLD_PID, _NEW_PID);
 
-		upgradeStep.upgrade(
-			new DBProcessContext() {
+		upgradeStep.upgrade(_DB_PROCESS_CONTEXT);
 
-				@Override
-				public DBContext getDBContext() {
-					return new DBContext();
-				}
+		Assert.assertFalse(_persistenceManager.exists(_OLD_PID));
+		Assert.assertTrue(_persistenceManager.exists(_NEW_PID));
 
-				@Override
-				public OutputStream getOutputStream() {
-					return null;
-				}
-
-			});
-
-		Assert.assertFalse(_persistenceManager.exists(oldPid));
-		Assert.assertTrue(_persistenceManager.exists(newPid));
-
-		_persistenceManager.delete(newPid);
+		_persistenceManager.delete(_NEW_PID);
 
 		ConfigurationTestUtil.deleteConfiguration(configuration);
 	}
@@ -96,7 +81,7 @@ public class ConfigurationUpgradeStepFactoryTest {
 	public void testCreateUpgradeStepWithFactory() throws Exception {
 		Configuration configuration =
 			_configurationAdmin.createFactoryConfiguration(
-				"test.old.pid", StringPool.QUESTION);
+				_OLD_PID, StringPool.QUESTION);
 
 		String oldPid = configuration.getPid();
 
@@ -125,25 +110,11 @@ public class ConfigurationUpgradeStepFactoryTest {
 
 		UpgradeStep upgradeStep =
 			_configurationUpgradeStepFactory.createUpgradeStep(
-				"test.old.pid", "test.new.pid");
+				_OLD_PID, _NEW_PID);
 
-		upgradeStep.upgrade(
-			new DBProcessContext() {
+		upgradeStep.upgrade(_DB_PROCESS_CONTEXT);
 
-				@Override
-				public DBContext getDBContext() {
-					return new DBContext();
-				}
-
-				@Override
-				public OutputStream getOutputStream() {
-					return null;
-				}
-
-			});
-
-		String newPid = StringUtil.replace(
-			oldPid, "test.old.pid", "test.new.pid");
+		String newPid = StringUtil.replace(oldPid, _OLD_PID, _NEW_PID);
 
 		Assert.assertFalse(_persistenceManager.exists(oldPid));
 		Assert.assertTrue(_persistenceManager.exists(newPid));
@@ -152,6 +123,25 @@ public class ConfigurationUpgradeStepFactoryTest {
 
 		ConfigurationTestUtil.deleteConfiguration(configuration);
 	}
+
+	private static final DBProcessContext _DB_PROCESS_CONTEXT =
+		new DBProcessContext() {
+
+			@Override
+			public DBContext getDBContext() {
+				return new DBContext();
+			}
+
+			@Override
+			public OutputStream getOutputStream() {
+				return null;
+			}
+
+		};
+
+	private static final String _NEW_PID = "test.new.pid";
+
+	private static final String _OLD_PID = "test.old.pid";
 
 	@Inject
 	private ConfigurationAdmin _configurationAdmin;

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/ConfigurationUpgradeStepFactoryTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/ConfigurationUpgradeStepFactoryTest.java
@@ -62,7 +62,9 @@ public class ConfigurationUpgradeStepFactoryTest {
 			_OLD_PID);
 
 		try {
-			Assert.assertTrue(_persistenceManager.exists(_OLD_PID));
+			Assert.assertTrue(
+				"Configuration " + _OLD_PID + " does not exist",
+				_persistenceManager.exists(_OLD_PID));
 
 			UpgradeStep upgradeStep =
 				_configurationUpgradeStepFactory.createUpgradeStep(
@@ -70,8 +72,12 @@ public class ConfigurationUpgradeStepFactoryTest {
 
 			upgradeStep.upgrade(_DB_PROCESS_CONTEXT);
 
-			Assert.assertFalse(_persistenceManager.exists(_OLD_PID));
-			Assert.assertTrue(_persistenceManager.exists(_NEW_PID));
+			Assert.assertFalse(
+				"Configuration " + _OLD_PID + " still exists",
+				_persistenceManager.exists(_OLD_PID));
+			Assert.assertTrue(
+				"Configuration " + _NEW_PID + " does not exist",
+				_persistenceManager.exists(_NEW_PID));
 		}
 		finally {
 			_persistenceManager.delete(_OLD_PID);
@@ -107,7 +113,9 @@ public class ConfigurationUpgradeStepFactoryTest {
 				MapUtil.singletonDictionary(
 					"felix.fileinstall.filename", uri.toString()));
 
-			Assert.assertTrue(_persistenceManager.exists(oldPid));
+			Assert.assertTrue(
+				"Configuration " + oldPid + " does not exist",
+				_persistenceManager.exists(oldPid));
 
 			UpgradeStep upgradeStep =
 				_configurationUpgradeStepFactory.createUpgradeStep(
@@ -115,8 +123,12 @@ public class ConfigurationUpgradeStepFactoryTest {
 
 			upgradeStep.upgrade(_DB_PROCESS_CONTEXT);
 
-			Assert.assertFalse(_persistenceManager.exists(oldPid));
-			Assert.assertTrue(_persistenceManager.exists(newPid));
+			Assert.assertFalse(
+				"Configuration " + oldPid + " still exists",
+				_persistenceManager.exists(oldPid));
+			Assert.assertTrue(
+				"Configuration " + newPid + " does not exist",
+				_persistenceManager.exists(newPid));
 		}
 		finally {
 			_persistenceManager.delete(oldPid);

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/ConfigurationUpgradeStepFactoryTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/ConfigurationUpgradeStepFactoryTest.java
@@ -61,20 +61,24 @@ public class ConfigurationUpgradeStepFactoryTest {
 		Configuration configuration = _configurationAdmin.getConfiguration(
 			_OLD_PID);
 
-		Assert.assertTrue(_persistenceManager.exists(_OLD_PID));
+		try {
+			Assert.assertTrue(_persistenceManager.exists(_OLD_PID));
 
-		UpgradeStep upgradeStep =
-			_configurationUpgradeStepFactory.createUpgradeStep(
-				_OLD_PID, _NEW_PID);
+			UpgradeStep upgradeStep =
+				_configurationUpgradeStepFactory.createUpgradeStep(
+					_OLD_PID, _NEW_PID);
 
-		upgradeStep.upgrade(_DB_PROCESS_CONTEXT);
+			upgradeStep.upgrade(_DB_PROCESS_CONTEXT);
 
-		Assert.assertFalse(_persistenceManager.exists(_OLD_PID));
-		Assert.assertTrue(_persistenceManager.exists(_NEW_PID));
+			Assert.assertFalse(_persistenceManager.exists(_OLD_PID));
+			Assert.assertTrue(_persistenceManager.exists(_NEW_PID));
+		}
+		finally {
+			_persistenceManager.delete(_OLD_PID);
+			_persistenceManager.delete(_NEW_PID);
 
-		_persistenceManager.delete(_NEW_PID);
-
-		ConfigurationTestUtil.deleteConfiguration(configuration);
+			ConfigurationTestUtil.deleteConfiguration(configuration);
+		}
 	}
 
 	@Test
@@ -85,43 +89,47 @@ public class ConfigurationUpgradeStepFactoryTest {
 
 		String oldPid = configuration.getPid();
 
-		int index = oldPid.lastIndexOf('.');
-
-		StringBundler sb = new StringBundler(4);
-
-		sb.append(configuration.getFactoryPid());
-		sb.append(StringPool.DASH);
-		sb.append(oldPid.substring(index + 1));
-		sb.append(".config");
-
-		File file = new File(
-			PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR, sb.toString());
-
-		file = file.getAbsoluteFile();
-
-		URI uri = file.toURI();
-
-		ConfigurationTestUtil.saveConfiguration(
-			configuration,
-			MapUtil.singletonDictionary(
-				"felix.fileinstall.filename", uri.toString()));
-
-		Assert.assertTrue(_persistenceManager.exists(oldPid));
-
-		UpgradeStep upgradeStep =
-			_configurationUpgradeStepFactory.createUpgradeStep(
-				_OLD_PID, _NEW_PID);
-
-		upgradeStep.upgrade(_DB_PROCESS_CONTEXT);
-
 		String newPid = StringUtil.replace(oldPid, _OLD_PID, _NEW_PID);
 
-		Assert.assertFalse(_persistenceManager.exists(oldPid));
-		Assert.assertTrue(_persistenceManager.exists(newPid));
+		try {
+			int index = oldPid.lastIndexOf('.');
 
-		_persistenceManager.delete(newPid);
+			StringBundler sb = new StringBundler(4);
 
-		ConfigurationTestUtil.deleteConfiguration(configuration);
+			sb.append(configuration.getFactoryPid());
+			sb.append(StringPool.DASH);
+			sb.append(oldPid.substring(index + 1));
+			sb.append(".config");
+
+			File file = new File(
+				PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR, sb.toString());
+
+			file = file.getAbsoluteFile();
+
+			URI uri = file.toURI();
+
+			ConfigurationTestUtil.saveConfiguration(
+				configuration,
+				MapUtil.singletonDictionary(
+					"felix.fileinstall.filename", uri.toString()));
+
+			Assert.assertTrue(_persistenceManager.exists(oldPid));
+
+			UpgradeStep upgradeStep =
+				_configurationUpgradeStepFactory.createUpgradeStep(
+					_OLD_PID, _NEW_PID);
+
+			upgradeStep.upgrade(_DB_PROCESS_CONTEXT);
+
+			Assert.assertFalse(_persistenceManager.exists(oldPid));
+			Assert.assertTrue(_persistenceManager.exists(newPid));
+		}
+		finally {
+			_persistenceManager.delete(oldPid);
+			_persistenceManager.delete(newPid);
+
+			ConfigurationTestUtil.deleteConfiguration(configuration);
+		}
 	}
 
 	private static final DBProcessContext _DB_PROCESS_CONTEXT =

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/ConfigurationUpgradeStepFactoryTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/ConfigurationUpgradeStepFactoryTest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.persistence.upgrade.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.persistence.upgrade.ConfigurationUpgradeStepFactory;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.dao.db.DBContext;
+import com.liferay.portal.kernel.dao.db.DBProcessContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+
+import java.io.File;
+import java.io.OutputStream;
+
+import java.net.URI;
+
+import org.apache.felix.cm.PersistenceManager;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Hai Yu
+ */
+@RunWith(Arquillian.class)
+public class ConfigurationUpgradeStepFactoryTest {
+
+	@ClassRule
+	@Rule
+	public static AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testCreateUpgradeStep() throws Exception {
+		String oldPid = "test.old.pid";
+		String newPid = "test.new.pid";
+
+		Configuration configuration = _configurationAdmin.getConfiguration(
+			oldPid);
+
+		Assert.assertTrue(_persistenceManager.exists(oldPid));
+
+		UpgradeStep upgradeStep =
+			_configurationUpgradeStepFactory.createUpgradeStep(oldPid, newPid);
+
+		upgradeStep.upgrade(
+			new DBProcessContext() {
+
+				@Override
+				public DBContext getDBContext() {
+					return new DBContext();
+				}
+
+				@Override
+				public OutputStream getOutputStream() {
+					return null;
+				}
+
+			});
+
+		Assert.assertFalse(_persistenceManager.exists(oldPid));
+		Assert.assertTrue(_persistenceManager.exists(newPid));
+
+		_persistenceManager.delete(newPid);
+
+		ConfigurationTestUtil.deleteConfiguration(configuration);
+	}
+
+	@Test
+	public void testCreateUpgradeStepWithFactory() throws Exception {
+		Configuration configuration =
+			_configurationAdmin.createFactoryConfiguration(
+				"test.old.pid", StringPool.QUESTION);
+
+		String oldPid = configuration.getPid();
+
+		int index = oldPid.lastIndexOf('.');
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(configuration.getFactoryPid());
+		sb.append(StringPool.DASH);
+		sb.append(oldPid.substring(index + 1));
+		sb.append(".config");
+
+		File file = new File(
+			PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR, sb.toString());
+
+		file = file.getAbsoluteFile();
+
+		URI uri = file.toURI();
+
+		ConfigurationTestUtil.saveConfiguration(
+			configuration,
+			MapUtil.singletonDictionary(
+				"felix.fileinstall.filename", uri.toString()));
+
+		Assert.assertTrue(_persistenceManager.exists(oldPid));
+
+		UpgradeStep upgradeStep =
+			_configurationUpgradeStepFactory.createUpgradeStep(
+				"test.old.pid", "test.new.pid");
+
+		upgradeStep.upgrade(
+			new DBProcessContext() {
+
+				@Override
+				public DBContext getDBContext() {
+					return new DBContext();
+				}
+
+				@Override
+				public OutputStream getOutputStream() {
+					return null;
+				}
+
+			});
+
+		String newPid = StringUtil.replace(
+			oldPid, "test.old.pid", "test.new.pid");
+
+		Assert.assertFalse(_persistenceManager.exists(oldPid));
+		Assert.assertTrue(_persistenceManager.exists(newPid));
+
+		_persistenceManager.delete(newPid);
+
+		ConfigurationTestUtil.deleteConfiguration(configuration);
+	}
+
+	@Inject
+	private ConfigurationAdmin _configurationAdmin;
+
+	@Inject
+	private ConfigurationUpgradeStepFactory _configurationUpgradeStepFactory;
+
+	@Inject
+	private PersistenceManager _persistenceManager;
+
+}

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/ConfigurationUpgradeStepFactoryTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/upgrade/test/ConfigurationUpgradeStepFactoryTest.java
@@ -92,17 +92,11 @@ public class ConfigurationUpgradeStepFactoryTest {
 		String newPid = StringUtil.replace(oldPid, _OLD_PID, _NEW_PID);
 
 		try {
-			int index = oldPid.lastIndexOf('.');
-
-			StringBundler sb = new StringBundler(4);
-
-			sb.append(configuration.getFactoryPid());
-			sb.append(StringPool.DASH);
-			sb.append(oldPid.substring(index + 1));
-			sb.append(".config");
-
 			File file = new File(
-				PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR, sb.toString());
+				PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR,
+				StringBundler.concat(
+					configuration.getFactoryPid(), StringPool.DASH,
+					oldPid.substring(oldPid.lastIndexOf('.') + 1), ".config"));
 
 			file = file.getAbsoluteFile();
 


### PR DESCRIPTION
@dantewang, the pr is based on https://github.com/tinatian/liferay-portal/pull/1685. Besides that, I do some change on the key "felix.fileinstall.filename". We allow that the name of file is different from service.pid. When we create one config file in \osgi\configs\, for example, 
The file:
com.liferay.configuration.test.configuration.ConfigurationTestConfiguration-hai.config
it will create one data in Configuraton_ table as the following:

> :org.apache.felix.configadmin.revision:=L"1"
> felix.fileinstall.filename="com.liferay.configuration.test.configuration.ConfigurationTestConfiguration-hai.config"
> name="testhai"
> service.bundleLocation="?"
> service.factoryPid="com.liferay.configuration.test.configuration.ConfigurationTestConfiguration"
> service.pid="com.liferay.configuration.test.configuration.ConfigurationTestConfiguration.f7d49298-4027-4ea7-b8d8-ab88c5c83c0c"


