### PR TITLE
[Bug] LPS-103369

### DIFF
--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/i18n/test/I18nFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/i18n/test/I18nFilterTest.java
@@ -97,7 +97,7 @@ public class I18nFilterTest {
 		throws Exception {
 
 		Assert.assertEquals(
-			LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+			LocaleUtil.toLanguageId(LocaleUtil.US),
 			_getPrependI18nLanguageId(
 				3, LocaleUtil.US, LocaleUtil.SPAIN, LocaleUtil.US));
 	}
@@ -107,7 +107,7 @@ public class I18nFilterTest {
 		throws Exception {
 
 		Assert.assertEquals(
-			LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+			LocaleUtil.toLanguageId(LocaleUtil.US),
 			_getPrependI18nLanguageId(
 				3, LocaleUtil.US, LocaleUtil.SPAIN, null));
 	}
@@ -117,7 +117,7 @@ public class I18nFilterTest {
 		throws Exception {
 
 		Assert.assertEquals(
-			LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+			LocaleUtil.toLanguageId(LocaleUtil.US),
 			_getPrependI18nLanguageId(
 				3, LocaleUtil.US, LocaleUtil.SPAIN, LocaleUtil.SPAIN));
 	}

--- a/portal-impl/src/com/liferay/portal/servlet/filters/i18n/I18nFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/i18n/I18nFilter.java
@@ -334,7 +334,7 @@ public class I18nFilter extends BasePortalFilter {
 					return null;
 				}
 
-				return requestedLanguageId;
+				return userLanguageId;
 			}
 
 			return prependIfRequestedLocaleDiffersFromDefaultLocale(

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -2569,8 +2569,18 @@ public class PortalImpl implements Portal {
 
 		String portalURL = getPortalURL(httpServletRequest);
 
-		return portalURL + _pathContext +
-			getRelativeHomeURL(httpServletRequest);
+		String i18NLanguageId = (String)httpServletRequest.getAttribute(
+			WebKeys.I18N_LANGUAGE_ID);
+
+		if (i18NLanguageId == null) {
+			return StringBundler.concat(
+				portalURL, _pathContext,
+				getRelativeHomeURL(httpServletRequest));
+		}
+
+		return StringBundler.concat(
+			portalURL, _pathContext, "/", i18NLanguageId,
+			getRelativeHomeURL(httpServletRequest));
 	}
 
 	@Override

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -2824,7 +2824,7 @@
     # Set this to 2 if the locale is automatically prepended to every URL. This
     # means that each URL points to just one language.
     #
-    # Set this to 3 if the locale is automatically prepended to a URL when the
+    # Set this to 3 if user locale is automatically prepended to a URL when the
     # requested locale is not the default user locale. In the case of guest
     # users, the behavior is the same as having a value of 1.
     #


### PR DESCRIPTION
@dantewang, I add the last commit to solve the below [issue](https://github.com/dantewang/liferay-portal/pull/1809#issuecomment-732059125). 

1. Set virtual.hosts.default.site.name= in portal-ext.
2. Login as Test user whose preferred language is en_US.
3. Open URL http://localhost:8080/web/guest/home.
4. Open URL http://localhost:8080/zh_CN/.
Result: URL change to http://localhost:8080/en/web/guest and page still displays in English. This is wrong.

The property virtual.hosts.default.site.name explanation
If this property is not set, then the default URL(http://localhost:8080) may be http://localhost:8080/web/guest/home.

When using http://localhost:8080/zh_CN/, during I18nServlet handle twice, it will use homeURL http://localhost:8080/web/guest and this will be handled by I18nFilter. Actually, the logic shouldn't be handled by I18nFilter if URL includes locale. And homeURL should be http://localhost:8080/zh_CN/web/guest.