### PR TITLE
Lps 119985 11 25 1

### DIFF
--- a/benchmarks/benchmarks.properties
+++ b/benchmarks/benchmarks.properties
@@ -25,6 +25,11 @@
     #sample.sql.db.type=postgresql
     #sample.sql.db.type=sqlserver
     #sample.sql.db.type=sybase
+    
+    #
+    # Specify the number of data type contained in AssetPublisher.
+    #
+    sample.sql.max.asset.entry.data.type.count=3
 
     #
     # Specify the number of asset categories to generate per asset vocabulary.

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsKeys.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsKeys.java
@@ -24,6 +24,9 @@ public interface BenchmarksPropsKeys {
 	public static final String MAX_ASSET_CATEGORY_COUNT =
 		"sample.sql.max.asset.category.count";
 
+	public static final String MAX_ASSET_ENTRY_DATA_TYPE_COUNT =
+		"sample.sql.max.asset.entry.data.type.count";
+
 	public static final String MAX_ASSET_ENTRY_TO_ASSET_CATEGORY_COUNT =
 		"sample.sql.max.asset.entry.to.asset.category.count";
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
@@ -46,6 +46,11 @@ public class BenchmarksPropsValues {
 	public static final int MAX_ASSET_CATEGORY_COUNT = GetterUtil.getInteger(
 		PropertiesHolder._get(BenchmarksPropsKeys.MAX_ASSET_CATEGORY_COUNT));
 
+	public static final int MAX_ASSET_ENTRY_DATA_TYPE_COUNT =
+		GetterUtil.getInteger(
+			PropertiesHolder._get(
+				BenchmarksPropsKeys.MAX_ASSET_ENTRY_DATA_TYPE_COUNT));
+
 	public static final int MAX_ASSET_ENTRY_TO_ASSET_CATEGORY_COUNT =
 		GetterUtil.getInteger(
 			PropertiesHolder._get(

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -484,20 +484,6 @@ public class DataFactory {
 		return allAssetTagModels;
 	}
 
-	public List<AssetVocabularyModel> getAssetVocabularyModels() {
-		List<AssetVocabularyModel> allAssetVocabularyModels = new ArrayList<>();
-
-		allAssetVocabularyModels.add(_defaultAssetVocabularyModel);
-
-		for (List<AssetVocabularyModel> assetVocabularyModels :
-				_assetVocabularyModelsArray) {
-
-			allAssetVocabularyModels.addAll(assetVocabularyModels);
-		}
-
-		return allAssetVocabularyModels;
-	}
-
 	public long getBlogsEntryClassNameId() {
 		return getClassNameId(BlogsEntry.class);
 	}
@@ -671,9 +657,6 @@ public class DataFactory {
 		_assetVocabularyModelsArray =
 			(List<AssetVocabularyModel>[])
 				new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-		_defaultAssetVocabularyModel = newAssetVocabularyModel(
-			_globalGroupId, _defaultUserId, null,
-			PropsValues.ASSET_VOCABULARY_DEFAULT);
 
 		StringBundler sb = new StringBundler(4);
 
@@ -1060,6 +1043,22 @@ public class DataFactory {
 				PortletConstants.DEFAULT_PREFERENCES));
 
 		return portletPreferencesModels;
+	}
+
+	public List<AssetVocabularyModel> newAssetVocabularyModels(
+		AssetVocabularyModel defaultAssetVocabularyModel) {
+
+		List<AssetVocabularyModel> allAssetVocabularyModels = new ArrayList<>();
+
+		allAssetVocabularyModels.add(defaultAssetVocabularyModel);
+
+		for (List<AssetVocabularyModel> assetVocabularyModels :
+				_assetVocabularyModelsArray) {
+
+			allAssetVocabularyModels.addAll(assetVocabularyModels);
+		}
+
+		return allAssetVocabularyModels;
 	}
 
 	public List<BlogsEntryModel> newBlogsEntryModels(long groupId) {
@@ -2044,6 +2043,12 @@ public class DataFactory {
 		ddmTemplateLinkModel.setTemplateId(templateId);
 
 		return ddmTemplateLinkModel;
+	}
+
+	public AssetVocabularyModel newDefaultAssetVocabularyModel() {
+		return newAssetVocabularyModel(
+			_globalGroupId, _defaultUserId, null,
+			PropsValues.ASSET_VOCABULARY_DEFAULT);
 	}
 
 	public DDMStructureLayoutModel newDefaultDLDDMStructureLayoutModel() {
@@ -5033,7 +5038,6 @@ public class DataFactory {
 	private final SimpleCounter _counter;
 	private final PortletPreferencesImpl
 		_defaultAssetPublisherPortletPreferencesImpl;
-	private AssetVocabularyModel _defaultAssetVocabularyModel;
 	private final long _defaultDLDDMStructureId;
 	private final long _defaultDLDDMStructureVersionId;
 	private long _defaultDLFileEntryTypeId =

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -768,23 +768,19 @@ public class DataFactory {
 		return accountModel;
 	}
 
-	public List<AssetCategoryModel> newAssetCategoryModels(long groupId) {
+	public List<AssetCategoryModel> newAssetCategoryModels(
+		long groupId, List<AssetVocabularyModel> assetVocabularyModels) {
+
 		List<AssetCategoryModel> assetCategoryModels = new ArrayList<>();
 
 		StringBundler sb = new StringBundler(4);
-
-		List<AssetVocabularyModel> assetVocabularyModels =
-			_assetVocabularyModelsArray[(int)groupId - 1];
 
 		List<AssetCategoryModel> groupAssetCategoryModels = new ArrayList<>(
 			BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT *
 				BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT);
 
-		for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT;
-			 j++) {
-
-			AssetVocabularyModel assetVocabularyModel =
-				assetVocabularyModels.get(j);
+		for (AssetVocabularyModel assetVocabularyModel :
+				assetVocabularyModels) {
 
 			for (int k = 0; k < BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT;
 				 k++) {
@@ -995,9 +991,6 @@ public class DataFactory {
 
 		StringBundler sb = new StringBundler(4);
 
-		List<AssetVocabularyModel> groupAssetVocabularyModels = new ArrayList<>(
-			BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT);
-
 		for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT;
 			 j++) {
 
@@ -1011,13 +1004,8 @@ public class DataFactory {
 			AssetVocabularyModel assetVocabularyModel = newAssetVocabularyModel(
 				groupId, _sampleUserId, _SAMPLE_USER_NAME, sb.toString());
 
-			groupAssetVocabularyModels.add(assetVocabularyModel);
-
 			assetVocabularyModels.add(assetVocabularyModel);
 		}
-
-		_assetVocabularyModelsArray[(int)groupId - 1] =
-			groupAssetVocabularyModels;
 
 		return assetVocabularyModels;
 	}
@@ -4995,9 +4983,6 @@ public class DataFactory {
 	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps =
 		(Map<Long, List<AssetTagModel>>[])
 			new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-	private List<AssetVocabularyModel>[] _assetVocabularyModelsArray =
-		(List<AssetVocabularyModel>[])
-			new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();
 	private final long _companyId;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -357,8 +357,6 @@ public class DataFactory {
 		_assetCategoryModelsMaps = newAssetCategoryModelsMaps(
 			_assetVocabularyModelsArray);
 
-		_assetTagModelsMaps = newAssetTagModelsMaps();
-
 		initJournalArticleContent();
 
 		initRoleModels();
@@ -969,26 +967,12 @@ public class DataFactory {
 	public List<AssetTagModel> newAssetTagModels() {
 		List<AssetTagModel> allAssetTagModels = new ArrayList<>();
 
-		for (Map<Long, List<AssetTagModel>> assetTagModelsMap :
-				_assetTagModelsMaps) {
-
-			for (List<AssetTagModel> assetTagModels :
-					assetTagModelsMap.values()) {
-
-				allAssetTagModels.addAll(assetTagModels);
-			}
-		}
-
-		return allAssetTagModels;
-	}
-
-	public Map<Long, List<AssetTagModel>>[] newAssetTagModelsMaps() {
-		Map<Long, List<AssetTagModel>>[] assetTagModelsMaps =
+		_assetTagModelsMaps =
 			(Map<Long, List<AssetTagModel>>[])
 				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
 
 		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
-			List<AssetTagModel> assetTagModels = new ArrayList<>(
+			List<AssetTagModel> groupAssetTagModels = new ArrayList<>(
 				BenchmarksPropsValues.MAX_ASSET_TAG_COUNT);
 
 			for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_TAG_COUNT;
@@ -1008,12 +992,15 @@ public class DataFactory {
 					StringBundler.concat("TestTag_", i, "_", j));
 				assetTagModel.setLastPublishDate(new Date());
 
-				assetTagModels.add(assetTagModel);
+				groupAssetTagModels.add(assetTagModel);
+
+				allAssetTagModels.add(assetTagModel);
 			}
 
 			Map<Long, List<AssetTagModel>> assetTagModelsMap = new HashMap<>();
 
-			int pageSize = assetTagModels.size() / _assetClassNameIds.length;
+			int pageSize =
+				groupAssetTagModels.size() / _assetClassNameIds.length;
 
 			for (int j = 0; j < _assetClassNameIds.length; j++) {
 				int fromIndex = j * pageSize;
@@ -1021,18 +1008,18 @@ public class DataFactory {
 				int toIndex = (j + 1) * pageSize;
 
 				if (j == (_assetClassNameIds.length - 1)) {
-					toIndex = assetTagModels.size();
+					toIndex = groupAssetTagModels.size();
 				}
 
 				assetTagModelsMap.put(
 					_assetClassNameIds[j],
-					assetTagModels.subList(fromIndex, toIndex));
+					groupAssetTagModels.subList(fromIndex, toIndex));
 			}
 
-			assetTagModelsMaps[i - 1] = assetTagModelsMap;
+			_assetTagModelsMaps[i - 1] = assetTagModelsMap;
 		}
 
-		return assetTagModelsMaps;
+		return allAssetTagModels;
 	}
 
 	public List<AssetVocabularyModel> newAssetVocabularyModels(
@@ -5054,7 +5041,7 @@ public class DataFactory {
 	private final Map<Long, Integer> _assetPublisherQueryStartIndexes =
 		new HashMap<>();
 	private Map<Long, SimpleCounter>[] _assetTagCounters;
-	private final Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
+	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
 	private final List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -769,7 +769,7 @@ public class DataFactory {
 	}
 
 	public List<AssetCategoryModel> newAssetCategoryModels(long groupId) {
-		List<AssetCategoryModel> allAssetCategoryModels = new ArrayList<>();
+		List<AssetCategoryModel> assetCategoryModels = new ArrayList<>();
 
 		StringBundler sb = new StringBundler(4);
 
@@ -802,7 +802,7 @@ public class DataFactory {
 
 				groupAssetCategoryModels.add(assetCategoryModel);
 
-				allAssetCategoryModels.add(assetCategoryModel);
+				assetCategoryModels.add(assetCategoryModel);
 			}
 		}
 
@@ -828,7 +828,7 @@ public class DataFactory {
 
 		_assetCategoryModelsMaps[(int)groupId - 1] = assetCategoryModelsMap;
 
-		return allAssetCategoryModels;
+		return assetCategoryModels;
 	}
 
 	public AssetEntryModel newAssetEntryModel(BlogsEntryModel blogsEntryModel) {
@@ -942,7 +942,7 @@ public class DataFactory {
 	}
 
 	public List<AssetTagModel> newAssetTagModels(long groupId) {
-		List<AssetTagModel> allAssetTagModels = new ArrayList<>();
+		List<AssetTagModel> assetTagModels = new ArrayList<>();
 
 		List<AssetTagModel> groupAssetTagModels = new ArrayList<>(
 			BenchmarksPropsValues.MAX_ASSET_TAG_COUNT);
@@ -964,7 +964,7 @@ public class DataFactory {
 
 			groupAssetTagModels.add(assetTagModel);
 
-			allAssetTagModels.add(assetTagModel);
+			assetTagModels.add(assetTagModel);
 		}
 
 		Map<Long, List<AssetTagModel>> assetTagModelsMap = new HashMap<>();
@@ -987,11 +987,11 @@ public class DataFactory {
 
 		_assetTagModelsMaps[(int)groupId - 1] = assetTagModelsMap;
 
-		return allAssetTagModels;
+		return assetTagModels;
 	}
 
 	public List<AssetVocabularyModel> newAssetVocabularyModels(long groupId) {
-		List<AssetVocabularyModel> allAssetVocabularyModels = new ArrayList<>();
+		List<AssetVocabularyModel> assetVocabularyModels = new ArrayList<>();
 
 		StringBundler sb = new StringBundler(4);
 
@@ -1013,13 +1013,13 @@ public class DataFactory {
 
 			groupAssetVocabularyModels.add(assetVocabularyModel);
 
-			allAssetVocabularyModels.add(assetVocabularyModel);
+			assetVocabularyModels.add(assetVocabularyModel);
 		}
 
 		_assetVocabularyModelsArray[(int)groupId - 1] =
 			groupAssetVocabularyModels;
 
-		return allAssetVocabularyModels;
+		return assetVocabularyModels;
 	}
 
 	public List<BlogsEntryModel> newBlogsEntryModels(long groupId) {

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -352,8 +352,12 @@ public class DataFactory {
 			(PortletPreferencesImpl)_portletPreferencesFactory.fromDefaultXML(
 				_readFile("default_asset_publisher_preference.xml"));
 
-		initAssetCategoryModels();
 		initAssetTagModels();
+
+		_assetVocabularyModelsArray = newAssetVocabularyModelsArray();
+
+		_assetCategoryModelsMaps = newAssetCategoryModelsMaps(
+			_assetVocabularyModelsArray);
 
 		initJournalArticleContent();
 
@@ -408,22 +412,6 @@ public class DataFactory {
 		}
 
 		return assetCategoryIds;
-	}
-
-	public List<AssetCategoryModel> getAssetCategoryModels() {
-		List<AssetCategoryModel> allAssetCategoryModels = new ArrayList<>();
-
-		for (Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap :
-				_assetCategoryModelsMaps) {
-
-			for (List<AssetCategoryModel> assetCategoryModels :
-					assetCategoryModelsMap.values()) {
-
-				allAssetCategoryModels.addAll(assetCategoryModels);
-			}
-		}
-
-		return allAssetCategoryModels;
 	}
 
 	public List<Long> getAssetTagIds(AssetEntryModel assetEntryModel) {
@@ -650,82 +638,6 @@ public class DataFactory {
 		return getClassNameId(WikiPage.class);
 	}
 
-	public void initAssetCategoryModels() {
-		_assetCategoryModelsMaps =
-			(Map<Long, List<AssetCategoryModel>>[])
-				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-		_assetVocabularyModelsArray =
-			(List<AssetVocabularyModel>[])
-				new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-
-		StringBundler sb = new StringBundler(4);
-
-		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
-			List<AssetVocabularyModel> assetVocabularyModels = new ArrayList<>(
-				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT);
-			List<AssetCategoryModel> assetCategoryModels = new ArrayList<>(
-				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT *
-					BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT);
-
-			for (int j = 0;
-				 j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT; j++) {
-
-				sb.setIndex(0);
-
-				sb.append("TestVocabulary_");
-				sb.append(i);
-				sb.append(StringPool.UNDERLINE);
-				sb.append(j);
-
-				AssetVocabularyModel assetVocabularyModel =
-					newAssetVocabularyModel(
-						i, _sampleUserId, _SAMPLE_USER_NAME, sb.toString());
-
-				assetVocabularyModels.add(assetVocabularyModel);
-
-				for (int k = 0;
-					 k < BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT; k++) {
-
-					sb.setIndex(0);
-
-					sb.append("TestCategory_");
-					sb.append(assetVocabularyModel.getVocabularyId());
-					sb.append(StringPool.UNDERLINE);
-					sb.append(k);
-
-					assetCategoryModels.add(
-						newAssetCategoryModel(
-							i, sb.toString(),
-							assetVocabularyModel.getVocabularyId()));
-				}
-			}
-
-			_assetVocabularyModelsArray[i - 1] = assetVocabularyModels;
-
-			Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap =
-				new HashMap<>();
-
-			int pageSize =
-				assetCategoryModels.size() / _assetClassNameIds.length;
-
-			for (int j = 0; j < _assetClassNameIds.length; j++) {
-				int fromIndex = j * pageSize;
-
-				int toIndex = (j + 1) * pageSize;
-
-				if (j == (_assetClassNameIds.length - 1)) {
-					toIndex = assetCategoryModels.size();
-				}
-
-				assetCategoryModelsMap.put(
-					_assetClassNameIds[j],
-					assetCategoryModels.subList(fromIndex, toIndex));
-			}
-
-			_assetCategoryModelsMaps[i - 1] = assetCategoryModelsMap;
-		}
-	}
-
 	public void initAssetTagModels() {
 		_assetTagModelsArray =
 			(List<AssetTagModel>[])
@@ -935,6 +847,87 @@ public class DataFactory {
 		return accountModel;
 	}
 
+	public List<AssetCategoryModel> newAssetCategoryModels() {
+		List<AssetCategoryModel> allAssetCategoryModels = new ArrayList<>();
+
+		for (Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap :
+				_assetCategoryModelsMaps) {
+
+			for (List<AssetCategoryModel> assetCategoryModels :
+					assetCategoryModelsMap.values()) {
+
+				allAssetCategoryModels.addAll(assetCategoryModels);
+			}
+		}
+
+		return allAssetCategoryModels;
+	}
+
+	public Map<Long, List<AssetCategoryModel>>[] newAssetCategoryModelsMaps(
+		List<AssetVocabularyModel>[] assetVocabularyModelsArray) {
+
+		Map<Long, List<AssetCategoryModel>>[] assetCategoryModelsMaps =
+			(Map<Long, List<AssetCategoryModel>>[])
+				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
+
+		StringBundler sb = new StringBundler(4);
+
+		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
+			List<AssetVocabularyModel> assetVocabularyModels =
+				assetVocabularyModelsArray[i - 1];
+			List<AssetCategoryModel> assetCategoryModels = new ArrayList<>(
+				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT *
+					BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT);
+
+			for (int j = 0;
+				 j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT; j++) {
+
+				AssetVocabularyModel assetVocabularyModel =
+					assetVocabularyModels.get(j);
+
+				for (int k = 0;
+					 k < BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT; k++) {
+
+					sb.setIndex(0);
+
+					sb.append("TestCategory_");
+					sb.append(assetVocabularyModel.getVocabularyId());
+					sb.append(StringPool.UNDERLINE);
+					sb.append(k);
+
+					assetCategoryModels.add(
+						newAssetCategoryModel(
+							i, sb.toString(),
+							assetVocabularyModel.getVocabularyId()));
+				}
+			}
+
+			Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap =
+				new HashMap<>();
+
+			int pageSize =
+				assetCategoryModels.size() / _assetClassNameIds.length;
+
+			for (int j = 0; j < _assetClassNameIds.length; j++) {
+				int fromIndex = j * pageSize;
+
+				int toIndex = (j + 1) * pageSize;
+
+				if (j == (_assetClassNameIds.length - 1)) {
+					toIndex = assetCategoryModels.size();
+				}
+
+				assetCategoryModelsMap.put(
+					_assetClassNameIds[j],
+					assetCategoryModels.subList(fromIndex, toIndex));
+			}
+
+			assetCategoryModelsMaps[i - 1] = assetCategoryModelsMap;
+		}
+
+		return assetCategoryModelsMaps;
+	}
+
 	public AssetEntryModel newAssetEntryModel(BlogsEntryModel blogsEntryModel) {
 		return newAssetEntryModel(
 			blogsEntryModel.getGroupId(), blogsEntryModel.getCreateDate(),
@@ -1059,6 +1052,40 @@ public class DataFactory {
 		}
 
 		return allAssetVocabularyModels;
+	}
+
+	public List<AssetVocabularyModel>[] newAssetVocabularyModelsArray() {
+		List<AssetVocabularyModel>[] assetVocabularyModelsArray =
+			(List<AssetVocabularyModel>[])
+				new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
+
+		StringBundler sb = new StringBundler(4);
+
+		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
+			List<AssetVocabularyModel> assetVocabularyModels = new ArrayList<>(
+				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT);
+
+			for (int j = 0;
+				 j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT; j++) {
+
+				sb.setIndex(0);
+
+				sb.append("TestVocabulary_");
+				sb.append(i);
+				sb.append(StringPool.UNDERLINE);
+				sb.append(j);
+
+				AssetVocabularyModel assetVocabularyModel =
+					newAssetVocabularyModel(
+						i, _sampleUserId, _SAMPLE_USER_NAME, sb.toString());
+
+				assetVocabularyModels.add(assetVocabularyModel);
+			}
+
+			assetVocabularyModelsArray[i - 1] = assetVocabularyModels;
+		}
+
+		return assetVocabularyModelsArray;
 	}
 
 	public List<BlogsEntryModel> newBlogsEntryModels(long groupId) {
@@ -5022,7 +5049,8 @@ public class DataFactory {
 	private final long _accountId;
 	private RoleModel _administratorRoleModel;
 	private Map<Long, SimpleCounter>[] _assetCategoryCounters;
-	private Map<Long, List<AssetCategoryModel>>[] _assetCategoryModelsMaps;
+	private final Map<Long, List<AssetCategoryModel>>[]
+		_assetCategoryModelsMaps;
 	private final long[] _assetClassNameIds;
 	private final Map<Long, Integer> _assetClassNameIdsIndexes =
 		new HashMap<>();
@@ -5031,7 +5059,7 @@ public class DataFactory {
 	private Map<Long, SimpleCounter>[] _assetTagCounters;
 	private List<AssetTagModel>[] _assetTagModelsArray;
 	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
-	private List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
+	private final List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();
 	private final long _companyId;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -352,8 +352,6 @@ public class DataFactory {
 			(PortletPreferencesImpl)_portletPreferencesFactory.fromDefaultXML(
 				_readFile("default_asset_publisher_preference.xml"));
 
-		_assetVocabularyModelsArray = newAssetVocabularyModelsArray();
-
 		initJournalArticleContent();
 
 		initRoleModels();
@@ -1014,25 +1012,16 @@ public class DataFactory {
 
 		allAssetVocabularyModels.add(defaultAssetVocabularyModel);
 
-		for (List<AssetVocabularyModel> assetVocabularyModels :
-				_assetVocabularyModelsArray) {
-
-			allAssetVocabularyModels.addAll(assetVocabularyModels);
-		}
-
-		return allAssetVocabularyModels;
-	}
-
-	public List<AssetVocabularyModel>[] newAssetVocabularyModelsArray() {
-		List<AssetVocabularyModel>[] assetVocabularyModelsArray =
+		_assetVocabularyModelsArray =
 			(List<AssetVocabularyModel>[])
 				new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
 
 		StringBundler sb = new StringBundler(4);
 
 		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
-			List<AssetVocabularyModel> assetVocabularyModels = new ArrayList<>(
-				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT);
+			List<AssetVocabularyModel> groupAssetVocabularyModels =
+				new ArrayList<>(
+					BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT);
 
 			for (int j = 0;
 				 j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT; j++) {
@@ -1048,13 +1037,15 @@ public class DataFactory {
 					newAssetVocabularyModel(
 						i, _sampleUserId, _SAMPLE_USER_NAME, sb.toString());
 
-				assetVocabularyModels.add(assetVocabularyModel);
+				groupAssetVocabularyModels.add(assetVocabularyModel);
+
+				allAssetVocabularyModels.add(assetVocabularyModel);
 			}
 
-			assetVocabularyModelsArray[i - 1] = assetVocabularyModels;
+			_assetVocabularyModelsArray[i - 1] = groupAssetVocabularyModels;
 		}
 
-		return assetVocabularyModelsArray;
+		return allAssetVocabularyModels;
 	}
 
 	public List<BlogsEntryModel> newBlogsEntryModels(long groupId) {
@@ -5026,7 +5017,7 @@ public class DataFactory {
 		new HashMap<>();
 	private Map<Long, SimpleCounter>[] _assetTagCounters;
 	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
-	private final List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
+	private List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();
 	private final long _companyId;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -354,9 +354,6 @@ public class DataFactory {
 
 		_assetVocabularyModelsArray = newAssetVocabularyModelsArray();
 
-		_assetCategoryModelsMaps = newAssetCategoryModelsMaps(
-			_assetVocabularyModelsArray);
-
 		initJournalArticleContent();
 
 		initRoleModels();
@@ -776,23 +773,7 @@ public class DataFactory {
 	public List<AssetCategoryModel> newAssetCategoryModels() {
 		List<AssetCategoryModel> allAssetCategoryModels = new ArrayList<>();
 
-		for (Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap :
-				_assetCategoryModelsMaps) {
-
-			for (List<AssetCategoryModel> assetCategoryModels :
-					assetCategoryModelsMap.values()) {
-
-				allAssetCategoryModels.addAll(assetCategoryModels);
-			}
-		}
-
-		return allAssetCategoryModels;
-	}
-
-	public Map<Long, List<AssetCategoryModel>>[] newAssetCategoryModelsMaps(
-		List<AssetVocabularyModel>[] assetVocabularyModelsArray) {
-
-		Map<Long, List<AssetCategoryModel>>[] assetCategoryModelsMaps =
+		_assetCategoryModelsMaps =
 			(Map<Long, List<AssetCategoryModel>>[])
 				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
 
@@ -800,8 +781,8 @@ public class DataFactory {
 
 		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
 			List<AssetVocabularyModel> assetVocabularyModels =
-				assetVocabularyModelsArray[i - 1];
-			List<AssetCategoryModel> assetCategoryModels = new ArrayList<>(
+				_assetVocabularyModelsArray[i - 1];
+			List<AssetCategoryModel> groupAssetCategoryModels = new ArrayList<>(
 				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT *
 					BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT);
 
@@ -821,10 +802,14 @@ public class DataFactory {
 					sb.append(StringPool.UNDERLINE);
 					sb.append(k);
 
-					assetCategoryModels.add(
+					AssetCategoryModel assetCategoryModel =
 						newAssetCategoryModel(
 							i, sb.toString(),
-							assetVocabularyModel.getVocabularyId()));
+							assetVocabularyModel.getVocabularyId());
+
+					groupAssetCategoryModels.add(assetCategoryModel);
+
+					allAssetCategoryModels.add(assetCategoryModel);
 				}
 			}
 
@@ -832,7 +817,7 @@ public class DataFactory {
 				new HashMap<>();
 
 			int pageSize =
-				assetCategoryModels.size() / _assetClassNameIds.length;
+				groupAssetCategoryModels.size() / _assetClassNameIds.length;
 
 			for (int j = 0; j < _assetClassNameIds.length; j++) {
 				int fromIndex = j * pageSize;
@@ -840,18 +825,18 @@ public class DataFactory {
 				int toIndex = (j + 1) * pageSize;
 
 				if (j == (_assetClassNameIds.length - 1)) {
-					toIndex = assetCategoryModels.size();
+					toIndex = groupAssetCategoryModels.size();
 				}
 
 				assetCategoryModelsMap.put(
 					_assetClassNameIds[j],
-					assetCategoryModels.subList(fromIndex, toIndex));
+					groupAssetCategoryModels.subList(fromIndex, toIndex));
 			}
 
-			assetCategoryModelsMaps[i - 1] = assetCategoryModelsMap;
+			_assetCategoryModelsMaps[i - 1] = assetCategoryModelsMap;
 		}
 
-		return assetCategoryModelsMaps;
+		return allAssetCategoryModels;
 	}
 
 	public AssetEntryModel newAssetEntryModel(BlogsEntryModel blogsEntryModel) {
@@ -5033,8 +5018,7 @@ public class DataFactory {
 	private final long _accountId;
 	private RoleModel _administratorRoleModel;
 	private Map<Long, SimpleCounter>[] _assetCategoryCounters;
-	private final Map<Long, List<AssetCategoryModel>>[]
-		_assetCategoryModelsMaps;
+	private Map<Long, List<AssetCategoryModel>>[] _assetCategoryModelsMaps;
 	private final long[] _assetClassNameIds;
 	private final Map<Long, Integer> _assetClassNameIdsIndexes =
 		new HashMap<>();

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -352,12 +352,12 @@ public class DataFactory {
 			(PortletPreferencesImpl)_portletPreferencesFactory.fromDefaultXML(
 				_readFile("default_asset_publisher_preference.xml"));
 
-		initAssetTagModels();
-
 		_assetVocabularyModelsArray = newAssetVocabularyModelsArray();
 
 		_assetCategoryModelsMaps = newAssetCategoryModelsMaps(
 			_assetVocabularyModelsArray);
+
+		_assetTagModelsMaps = newAssetTagModelsMaps();
 
 		initJournalArticleContent();
 
@@ -454,22 +454,6 @@ public class DataFactory {
 		}
 
 		return assetTagIds;
-	}
-
-	public List<AssetTagModel> getAssetTagModels() {
-		List<AssetTagModel> allAssetTagModels = new ArrayList<>();
-
-		for (Map<Long, List<AssetTagModel>> assetTagModelsMap :
-				_assetTagModelsMaps) {
-
-			for (List<AssetTagModel> assetTagModels :
-					assetTagModelsMap.values()) {
-
-				allAssetTagModels.addAll(assetTagModels);
-			}
-		}
-
-		return allAssetTagModels;
 	}
 
 	public long getBlogsEntryClassNameId() {
@@ -636,62 +620,6 @@ public class DataFactory {
 
 	public long getWikiPageClassNameId() {
 		return getClassNameId(WikiPage.class);
-	}
-
-	public void initAssetTagModels() {
-		_assetTagModelsArray =
-			(List<AssetTagModel>[])
-				new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-		_assetTagModelsMaps =
-			(Map<Long, List<AssetTagModel>>[])
-				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-
-		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
-			List<AssetTagModel> assetTagModels = new ArrayList<>(
-				BenchmarksPropsValues.MAX_ASSET_TAG_COUNT);
-
-			for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_TAG_COUNT;
-				 j++) {
-
-				AssetTagModel assetTagModel = new AssetTagModelImpl();
-
-				assetTagModel.setUuid(SequentialUUID.generate());
-				assetTagModel.setTagId(_counter.get());
-				assetTagModel.setGroupId(i);
-				assetTagModel.setCompanyId(_companyId);
-				assetTagModel.setUserId(_sampleUserId);
-				assetTagModel.setUserName(_SAMPLE_USER_NAME);
-				assetTagModel.setCreateDate(new Date());
-				assetTagModel.setModifiedDate(new Date());
-				assetTagModel.setName(
-					StringBundler.concat("TestTag_", i, "_", j));
-				assetTagModel.setLastPublishDate(new Date());
-
-				assetTagModels.add(assetTagModel);
-			}
-
-			_assetTagModelsArray[i - 1] = assetTagModels;
-
-			Map<Long, List<AssetTagModel>> assetTagModelsMap = new HashMap<>();
-
-			int pageSize = assetTagModels.size() / _assetClassNameIds.length;
-
-			for (int j = 0; j < _assetClassNameIds.length; j++) {
-				int fromIndex = j * pageSize;
-
-				int toIndex = (j + 1) * pageSize;
-
-				if (j == (_assetClassNameIds.length - 1)) {
-					toIndex = assetTagModels.size();
-				}
-
-				assetTagModelsMap.put(
-					_assetClassNameIds[j],
-					assetTagModels.subList(fromIndex, toIndex));
-			}
-
-			_assetTagModelsMaps[i - 1] = assetTagModelsMap;
-		}
 	}
 
 	public void initJournalArticleContent() {
@@ -1036,6 +964,75 @@ public class DataFactory {
 				PortletConstants.DEFAULT_PREFERENCES));
 
 		return portletPreferencesModels;
+	}
+
+	public List<AssetTagModel> newAssetTagModels() {
+		List<AssetTagModel> allAssetTagModels = new ArrayList<>();
+
+		for (Map<Long, List<AssetTagModel>> assetTagModelsMap :
+				_assetTagModelsMaps) {
+
+			for (List<AssetTagModel> assetTagModels :
+					assetTagModelsMap.values()) {
+
+				allAssetTagModels.addAll(assetTagModels);
+			}
+		}
+
+		return allAssetTagModels;
+	}
+
+	public Map<Long, List<AssetTagModel>>[] newAssetTagModelsMaps() {
+		Map<Long, List<AssetTagModel>>[] assetTagModelsMaps =
+			(Map<Long, List<AssetTagModel>>[])
+				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
+
+		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
+			List<AssetTagModel> assetTagModels = new ArrayList<>(
+				BenchmarksPropsValues.MAX_ASSET_TAG_COUNT);
+
+			for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_TAG_COUNT;
+				 j++) {
+
+				AssetTagModel assetTagModel = new AssetTagModelImpl();
+
+				assetTagModel.setUuid(SequentialUUID.generate());
+				assetTagModel.setTagId(_counter.get());
+				assetTagModel.setGroupId(i);
+				assetTagModel.setCompanyId(_companyId);
+				assetTagModel.setUserId(_sampleUserId);
+				assetTagModel.setUserName(_SAMPLE_USER_NAME);
+				assetTagModel.setCreateDate(new Date());
+				assetTagModel.setModifiedDate(new Date());
+				assetTagModel.setName(
+					StringBundler.concat("TestTag_", i, "_", j));
+				assetTagModel.setLastPublishDate(new Date());
+
+				assetTagModels.add(assetTagModel);
+			}
+
+			Map<Long, List<AssetTagModel>> assetTagModelsMap = new HashMap<>();
+
+			int pageSize = assetTagModels.size() / _assetClassNameIds.length;
+
+			for (int j = 0; j < _assetClassNameIds.length; j++) {
+				int fromIndex = j * pageSize;
+
+				int toIndex = (j + 1) * pageSize;
+
+				if (j == (_assetClassNameIds.length - 1)) {
+					toIndex = assetTagModels.size();
+				}
+
+				assetTagModelsMap.put(
+					_assetClassNameIds[j],
+					assetTagModels.subList(fromIndex, toIndex));
+			}
+
+			assetTagModelsMaps[i - 1] = assetTagModelsMap;
+		}
+
+		return assetTagModelsMaps;
 	}
 
 	public List<AssetVocabularyModel> newAssetVocabularyModels(
@@ -5057,8 +5054,7 @@ public class DataFactory {
 	private final Map<Long, Integer> _assetPublisherQueryStartIndexes =
 		new HashMap<>();
 	private Map<Long, SimpleCounter>[] _assetTagCounters;
-	private List<AssetTagModel>[] _assetTagModelsArray;
-	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
+	private final Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
 	private final List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -768,71 +768,65 @@ public class DataFactory {
 		return accountModel;
 	}
 
-	public List<AssetCategoryModel> newAssetCategoryModels() {
+	public List<AssetCategoryModel> newAssetCategoryModels(long groupId) {
 		List<AssetCategoryModel> allAssetCategoryModels = new ArrayList<>();
-
-		_assetCategoryModelsMaps =
-			(Map<Long, List<AssetCategoryModel>>[])
-				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
 
 		StringBundler sb = new StringBundler(4);
 
-		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
-			List<AssetVocabularyModel> assetVocabularyModels =
-				_assetVocabularyModelsArray[i - 1];
-			List<AssetCategoryModel> groupAssetCategoryModels = new ArrayList<>(
-				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT *
-					BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT);
+		List<AssetVocabularyModel> assetVocabularyModels =
+			_assetVocabularyModelsArray[(int)groupId - 1];
 
-			for (int j = 0;
-				 j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT; j++) {
+		List<AssetCategoryModel> groupAssetCategoryModels = new ArrayList<>(
+			BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT *
+				BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT);
 
-				AssetVocabularyModel assetVocabularyModel =
-					assetVocabularyModels.get(j);
+		for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT;
+			 j++) {
 
-				for (int k = 0;
-					 k < BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT; k++) {
+			AssetVocabularyModel assetVocabularyModel =
+				assetVocabularyModels.get(j);
 
-					sb.setIndex(0);
+			for (int k = 0; k < BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT;
+				 k++) {
 
-					sb.append("TestCategory_");
-					sb.append(assetVocabularyModel.getVocabularyId());
-					sb.append(StringPool.UNDERLINE);
-					sb.append(k);
+				sb.setIndex(0);
 
-					AssetCategoryModel assetCategoryModel =
-						newAssetCategoryModel(
-							i, sb.toString(),
-							assetVocabularyModel.getVocabularyId());
+				sb.append("TestCategory_");
+				sb.append(assetVocabularyModel.getVocabularyId());
+				sb.append(StringPool.UNDERLINE);
+				sb.append(k);
 
-					groupAssetCategoryModels.add(assetCategoryModel);
+				AssetCategoryModel assetCategoryModel = newAssetCategoryModel(
+					groupId, sb.toString(),
+					assetVocabularyModel.getVocabularyId());
 
-					allAssetCategoryModels.add(assetCategoryModel);
-				}
+				groupAssetCategoryModels.add(assetCategoryModel);
+
+				allAssetCategoryModels.add(assetCategoryModel);
 			}
-
-			Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap =
-				new HashMap<>();
-
-			int pageSize =
-				groupAssetCategoryModels.size() / _assetClassNameIds.length;
-
-			for (int j = 0; j < _assetClassNameIds.length; j++) {
-				int fromIndex = j * pageSize;
-
-				int toIndex = (j + 1) * pageSize;
-
-				if (j == (_assetClassNameIds.length - 1)) {
-					toIndex = groupAssetCategoryModels.size();
-				}
-
-				assetCategoryModelsMap.put(
-					_assetClassNameIds[j],
-					groupAssetCategoryModels.subList(fromIndex, toIndex));
-			}
-
-			_assetCategoryModelsMaps[i - 1] = assetCategoryModelsMap;
 		}
+
+		Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap =
+			new HashMap<>();
+
+		int pageSize =
+			groupAssetCategoryModels.size() / _assetClassNameIds.length;
+
+		for (int j = 0; j < _assetClassNameIds.length; j++) {
+			int fromIndex = j * pageSize;
+
+			int toIndex = (j + 1) * pageSize;
+
+			if (j == (_assetClassNameIds.length - 1)) {
+				toIndex = groupAssetCategoryModels.size();
+			}
+
+			assetCategoryModelsMap.put(
+				_assetClassNameIds[j],
+				groupAssetCategoryModels.subList(fromIndex, toIndex));
+		}
+
+		_assetCategoryModelsMaps[(int)groupId - 1] = assetCategoryModelsMap;
 
 		return allAssetCategoryModels;
 	}
@@ -947,103 +941,83 @@ public class DataFactory {
 		return portletPreferencesModels;
 	}
 
-	public List<AssetTagModel> newAssetTagModels() {
+	public List<AssetTagModel> newAssetTagModels(long groupId) {
 		List<AssetTagModel> allAssetTagModels = new ArrayList<>();
 
-		_assetTagModelsMaps =
-			(Map<Long, List<AssetTagModel>>[])
-				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
+		List<AssetTagModel> groupAssetTagModels = new ArrayList<>(
+			BenchmarksPropsValues.MAX_ASSET_TAG_COUNT);
 
-		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
-			List<AssetTagModel> groupAssetTagModels = new ArrayList<>(
-				BenchmarksPropsValues.MAX_ASSET_TAG_COUNT);
+		for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_TAG_COUNT; j++) {
+			AssetTagModel assetTagModel = new AssetTagModelImpl();
 
-			for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_TAG_COUNT;
-				 j++) {
+			assetTagModel.setUuid(SequentialUUID.generate());
+			assetTagModel.setTagId(_counter.get());
+			assetTagModel.setGroupId(groupId);
+			assetTagModel.setCompanyId(_companyId);
+			assetTagModel.setUserId(_sampleUserId);
+			assetTagModel.setUserName(_SAMPLE_USER_NAME);
+			assetTagModel.setCreateDate(new Date());
+			assetTagModel.setModifiedDate(new Date());
+			assetTagModel.setName(
+				StringBundler.concat("TestTag_", groupId, "_", j));
+			assetTagModel.setLastPublishDate(new Date());
 
-				AssetTagModel assetTagModel = new AssetTagModelImpl();
+			groupAssetTagModels.add(assetTagModel);
 
-				assetTagModel.setUuid(SequentialUUID.generate());
-				assetTagModel.setTagId(_counter.get());
-				assetTagModel.setGroupId(i);
-				assetTagModel.setCompanyId(_companyId);
-				assetTagModel.setUserId(_sampleUserId);
-				assetTagModel.setUserName(_SAMPLE_USER_NAME);
-				assetTagModel.setCreateDate(new Date());
-				assetTagModel.setModifiedDate(new Date());
-				assetTagModel.setName(
-					StringBundler.concat("TestTag_", i, "_", j));
-				assetTagModel.setLastPublishDate(new Date());
-
-				groupAssetTagModels.add(assetTagModel);
-
-				allAssetTagModels.add(assetTagModel);
-			}
-
-			Map<Long, List<AssetTagModel>> assetTagModelsMap = new HashMap<>();
-
-			int pageSize =
-				groupAssetTagModels.size() / _assetClassNameIds.length;
-
-			for (int j = 0; j < _assetClassNameIds.length; j++) {
-				int fromIndex = j * pageSize;
-
-				int toIndex = (j + 1) * pageSize;
-
-				if (j == (_assetClassNameIds.length - 1)) {
-					toIndex = groupAssetTagModels.size();
-				}
-
-				assetTagModelsMap.put(
-					_assetClassNameIds[j],
-					groupAssetTagModels.subList(fromIndex, toIndex));
-			}
-
-			_assetTagModelsMaps[i - 1] = assetTagModelsMap;
+			allAssetTagModels.add(assetTagModel);
 		}
+
+		Map<Long, List<AssetTagModel>> assetTagModelsMap = new HashMap<>();
+
+		int pageSize = groupAssetTagModels.size() / _assetClassNameIds.length;
+
+		for (int j = 0; j < _assetClassNameIds.length; j++) {
+			int fromIndex = j * pageSize;
+
+			int toIndex = (j + 1) * pageSize;
+
+			if (j == (_assetClassNameIds.length - 1)) {
+				toIndex = groupAssetTagModels.size();
+			}
+
+			assetTagModelsMap.put(
+				_assetClassNameIds[j],
+				groupAssetTagModels.subList(fromIndex, toIndex));
+		}
+
+		_assetTagModelsMaps[(int)groupId - 1] = assetTagModelsMap;
 
 		return allAssetTagModels;
 	}
 
-	public List<AssetVocabularyModel> newAssetVocabularyModels(
-		AssetVocabularyModel defaultAssetVocabularyModel) {
-
+	public List<AssetVocabularyModel> newAssetVocabularyModels(long groupId) {
 		List<AssetVocabularyModel> allAssetVocabularyModels = new ArrayList<>();
-
-		allAssetVocabularyModels.add(defaultAssetVocabularyModel);
-
-		_assetVocabularyModelsArray =
-			(List<AssetVocabularyModel>[])
-				new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
 
 		StringBundler sb = new StringBundler(4);
 
-		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
-			List<AssetVocabularyModel> groupAssetVocabularyModels =
-				new ArrayList<>(
-					BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT);
+		List<AssetVocabularyModel> groupAssetVocabularyModels = new ArrayList<>(
+			BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT);
 
-			for (int j = 0;
-				 j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT; j++) {
+		for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT;
+			 j++) {
 
-				sb.setIndex(0);
+			sb.setIndex(0);
 
-				sb.append("TestVocabulary_");
-				sb.append(i);
-				sb.append(StringPool.UNDERLINE);
-				sb.append(j);
+			sb.append("TestVocabulary_");
+			sb.append(groupId);
+			sb.append(StringPool.UNDERLINE);
+			sb.append(j);
 
-				AssetVocabularyModel assetVocabularyModel =
-					newAssetVocabularyModel(
-						i, _sampleUserId, _SAMPLE_USER_NAME, sb.toString());
+			AssetVocabularyModel assetVocabularyModel = newAssetVocabularyModel(
+				groupId, _sampleUserId, _SAMPLE_USER_NAME, sb.toString());
 
-				groupAssetVocabularyModels.add(assetVocabularyModel);
+			groupAssetVocabularyModels.add(assetVocabularyModel);
 
-				allAssetVocabularyModels.add(assetVocabularyModel);
-			}
-
-			_assetVocabularyModelsArray[i - 1] = groupAssetVocabularyModels;
+			allAssetVocabularyModels.add(assetVocabularyModel);
 		}
+
+		_assetVocabularyModelsArray[(int)groupId - 1] =
+			groupAssetVocabularyModels;
 
 		return allAssetVocabularyModels;
 	}
@@ -5009,15 +4983,21 @@ public class DataFactory {
 	private final long _accountId;
 	private RoleModel _administratorRoleModel;
 	private Map<Long, SimpleCounter>[] _assetCategoryCounters;
-	private Map<Long, List<AssetCategoryModel>>[] _assetCategoryModelsMaps;
+	private Map<Long, List<AssetCategoryModel>>[] _assetCategoryModelsMaps =
+		(Map<Long, List<AssetCategoryModel>>[])
+			new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
 	private final long[] _assetClassNameIds;
 	private final Map<Long, Integer> _assetClassNameIdsIndexes =
 		new HashMap<>();
 	private final Map<Long, Integer> _assetPublisherQueryStartIndexes =
 		new HashMap<>();
 	private Map<Long, SimpleCounter>[] _assetTagCounters;
-	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
-	private List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
+	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps =
+		(Map<Long, List<AssetTagModel>>[])
+			new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
+	private List<AssetVocabularyModel>[] _assetVocabularyModelsArray =
+		(List<AssetVocabularyModel>[])
+			new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();
 	private final long _companyId;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -283,9 +283,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TimeZone;
-import java.util.stream.Stream;
 
 import javax.portlet.PortletPreferences;
 
@@ -361,10 +359,7 @@ public class DataFactory {
 
 	public List<Long> getAssetCategoryIds(
 		AssetEntryModel assetEntryModel,
-		List<AssetCategoryModel> fullAssetCategoryModels) {
-
-		List<AssetCategoryModel> assetCategoryModels = _pickAssetCategoryModels(
-			assetEntryModel.getClassNameId(), fullAssetCategoryModels);
+		List<AssetCategoryModel> assetCategoryModels) {
 
 		if ((assetCategoryModels == null) || assetCategoryModels.isEmpty()) {
 			return Collections.emptyList();
@@ -399,11 +394,7 @@ public class DataFactory {
 	}
 
 	public List<Long> getAssetTagIds(
-		AssetEntryModel assetEntryModel,
-		List<AssetTagModel> fullAssetTagModels) {
-
-		List<AssetTagModel> assetTagModels = _pickAssetTagModels(
-			assetEntryModel.getClassNameId(), fullAssetTagModels);
+		AssetEntryModel assetEntryModel, List<AssetTagModel> assetTagModels) {
 
 		if ((assetTagModels == null) || assetTagModels.isEmpty()) {
 			return Collections.emptyList();
@@ -557,22 +548,21 @@ public class DataFactory {
 		return groupIds;
 	}
 
-	public long getNextAssetClassNameId(Set<Long> classNameIds, long groupId) {
-		Stream<Long> classNameIdsStream = classNameIds.stream();
+	public List<AssetCategoryModel> getNextAssetCategoryModels(
+		List<AssetCategoryModel>[] fullAssetCategoryModels) {
 
-		Long[] assetClassNameIds = classNameIdsStream.toArray(Long[]::new);
+		return fullAssetCategoryModels[getNextIndex()];
+	}
 
-		Integer index = _assetClassNameIdsIndexes.get(groupId);
+	public List<AssetTagModel> getNextAssetTagModels(
+		List<AssetTagModel>[] fullAssetTagModels) {
 
-		if (index == null) {
-			index = 0;
-		}
+		return fullAssetTagModels[getNextIndex()];
+	}
 
-		long classNameId = assetClassNameIds[index % assetClassNameIds.length];
-
-		_assetClassNameIdsIndexes.put(groupId, ++index);
-
-		return classNameId;
+	public int getNextIndex() {
+		return _indexCounter++ %
+			BenchmarksPropsValues.MAX_ASSET_ENTRY_DATA_TYPE_COUNT;
 	}
 
 	public String getPortletId(String portletPrefix) {
@@ -3088,19 +3078,16 @@ public class DataFactory {
 	}
 
 	public PortletPreferencesModel newPortletPreferencesModel(
-			long plid, long groupId, String portletId, int currentIndex)
+			long plid, long groupId, String portletId, int currentIndex,
+			List<Object> models)
 		throws Exception {
 
-		if (currentIndex == 1) {
+		if ((models == null) || models.isEmpty()) {
 			return newPortletPreferencesModel(
 				plid, portletId, PortletConstants.DEFAULT_PREFERENCES);
 		}
 
 		String assetPublisherQueryName = "assetCategories";
-
-		if ((currentIndex % 2) == 0) {
-			assetPublisherQueryName = "assetTags";
-		}
 
 		ObjectValuePair<String[], Integer> objectValuePair = null;
 
@@ -3110,35 +3097,14 @@ public class DataFactory {
 			startIndex = 0;
 		}
 
-		if (assetPublisherQueryName.equals("assetCategories")) {
-			List<AssetCategoryModel> specificAssetCategoryModels =
-				_assetCategoryModelsMap.get(
-					getNextAssetClassNameId(
-						_assetCategoryModelsMap.keySet(), groupId));
-
-			if ((specificAssetCategoryModels == null) ||
-				specificAssetCategoryModels.isEmpty()) {
-
-				return newPortletPreferencesModel(
-					plid, portletId, PortletConstants.DEFAULT_PREFERENCES);
-			}
-
-			objectValuePair = getAssetPublisherAssetCategoriesQueryValues(
-				specificAssetCategoryModels, startIndex);
+		if ((currentIndex % 2) == 0) {
+			assetPublisherQueryName = "assetTags";
+			objectValuePair = getAssetPublisherAssetTagsQueryValues(
+				models, startIndex);
 		}
 		else {
-			List<AssetTagModel> specificAssetTagModels = _assetTagModelsMap.get(
-				getNextAssetClassNameId(_assetTagModelsMap.keySet(), groupId));
-
-			if ((specificAssetTagModels == null) ||
-				specificAssetTagModels.isEmpty()) {
-
-				return newPortletPreferencesModel(
-					plid, portletId, PortletConstants.DEFAULT_PREFERENCES);
-			}
-
-			objectValuePair = getAssetPublisherAssetTagsQueryValues(
-				specificAssetTagModels, startIndex);
+			objectValuePair = getAssetPublisherAssetCategoriesQueryValues(
+				models, startIndex);
 		}
 
 		String[] assetPublisherQueryValues = objectValuePair.getKey();
@@ -3146,28 +3112,18 @@ public class DataFactory {
 		_assetPublisherQueryStartIndexes.put(
 			groupId, objectValuePair.getValue());
 
-		PortletPreferences jxPortletPreferences =
-			(PortletPreferences)
-				_defaultAssetPublisherPortletPreferencesImpl.clone();
-
-		jxPortletPreferences.setValue("queryAndOperator0", "false");
-		jxPortletPreferences.setValue("queryContains0", "true");
-		jxPortletPreferences.setValue("queryName0", assetPublisherQueryName);
-		jxPortletPreferences.setValues(
-			"queryValues0",
-			new String[] {
-				assetPublisherQueryValues[0], assetPublisherQueryValues[1],
-				assetPublisherQueryValues[2]
-			});
-		jxPortletPreferences.setValue("queryAndOperator1", "false");
-		jxPortletPreferences.setValue("queryContains1", "false");
-		jxPortletPreferences.setValue("queryName1", assetPublisherQueryName);
-		jxPortletPreferences.setValue(
-			"queryValues1", assetPublisherQueryValues[3]);
-
 		return newPortletPreferencesModel(
 			plid, portletId,
-			_portletPreferencesFactory.toXML(jxPortletPreferences));
+			_portletPreferencesFactory.toXML(
+				_newPortletPreferences(
+					assetPublisherQueryName, assetPublisherQueryValues)));
+	}
+
+	public PortletPreferencesModel newPortletPreferencesModel(
+		long plid, String portletId) {
+
+		return newPortletPreferencesModel(
+			plid, portletId, PortletConstants.DEFAULT_PREFERENCES);
 	}
 
 	public PortletPreferencesModel newPortletPreferencesModel(
@@ -3673,6 +3629,32 @@ public class DataFactory {
 		return userName;
 	}
 
+	public List<AssetCategoryModel> pickAssetCategoryModels(
+		List<AssetCategoryModel> fullAssetCategoryModels, int index) {
+
+		int pageSize =
+			fullAssetCategoryModels.size() /
+				BenchmarksPropsValues.MAX_ASSET_ENTRY_DATA_TYPE_COUNT;
+
+		int fromIndex = (index - 1) * pageSize;
+		int toIndex = index * pageSize;
+
+		return fullAssetCategoryModels.subList(fromIndex, toIndex);
+	}
+
+	public List<AssetTagModel> pickAssetTagModels(
+		List<AssetTagModel> fullAssetTagModels, int index) {
+
+		int pageSize =
+			fullAssetTagModels.size() /
+				BenchmarksPropsValues.MAX_ASSET_ENTRY_DATA_TYPE_COUNT;
+
+		int fromIndex = (index - 1) * pageSize;
+		int toIndex = index * pageSize;
+
+		return fullAssetTagModels.subList(fromIndex, toIndex);
+	}
+
 	public String toInsertSQL(BaseModel<?> baseModel) {
 		try {
 			StringBundler sb = new StringBundler();
@@ -3727,7 +3709,7 @@ public class DataFactory {
 
 	protected ObjectValuePair<String[], Integer>
 		getAssetPublisherAssetCategoriesQueryValues(
-			List<AssetCategoryModel> assetCategoryModels, int index) {
+			List<Object> assetCategoryModels, int index) {
 
 		String[] categoryIds = new String[4];
 
@@ -3738,8 +3720,9 @@ public class DataFactory {
 						MAX_ASSET_ENTRY_TO_ASSET_CATEGORY_COUNT;
 			}
 
-			AssetCategoryModel assetCategoryModel = assetCategoryModels.get(
-				index % assetCategoryModels.size());
+			AssetCategoryModel assetCategoryModel =
+				(AssetCategoryModel)assetCategoryModels.get(
+					index % assetCategoryModels.size());
 
 			categoryIds[i] = String.valueOf(assetCategoryModel.getCategoryId());
 		}
@@ -3752,7 +3735,7 @@ public class DataFactory {
 
 	protected ObjectValuePair<String[], Integer>
 		getAssetPublisherAssetTagsQueryValues(
-			List<AssetTagModel> assetTagModels, int index) {
+			List<Object> assetTagModels, int index) {
 
 		String[] assetTagNames = new String[4];
 
@@ -3762,7 +3745,7 @@ public class DataFactory {
 					BenchmarksPropsValues.MAX_ASSET_ENTRY_TO_ASSET_TAG_COUNT;
 			}
 
-			AssetTagModel assetTagModel = assetTagModels.get(
+			AssetTagModel assetTagModel = (AssetTagModel)assetTagModels.get(
 				index % assetTagModels.size());
 
 			assetTagNames[i] = String.valueOf(assetTagModel.getName());
@@ -4880,78 +4863,30 @@ public class DataFactory {
 		return sb.toString();
 	}
 
-	private List<AssetCategoryModel> _pickAssetCategoryModels(
-		long classNameId, List<AssetCategoryModel> assetCategoryModels) {
+	private PortletPreferences _newPortletPreferences(
+			String assetPublisherQueryName, String[] assetPublisherQueryValues)
+		throws Exception {
 
-		int fromIndex = 0;
-		int toIndex = 0;
+		PortletPreferences jxPortletPreferences =
+			(PortletPreferences)
+				_defaultAssetPublisherPortletPreferencesImpl.clone();
 
-		int pageSize =
-			assetCategoryModels.size() /
-				BenchmarksPropsValues.MAX_ASSET_ENTRY_DATA_TYPE_COUNT;
+		jxPortletPreferences.setValue("queryAndOperator0", "false");
+		jxPortletPreferences.setValue("queryContains0", "true");
+		jxPortletPreferences.setValue("queryName0", assetPublisherQueryName);
+		jxPortletPreferences.setValues(
+			"queryValues0",
+			new String[] {
+				assetPublisherQueryValues[0], assetPublisherQueryValues[1],
+				assetPublisherQueryValues[2]
+			});
+		jxPortletPreferences.setValue("queryAndOperator1", "false");
+		jxPortletPreferences.setValue("queryContains1", "false");
+		jxPortletPreferences.setValue("queryName1", assetPublisherQueryName);
+		jxPortletPreferences.setValue(
+			"queryValues1", assetPublisherQueryValues[3]);
 
-		List<AssetCategoryModel> pickedAssetCategoryModels = new ArrayList<>();
-
-		if (_assetCategoryModelsMap.size() == 0) {
-			fromIndex = _assetCategoryModelsMap.size() * pageSize;
-			toIndex = (_assetCategoryModelsMap.size() + 1) * pageSize;
-
-			pickedAssetCategoryModels = assetCategoryModels.subList(
-				fromIndex, toIndex);
-		}
-		else if ((_assetCategoryModelsMap.size() - 1) <
-					BenchmarksPropsValues.MAX_ASSET_ENTRY_DATA_TYPE_COUNT) {
-
-			if (_assetCategoryModelsMap.containsKey(classNameId)) {
-				return _assetCategoryModelsMap.get(classNameId);
-			}
-
-			fromIndex = _assetCategoryModelsMap.size() * pageSize;
-			toIndex = (_assetCategoryModelsMap.size() + 1) * pageSize;
-
-			pickedAssetCategoryModels = assetCategoryModels.subList(
-				fromIndex, toIndex);
-		}
-
-		_assetCategoryModelsMap.put(classNameId, pickedAssetCategoryModels);
-
-		return pickedAssetCategoryModels;
-	}
-
-	private List<AssetTagModel> _pickAssetTagModels(
-		long classNameId, List<AssetTagModel> assetTagModels) {
-
-		int fromIndex = 0;
-		int toIndex = 0;
-
-		int pageSize =
-			assetTagModels.size() /
-				BenchmarksPropsValues.MAX_ASSET_ENTRY_DATA_TYPE_COUNT;
-
-		List<AssetTagModel> pickedAssetTagModels = new ArrayList<>();
-
-		if (_assetTagModelsMap.size() == 0) {
-			fromIndex = _assetTagModelsMap.size() * pageSize;
-			toIndex = (_assetTagModelsMap.size() + 1) * pageSize;
-
-			pickedAssetTagModels = assetTagModels.subList(fromIndex, toIndex);
-		}
-		else if ((_assetTagModelsMap.size() - 1) <
-					BenchmarksPropsValues.MAX_ASSET_ENTRY_DATA_TYPE_COUNT) {
-
-			if (_assetTagModelsMap.containsKey(classNameId)) {
-				return _assetTagModelsMap.get(classNameId);
-			}
-
-			fromIndex = _assetTagModelsMap.size() * pageSize;
-			toIndex = (_assetTagModelsMap.size() + 1) * pageSize;
-
-			pickedAssetTagModels = assetTagModels.subList(fromIndex, toIndex);
-		}
-
-		_assetTagModelsMap.put(classNameId, pickedAssetTagModels);
-
-		return pickedAssetTagModels;
+		return jxPortletPreferences;
 	}
 
 	private String _readFile(String resourceName) throws Exception {
@@ -4974,21 +4909,16 @@ public class DataFactory {
 
 	private static final String _SAMPLE_USER_NAME = "Sample";
 
+	private static int _indexCounter;
 	private static final PortletPreferencesFactory _portletPreferencesFactory =
 		new PortletPreferencesFactoryImpl();
 
 	private final long _accountId;
 	private RoleModel _administratorRoleModel;
 	private Map<Long, SimpleCounter>[] _assetCategoryCounters;
-	private final Map<Long, List<AssetCategoryModel>> _assetCategoryModelsMap =
-		new HashMap<>();
-	private final Map<Long, Integer> _assetClassNameIdsIndexes =
-		new HashMap<>();
 	private final Map<Long, Integer> _assetPublisherQueryStartIndexes =
 		new HashMap<>();
 	private Map<Long, SimpleCounter>[] _assetTagCounters;
-	private final Map<Long, List<AssetTagModel>> _assetTagModelsMap =
-		new HashMap<>();
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();
 	private final long _companyId;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -283,7 +283,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
 import javax.portlet.PortletPreferences;
 
@@ -319,11 +321,6 @@ public class DataFactory {
 
 			_classNameModels.put(model, classNameModel);
 		}
-
-		_assetClassNameIds = new long[] {
-			getClassNameId(BlogsEntry.class),
-			getClassNameId(JournalArticle.class), getClassNameId(WikiPage.class)
-		};
 
 		_accountId = _counter.get();
 		_companyId = _counter.get();
@@ -362,18 +359,12 @@ public class DataFactory {
 		return _administratorRoleModel;
 	}
 
-	public List<Long> getAssetCategoryIds(AssetEntryModel assetEntryModel) {
-		Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap =
-			_assetCategoryModelsMaps[(int)assetEntryModel.getGroupId() - 1];
+	public List<Long> getAssetCategoryIds(
+		AssetEntryModel assetEntryModel,
+		List<AssetCategoryModel> fullAssetCategoryModels) {
 
-		if ((assetCategoryModelsMap == null) ||
-			assetCategoryModelsMap.isEmpty()) {
-
-			return Collections.emptyList();
-		}
-
-		List<AssetCategoryModel> assetCategoryModels =
-			assetCategoryModelsMap.get(assetEntryModel.getClassNameId());
+		List<AssetCategoryModel> assetCategoryModels = _pickAssetCategoryModels(
+			assetEntryModel.getClassNameId(), fullAssetCategoryModels);
 
 		if ((assetCategoryModels == null) || assetCategoryModels.isEmpty()) {
 			return Collections.emptyList();
@@ -407,16 +398,12 @@ public class DataFactory {
 		return assetCategoryIds;
 	}
 
-	public List<Long> getAssetTagIds(AssetEntryModel assetEntryModel) {
-		Map<Long, List<AssetTagModel>> assetTagModelsMap =
-			_assetTagModelsMaps[(int)assetEntryModel.getGroupId() - 1];
+	public List<Long> getAssetTagIds(
+		AssetEntryModel assetEntryModel,
+		List<AssetTagModel> fullAssetTagModels) {
 
-		if ((assetTagModelsMap == null) || assetTagModelsMap.isEmpty()) {
-			return Collections.emptyList();
-		}
-
-		List<AssetTagModel> assetTagModels = assetTagModelsMap.get(
-			assetEntryModel.getClassNameId());
+		List<AssetTagModel> assetTagModels = _pickAssetTagModels(
+			assetEntryModel.getClassNameId(), fullAssetTagModels);
 
 		if ((assetTagModels == null) || assetTagModels.isEmpty()) {
 			return Collections.emptyList();
@@ -570,15 +557,18 @@ public class DataFactory {
 		return groupIds;
 	}
 
-	public long getNextAssetClassNameId(long groupId) {
+	public long getNextAssetClassNameId(Set<Long> classNameIds, long groupId) {
+		Stream<Long> classNameIdsStream = classNameIds.stream();
+
+		Long[] assetClassNameIds = classNameIdsStream.toArray(Long[]::new);
+
 		Integer index = _assetClassNameIdsIndexes.get(groupId);
 
 		if (index == null) {
 			index = 0;
 		}
 
-		long classNameId =
-			_assetClassNameIds[index % _assetClassNameIds.length];
+		long classNameId = assetClassNameIds[index % assetClassNameIds.length];
 
 		_assetClassNameIdsIndexes.put(groupId, ++index);
 
@@ -775,10 +765,6 @@ public class DataFactory {
 
 		StringBundler sb = new StringBundler(4);
 
-		List<AssetCategoryModel> groupAssetCategoryModels = new ArrayList<>(
-			BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT *
-				BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT);
-
 		for (AssetVocabularyModel assetVocabularyModel :
 				assetVocabularyModels) {
 
@@ -796,33 +782,9 @@ public class DataFactory {
 					groupId, sb.toString(),
 					assetVocabularyModel.getVocabularyId());
 
-				groupAssetCategoryModels.add(assetCategoryModel);
-
 				assetCategoryModels.add(assetCategoryModel);
 			}
 		}
-
-		Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap =
-			new HashMap<>();
-
-		int pageSize =
-			groupAssetCategoryModels.size() / _assetClassNameIds.length;
-
-		for (int j = 0; j < _assetClassNameIds.length; j++) {
-			int fromIndex = j * pageSize;
-
-			int toIndex = (j + 1) * pageSize;
-
-			if (j == (_assetClassNameIds.length - 1)) {
-				toIndex = groupAssetCategoryModels.size();
-			}
-
-			assetCategoryModelsMap.put(
-				_assetClassNameIds[j],
-				groupAssetCategoryModels.subList(fromIndex, toIndex));
-		}
-
-		_assetCategoryModelsMaps[(int)groupId - 1] = assetCategoryModelsMap;
 
 		return assetCategoryModels;
 	}
@@ -940,9 +902,6 @@ public class DataFactory {
 	public List<AssetTagModel> newAssetTagModels(long groupId) {
 		List<AssetTagModel> assetTagModels = new ArrayList<>();
 
-		List<AssetTagModel> groupAssetTagModels = new ArrayList<>(
-			BenchmarksPropsValues.MAX_ASSET_TAG_COUNT);
-
 		for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_TAG_COUNT; j++) {
 			AssetTagModel assetTagModel = new AssetTagModelImpl();
 
@@ -958,30 +917,8 @@ public class DataFactory {
 				StringBundler.concat("TestTag_", groupId, "_", j));
 			assetTagModel.setLastPublishDate(new Date());
 
-			groupAssetTagModels.add(assetTagModel);
-
 			assetTagModels.add(assetTagModel);
 		}
-
-		Map<Long, List<AssetTagModel>> assetTagModelsMap = new HashMap<>();
-
-		int pageSize = groupAssetTagModels.size() / _assetClassNameIds.length;
-
-		for (int j = 0; j < _assetClassNameIds.length; j++) {
-			int fromIndex = j * pageSize;
-
-			int toIndex = (j + 1) * pageSize;
-
-			if (j == (_assetClassNameIds.length - 1)) {
-				toIndex = groupAssetTagModels.size();
-			}
-
-			assetTagModelsMap.put(
-				_assetClassNameIds[j],
-				groupAssetTagModels.subList(fromIndex, toIndex));
-		}
-
-		_assetTagModelsMaps[(int)groupId - 1] = assetTagModelsMap;
 
 		return assetTagModels;
 	}
@@ -3174,36 +3111,34 @@ public class DataFactory {
 		}
 
 		if (assetPublisherQueryName.equals("assetCategories")) {
-			Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap =
-				_assetCategoryModelsMaps[(int)groupId - 1];
+			List<AssetCategoryModel> specificAssetCategoryModels =
+				_assetCategoryModelsMap.get(
+					getNextAssetClassNameId(
+						_assetCategoryModelsMap.keySet(), groupId));
 
-			List<AssetCategoryModel> assetCategoryModels =
-				assetCategoryModelsMap.get(getNextAssetClassNameId(groupId));
-
-			if ((assetCategoryModels == null) ||
-				assetCategoryModels.isEmpty()) {
+			if ((specificAssetCategoryModels == null) ||
+				specificAssetCategoryModels.isEmpty()) {
 
 				return newPortletPreferencesModel(
 					plid, portletId, PortletConstants.DEFAULT_PREFERENCES);
 			}
 
 			objectValuePair = getAssetPublisherAssetCategoriesQueryValues(
-				assetCategoryModels, startIndex);
+				specificAssetCategoryModels, startIndex);
 		}
 		else {
-			Map<Long, List<AssetTagModel>> assetTagModelsMap =
-				_assetTagModelsMaps[(int)groupId - 1];
+			List<AssetTagModel> specificAssetTagModels = _assetTagModelsMap.get(
+				getNextAssetClassNameId(_assetTagModelsMap.keySet(), groupId));
 
-			List<AssetTagModel> assetTagModels = assetTagModelsMap.get(
-				getNextAssetClassNameId(groupId));
+			if ((specificAssetTagModels == null) ||
+				specificAssetTagModels.isEmpty()) {
 
-			if ((assetTagModels == null) || assetTagModels.isEmpty()) {
 				return newPortletPreferencesModel(
 					plid, portletId, PortletConstants.DEFAULT_PREFERENCES);
 			}
 
 			objectValuePair = getAssetPublisherAssetTagsQueryValues(
-				assetTagModels, startIndex);
+				specificAssetTagModels, startIndex);
 		}
 
 		String[] assetPublisherQueryValues = objectValuePair.getKey();
@@ -4945,6 +4880,80 @@ public class DataFactory {
 		return sb.toString();
 	}
 
+	private List<AssetCategoryModel> _pickAssetCategoryModels(
+		long classNameId, List<AssetCategoryModel> assetCategoryModels) {
+
+		int fromIndex = 0;
+		int toIndex = 0;
+
+		int pageSize =
+			assetCategoryModels.size() /
+				BenchmarksPropsValues.MAX_ASSET_ENTRY_DATA_TYPE_COUNT;
+
+		List<AssetCategoryModel> pickedAssetCategoryModels = new ArrayList<>();
+
+		if (_assetCategoryModelsMap.size() == 0) {
+			fromIndex = _assetCategoryModelsMap.size() * pageSize;
+			toIndex = (_assetCategoryModelsMap.size() + 1) * pageSize;
+
+			pickedAssetCategoryModels = assetCategoryModels.subList(
+				fromIndex, toIndex);
+		}
+		else if ((_assetCategoryModelsMap.size() - 1) <
+					BenchmarksPropsValues.MAX_ASSET_ENTRY_DATA_TYPE_COUNT) {
+
+			if (_assetCategoryModelsMap.containsKey(classNameId)) {
+				return _assetCategoryModelsMap.get(classNameId);
+			}
+
+			fromIndex = _assetCategoryModelsMap.size() * pageSize;
+			toIndex = (_assetCategoryModelsMap.size() + 1) * pageSize;
+
+			pickedAssetCategoryModels = assetCategoryModels.subList(
+				fromIndex, toIndex);
+		}
+
+		_assetCategoryModelsMap.put(classNameId, pickedAssetCategoryModels);
+
+		return pickedAssetCategoryModels;
+	}
+
+	private List<AssetTagModel> _pickAssetTagModels(
+		long classNameId, List<AssetTagModel> assetTagModels) {
+
+		int fromIndex = 0;
+		int toIndex = 0;
+
+		int pageSize =
+			assetTagModels.size() /
+				BenchmarksPropsValues.MAX_ASSET_ENTRY_DATA_TYPE_COUNT;
+
+		List<AssetTagModel> pickedAssetTagModels = new ArrayList<>();
+
+		if (_assetTagModelsMap.size() == 0) {
+			fromIndex = _assetTagModelsMap.size() * pageSize;
+			toIndex = (_assetTagModelsMap.size() + 1) * pageSize;
+
+			pickedAssetTagModels = assetTagModels.subList(fromIndex, toIndex);
+		}
+		else if ((_assetTagModelsMap.size() - 1) <
+					BenchmarksPropsValues.MAX_ASSET_ENTRY_DATA_TYPE_COUNT) {
+
+			if (_assetTagModelsMap.containsKey(classNameId)) {
+				return _assetTagModelsMap.get(classNameId);
+			}
+
+			fromIndex = _assetTagModelsMap.size() * pageSize;
+			toIndex = (_assetTagModelsMap.size() + 1) * pageSize;
+
+			pickedAssetTagModels = assetTagModels.subList(fromIndex, toIndex);
+		}
+
+		_assetTagModelsMap.put(classNameId, pickedAssetTagModels);
+
+		return pickedAssetTagModels;
+	}
+
 	private String _readFile(String resourceName) throws Exception {
 		List<String> lines = new ArrayList<>();
 
@@ -4971,18 +4980,15 @@ public class DataFactory {
 	private final long _accountId;
 	private RoleModel _administratorRoleModel;
 	private Map<Long, SimpleCounter>[] _assetCategoryCounters;
-	private Map<Long, List<AssetCategoryModel>>[] _assetCategoryModelsMaps =
-		(Map<Long, List<AssetCategoryModel>>[])
-			new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-	private final long[] _assetClassNameIds;
+	private final Map<Long, List<AssetCategoryModel>> _assetCategoryModelsMap =
+		new HashMap<>();
 	private final Map<Long, Integer> _assetClassNameIdsIndexes =
 		new HashMap<>();
 	private final Map<Long, Integer> _assetPublisherQueryStartIndexes =
 		new HashMap<>();
 	private Map<Long, SimpleCounter>[] _assetTagCounters;
-	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps =
-		(Map<Long, List<AssetTagModel>>[])
-			new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
+	private final Map<Long, List<AssetTagModel>> _assetTagModelsMap =
+		new HashMap<>();
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();
 	private final long _companyId;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
@@ -1,4 +1,4 @@
-<#list dataFactory.assetVocabularyModels as assetVocabularyModel>
+<#list dataFactory.newAssetVocabularyModels(dataFactory.newDefaultAssetVocabularyModel()) as assetVocabularyModel>
 	${dataFactory.toInsertSQL(assetVocabularyModel)}
 </#list>
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
@@ -1,11 +1,1 @@
-<#list dataFactory.newAssetVocabularyModels(dataFactory.newDefaultAssetVocabularyModel()) as assetVocabularyModel>
-	${dataFactory.toInsertSQL(assetVocabularyModel)}
-</#list>
-
-<#list dataFactory.newAssetCategoryModels() as assetCategoryModel>
-	${dataFactory.toInsertSQL(assetCategoryModel)}
-</#list>
-
-<#list dataFactory.newAssetTagModels() as assetTagModel>
-	${dataFactory.toInsertSQL(assetTagModel)}
-</#list>
+${dataFactory.toInsertSQL(dataFactory.newDefaultAssetVocabularyModel())}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
@@ -2,7 +2,7 @@
 	${dataFactory.toInsertSQL(assetVocabularyModel)}
 </#list>
 
-<#list dataFactory.assetCategoryModels as assetCategoryModel>
+<#list dataFactory.newAssetCategoryModels() as assetCategoryModel>
 	${dataFactory.toInsertSQL(assetCategoryModel)}
 </#list>
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
@@ -6,6 +6,6 @@
 	${dataFactory.toInsertSQL(assetCategoryModel)}
 </#list>
 
-<#list dataFactory.assetTagModels as assetTagModel>
+<#list dataFactory.newAssetTagModels() as assetTagModel>
 	${dataFactory.toInsertSQL(assetTagModel)}
 </#list>

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset_publisher.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset_publisher.ftl
@@ -7,7 +7,7 @@
 	${dataFactory.toInsertSQL(assetVocabularyModel)}
 </#list>
 
-<#list dataFactory.newAssetCategoryModels(groupId) as assetCategoryModel>
+<#list dataFactory.newAssetCategoryModels(groupId, assetVocabularyModels) as assetCategoryModel>
 	${dataFactory.toInsertSQL(assetCategoryModel)}
 </#list>
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset_publisher.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset_publisher.ftl
@@ -1,4 +1,19 @@
-<#assign pageCounts = dataFactory.getSequence(dataFactory.maxAssetPublisherPageCount) />
+<#assign
+	assetVocabularyModels = dataFactory.newAssetVocabularyModels(groupId)
+	pageCounts = dataFactory.getSequence(dataFactory.maxAssetPublisherPageCount)
+/>
+
+<#list assetVocabularyModels as assetVocabularyModel>
+	${dataFactory.toInsertSQL(assetVocabularyModel)}
+</#list>
+
+<#list dataFactory.newAssetCategoryModels(groupId) as assetCategoryModel>
+	${dataFactory.toInsertSQL(assetCategoryModel)}
+</#list>
+
+<#list dataFactory.newAssetTagModels(groupId) as assetTagModel>
+	${dataFactory.toInsertSQL(assetTagModel)}
+</#list>
 
 <#list pageCounts as pageCount>
 	<#assign

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset_publisher.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset_publisher.ftl
@@ -1,5 +1,7 @@
 <#assign
 	assetVocabularyModels = dataFactory.newAssetVocabularyModels(groupId)
+	assetCategoryModels = dataFactory.newAssetCategoryModels(groupId, assetVocabularyModels)
+	assetTagModels = dataFactory.newAssetTagModels(groupId)
 	pageCounts = dataFactory.getSequence(dataFactory.maxAssetPublisherPageCount)
 />
 
@@ -7,13 +9,19 @@
 	${dataFactory.toInsertSQL(assetVocabularyModel)}
 </#list>
 
-<#list dataFactory.newAssetCategoryModels(groupId, assetVocabularyModels) as assetCategoryModel>
+<#list assetCategoryModels as assetCategoryModel>
 	${dataFactory.toInsertSQL(assetCategoryModel)}
 </#list>
 
-<#list dataFactory.newAssetTagModels(groupId) as assetTagModel>
+<#list assetTagModels as assetTagModel>
 	${dataFactory.toInsertSQL(assetTagModel)}
 </#list>
+
+<#include "blogs.ftl">
+
+<#include "journal_article.ftl">
+
+<#include "wiki.ftl">
 
 <#list pageCounts as pageCount>
 	<#assign

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset_publisher.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset_publisher.ftl
@@ -40,5 +40,15 @@
 		${dataFactory.toInsertSQL(portletPreferencesModel)}
 	</#list>
 
-	${dataFactory.toInsertSQL(dataFactory.newPortletPreferencesModel(layoutModel.plid, groupId, portletId, pageCount))}
+	<#if pageCount = 1>
+		${dataFactory.toInsertSQL(dataFactory.newPortletPreferencesModel(layoutModel.plid, portletId))}
+	<#elseif pageCount % 2 = 0>
+		<#assign nextAssetTagModels = dataFactory.getNextAssetTagModels([journalArticleAssetTagModels, blogAssetTagModels, wikiAssetTagModels]) />
+
+		${dataFactory.toInsertSQL(dataFactory.newPortletPreferencesModel(layoutModel.plid, groupId, portletId, pageCount, nextAssetTagModels))}
+	<#else>
+		<#assign nextAssetCategoryModels = dataFactory.getNextAssetCategoryModels([journalArticleAssetCategoryModels, blogAssetCategoryModels, wikiAssetCategoryModels]) />
+
+		${dataFactory.toInsertSQL(dataFactory.newPortletPreferencesModel(layoutModel.plid, groupId, portletId, pageCount, nextAssetCategoryModels))}
+	</#if>
 </#list>

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/blogs.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/blogs.ftl
@@ -14,7 +14,8 @@
 	${dataFactory.toInsertSQL(dataFactory.newMBDiscussionAssetEntryModel(blogsEntryModel))}
 
 	<@insertAssetEntry
-		_categoryAndTag=true
+		_assetCategoryModels=assetCategoryModels
+		_assetTagModels=assetTagModels
 		_entry=blogsEntryModel
 	/>
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/blogs.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/blogs.ftl
@@ -1,4 +1,10 @@
-<#assign blogsEntryModels = dataFactory.newBlogsEntryModels(groupId) />
+<#assign
+	blogAssetCategoryModels = dataFactory.pickAssetCategoryModels(assetCategoryModels, 2)
+
+	blogAssetTagModels = dataFactory.pickAssetTagModels(assetTagModels, 2)
+
+	blogsEntryModels = dataFactory.newBlogsEntryModels(groupId)
+/>
 
 <#list blogsEntryModels as blogsEntryModel>
 	${dataFactory.toInsertSQL(blogsEntryModel)}
@@ -14,8 +20,8 @@
 	${dataFactory.toInsertSQL(dataFactory.newMBDiscussionAssetEntryModel(blogsEntryModel))}
 
 	<@insertAssetEntry
-		_assetCategoryModels=assetCategoryModels
-		_assetTagModels=assetTagModels
+		_assetCategoryModels=blogAssetCategoryModels
+		_assetTagModels=blogAssetTagModels
 		_entry=blogsEntryModel
 	/>
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
@@ -15,19 +15,13 @@
 
 	<#include "asset_publisher.ftl">
 
-	<#include "blogs.ftl">
-
 	<#include "ddl.ftl">
-
-	<#include "journal_article.ftl">
 
 	<#include "fragment.ftl">
 
 	<#include "mb.ftl">
 
 	<#include "users.ftl">
-
-	<#include "wiki.ftl">
 
 	<@insertDLFolder
 		_ddmStructureId=dataFactory.defaultDLDDMStructureId

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/journal_article.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/journal_article.ftl
@@ -51,7 +51,8 @@
 
 			<#if versionCount = dataFactory.maxJournalArticleVersionCount>
 				<@insertAssetEntry
-					_categoryAndTag=true
+					_assetCategoryModels=assetCategoryModels
+					_assetTagModels=assetTagModels
 					_entry=dataFactory.newObjectValuePair(journalArticleModel, journalArticleLocalizationModel)
 				/>
 			</#if>

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/journal_article.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/journal_article.ftl
@@ -1,4 +1,8 @@
 <#assign
+	journalArticleAssetCategoryModels = dataFactory.pickAssetCategoryModels(assetCategoryModels, 1)
+
+	journalArticleAssetTagModels = dataFactory.pickAssetTagModels(assetTagModels, 1)
+
 	journalArticlePageCounts = dataFactory.getSequence(dataFactory.maxJournalArticlePageCount)
 
 	resourcePermissionModels = dataFactory.newResourcePermissionModels("com.liferay.journal", groupId)
@@ -51,8 +55,8 @@
 
 			<#if versionCount = dataFactory.maxJournalArticleVersionCount>
 				<@insertAssetEntry
-					_assetCategoryModels=assetCategoryModels
-					_assetTagModels=assetTagModels
+					_assetCategoryModels=journalArticleAssetCategoryModels
+					_assetTagModels=journalArticleAssetTagModels
 					_entry=dataFactory.newObjectValuePair(journalArticleModel, journalArticleLocalizationModel)
 				/>
 			</#if>

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/macro.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/macro.ftl
@@ -2,22 +2,25 @@
 
 <#macro insertAssetEntry
 	_entry
-	_categoryAndTag = false
+	_assetCategoryModels = {}
+	_assetTagModels = {}
 >
 	<#local assetEntryModel = dataFactory.newAssetEntryModel(_entry)>
 
 	${dataFactory.toInsertSQL(assetEntryModel)}
 
-	<#if _categoryAndTag>
-		<#local assetCategoryIds = dataFactory.getAssetCategoryIds(assetEntryModel)>
+	<#if (_assetCategoryModels?size > 0)>
+		<#local assetCategoryIds = dataFactory.getAssetCategoryIds(assetEntryModel, _assetCategoryModels)>
 
 		<#list assetCategoryIds as assetCategoryId>
 			<#local assetEntryAssetCategoryRelId = dataFactory.getCounterNext()>
 
 			insert into AssetEntryAssetCategoryRel values (0, 0, ${assetEntryAssetCategoryRelId}, ${assetEntryModel.companyId}, ${assetEntryModel.entryId}, ${assetCategoryId}, 0);
 		</#list>
+	</#if>
 
-		<#local assetTagIds = dataFactory.getAssetTagIds(assetEntryModel)>
+	<#if (_assetTagModels?size > 0)>
+		<#local assetTagIds = dataFactory.getAssetTagIds(assetEntryModel, _assetTagModels)>
 
 		<#list assetTagIds as assetTagId>
 			${dataFactory.toInsertSQL("AssetEntries_AssetTags", assetEntryModel.companyId, assetEntryModel.entryId, assetTagId)}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/wiki.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/wiki.ftl
@@ -15,7 +15,8 @@
 		${dataFactory.toInsertSQL(dataFactory.newWikiPageResourceModel(wikiPageModel))}
 
 		<@insertAssetEntry
-			_categoryAndTag=true
+			_assetCategoryModels=assetCategoryModels
+			_assetTagModels=assetTagModels
 			_entry=wikiPageModel
 		/>
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/wiki.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/wiki.ftl
@@ -1,4 +1,10 @@
-<#assign wikiNodeModels = dataFactory.newWikiNodeModels(groupId) />
+<#assign
+	wikiAssetCategoryModels = dataFactory.pickAssetCategoryModels(assetCategoryModels, 3)
+
+	wikiAssetTagModels = dataFactory.pickAssetTagModels(assetTagModels, 3)
+
+	wikiNodeModels = dataFactory.newWikiNodeModels(groupId)
+/>
 
 <#list wikiNodeModels as wikiNodeModel>
 	${dataFactory.toInsertSQL(wikiNodeModel)}
@@ -15,8 +21,8 @@
 		${dataFactory.toInsertSQL(dataFactory.newWikiPageResourceModel(wikiPageModel))}
 
 		<@insertAssetEntry
-			_assetCategoryModels=assetCategoryModels
-			_assetTagModels=assetTagModels
+			_assetCategoryModels=wikiAssetCategoryModels
+			_assetTagModels=wikiAssetTagModels
 			_entry=wikiPageModel
 		/>
 

--- a/modules/util/portal-tools-sample-sql-builder/src/test/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilderTest.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/test/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilderTest.java
@@ -127,6 +127,8 @@ public class SampleSQLBuilderTest {
 		properties.put(BenchmarksPropsKeys.DB_TYPE, "hypersonic");
 		properties.put(BenchmarksPropsKeys.MAX_ASSET_CATEGORY_COUNT, "1");
 		properties.put(
+			BenchmarksPropsKeys.MAX_ASSET_ENTRY_DATA_TYPE_COUNT, "3");
+		properties.put(
 			BenchmarksPropsKeys.MAX_ASSET_ENTRY_TO_ASSET_CATEGORY_COUNT, "1");
 		properties.put(
 			BenchmarksPropsKeys.MAX_ASSET_ENTRY_TO_ASSET_TAG_COUNT, "1");


### PR DESCRIPTION
Hi @dantewang @tinatian

In this pull, I removed the classNameId array which is used to distribute categories and tags to specific entries, and also removed AssetPublisher related maps.
`_assetClassNameIds = new long[] {
			getClassNameId(BlogsEntry.class),
			getClassNameId(JournalArticle.class), getClassNameId(WikiPage.class)
		};
`

So after this pull these parts can be removed from the BaseDataFactory:
https://github.com/dantewang/liferay-portal/blob/6acb42f7cc40c0b9819413ea39ab4be9207044c9/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BaseDataFactory.java#L180~L185

https://github.com/dantewang/liferay-portal/blob/6acb42f7cc40c0b9819413ea39ab4be9207044c9/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BaseDataFactory.java#L231~L233

However, if we still want to move the data like _classNameModels https://github.com/dantewang/liferay-portal/blob/6acb42f7cc40c0b9819413ea39ab4be9207044c9/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BaseDataFactory.java#L196~L213 out of the BaseDataFactory, we still need additional changes please see this pull:https://github.com/dantewang/liferay-portal/pull/1816

Lily



https://github.com/tinatian/liferay-portal/pull/1937#issuecomment-673891531