### PR TITLE
Lps 83275 pr 929

### DIFF
--- a/benchmarks/benchmarks.properties
+++ b/benchmarks/benchmarks.properties
@@ -26,6 +26,11 @@
     #sample.sql.db.type=sqlserver
     #sample.sql.db.type=sybase
 
+	#
+    # Specify whether enable search bar on a new site
+    #
+    sample.sql.enable.search.bar=false
+
     #
     # Specify the number of asset categories to generate per asset vocabulary.
     #

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsKeys.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsKeys.java
@@ -21,6 +21,9 @@ public interface BenchmarksPropsKeys {
 
 	public static final String DB_TYPE = "sample.sql.db.type";
 
+	public static final String ENABLE_SEARCH_BAR =
+		"sample.sql.enable.search.bar";
+
 	public static final String MAX_ASSET_CATEGORY_COUNT =
 		"sample.sql.max.asset.category.count";
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
@@ -43,6 +43,9 @@ public class BenchmarksPropsValues {
 		StringUtil.toUpperCase(
 			PropertiesHolder._get(BenchmarksPropsKeys.DB_TYPE)));
 
+	public static final boolean ENABLE_SEARCH_BAR = GetterUtil.getBoolean(
+		PropertiesHolder._get(BenchmarksPropsKeys.ENABLE_SEARCH_BAR));
+
 	public static final int MAX_ASSET_CATEGORY_COUNT = GetterUtil.getInteger(
 		PropertiesHolder._get(BenchmarksPropsKeys.MAX_ASSET_CATEGORY_COUNT));
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -524,6 +524,10 @@ public class DataFactory {
 		return getClassNameId(DLFileEntry.class);
 	}
 
+	public boolean getEnableSearchBar() {
+		return BenchmarksPropsValues.ENABLE_SEARCH_BAR;
+	}
+
 	public long getJournalArticleClassNameId() {
 		return getClassNameId(JournalArticle.class);
 	}
@@ -3594,6 +3598,110 @@ public class DataFactory {
 		return newUserModel(
 			_sampleUserId, _SAMPLE_USER_NAME, _SAMPLE_USER_NAME,
 			_SAMPLE_USER_NAME, false);
+	}
+
+	public LayoutModel newSearchLayoutModel(long groupId) {
+		SimpleCounter simpleCounter = _layoutCounters.get(groupId);
+		String prefix = "com_liferay_portal_search_web";
+
+		StringBundler column1SB = new StringBundler(4);
+
+		column1SB.append(prefix);
+		column1SB.append("_search_bar_portlet_SearchBarPortlet,");
+		column1SB.append(prefix);
+		column1SB.append("_suggestions_portlet_SuggestionsPortlet,");
+
+		StringBundler column2SB = new StringBundler(14);
+
+		column2SB.append(prefix);
+		column2SB.append("_site_facet_portlet_SiteFacetPortlet,");
+		column2SB.append(prefix);
+		column2SB.append("_type_facet_portlet_TypeFacetPortlet,");
+		column2SB.append(prefix);
+		column2SB.append("_tag_facet_portlet_TagFacetPortlet,");
+		column2SB.append(prefix);
+		column2SB.append("_category_facet_portlet_CategoryFacetPortlet,");
+		column2SB.append(prefix);
+		column2SB.append("_folder_facet_portlet_FolderFacetPortlet,");
+		column2SB.append(prefix);
+		column2SB.append("_user_facet_portlet_UserFacetPortlet,");
+		column2SB.append(prefix);
+		column2SB.append("_modified_facet_portlet_ModifiedFacetPortlet,");
+
+		StringBundler column3SB = new StringBundler(4);
+
+		column3SB.append(prefix);
+		column3SB.append("_search_results_portlet_SearchResultsPortlet,");
+		column3SB.append(prefix);
+		column3SB.append("_search_options_portlet_SearchOptionsPortlet,");
+
+		if (simpleCounter == null) {
+			simpleCounter = new SimpleCounter();
+
+			_layoutCounters.put(groupId, simpleCounter);
+		}
+
+		LayoutModel layoutModel = new LayoutModelImpl();
+
+		// UUID
+
+		layoutModel.setUuid(SequentialUUID.generate());
+
+		// PK fields
+
+		layoutModel.setPlid(_counter.get());
+
+		// Group instance
+
+		layoutModel.setGroupId(groupId);
+
+		// Audit fields
+
+		layoutModel.setCompanyId(_companyId);
+		layoutModel.setUserId(_sampleUserId);
+		layoutModel.setUserName(_SAMPLE_USER_NAME);
+		layoutModel.setCreateDate(new Date());
+		layoutModel.setModifiedDate(new Date());
+
+		// Other fields
+
+		layoutModel.setLayoutId(simpleCounter.get());
+		layoutModel.setName(
+			"<?xml version=\"1.0\"?><root><name>search</name></root>");
+		layoutModel.setType(LayoutConstants.TYPE_PORTLET);
+		layoutModel.setFriendlyURL(StringPool.FORWARD_SLASH + "search");
+
+		UnicodeProperties typeSettingsUnicodeProperties = new UnicodeProperties(
+			true);
+
+		typeSettingsUnicodeProperties.setProperty(
+			LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID, "1_2_columns_i");
+		typeSettingsUnicodeProperties.setProperty(
+			"column-1", column1SB.toString());
+		typeSettingsUnicodeProperties.setProperty(
+			"column-2", column2SB.toString());
+		typeSettingsUnicodeProperties.setProperty(
+			"column-3", column3SB.toString());
+		typeSettingsUnicodeProperties.setProperty(
+			"column-1-customizable", "false");
+		typeSettingsUnicodeProperties.setProperty(
+			"column-2-customizable", "false");
+		typeSettingsUnicodeProperties.setProperty(
+			"column-3-customizable", "false");
+		typeSettingsUnicodeProperties.setProperty(
+			LayoutConstants.CUSTOMIZABLE_LAYOUT, "false");
+		typeSettingsUnicodeProperties.setProperty("layoutUpdateable", "true");
+		typeSettingsUnicodeProperties.setProperty("merge-fail-count", "0");
+		typeSettingsUnicodeProperties.setProperty("privateLayout", "true");
+
+		String typeSettings = StringUtil.replace(
+			typeSettingsUnicodeProperties.toString(), '\n', "\\n");
+
+		layoutModel.setTypeSettings(typeSettings);
+
+		layoutModel.setLastPublishDate(new Date());
+
+		return layoutModel;
 	}
 
 	public SocialActivityModel newSocialActivityModel(

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
@@ -44,5 +44,9 @@
 
 	<@insertGroup _groupModel=groupModel />
 
+	<#if dataFactory.enableSearchBar>
+		<@insertLayout _layoutModel=dataFactory.newSearchLayoutModel(groupId) />
+	</#if>
+
 	${csvFileWriter.write("repository", groupId + ", " + groupModel.name + "\n")}
 </#list>

--- a/modules/util/portal-tools-sample-sql-builder/src/test/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilderTest.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/test/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilderTest.java
@@ -125,6 +125,7 @@ public class SampleSQLBuilderTest {
 
 	private void _initProperties(Properties properties, String outputDir) {
 		properties.put(BenchmarksPropsKeys.DB_TYPE, "hypersonic");
+		properties.put(BenchmarksPropsKeys.ENABLE_SEARCH_BAR, "true");
 		properties.put(BenchmarksPropsKeys.MAX_ASSET_CATEGORY_COUNT, "1");
 		properties.put(
 			BenchmarksPropsKeys.MAX_ASSET_ENTRY_TO_ASSET_CATEGORY_COUNT, "1");


### PR DESCRIPTION
Hi @dantewang and @tinatian

This pull aims to enable the search bar for the site created by SampleSQLBuilder by creating a page with the name "search" and template "search".

Compare with the origin changes in https://github.com/tinatian/liferay-portal/pull/929, I add a property to control enable/disable the search bar. We can disable the search bar in our daily performance tests as enable the search bar we can see regression on our test cases (please see the comment: https://github.com/tinatian/liferay-portal/pull/929#issue-200267551), but search team needs the search bar to do their performance tests.

Regards
Lily