### PR TITLE
LPS-X Update the classpath for SampleSQLBuilder to generate data for DB2

### DIFF
--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -67,6 +67,11 @@
 				dir="${sdk.dir}/dist"
 				includes="com.liferay.wiki.*.jar"
 			/>
+			
+			<fileset
+				dir="${sdk.dir}/dist"
+				includes="com.liferay.portal.dao.db*.jar"
+			/>
 			<path refid="project.classpath" />
 		</path>
 


### PR DESCRIPTION
Apply this pull, run "ant setup-profile-dxp" before "ant all" and then we can invoke SampleSQLBuilder to generate data for DB2