### PR TITLE
[Bug] LPS-83768

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/background/task/DDMStructureBackgroundTask.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/background/task/DDMStructureBackgroundTask.java
@@ -106,6 +106,11 @@ public class DDMStructureBackgroundTask implements BackgroundTask {
 	}
 
 	@Override
+	public Date getModifiedDate() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public String getName() {
 		throw new UnsupportedOperationException();
 	}

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskImpl.java
@@ -116,6 +116,11 @@ public class BackgroundTaskImpl implements BackgroundTask {
 	}
 
 	@Override
+	public Date getModifiedDate() {
+		return _backgroundTask.getModifiedDate();
+	}
+
+	@Override
 	public String getName() {
 		return _backgroundTask.getName();
 	}

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.background.task.internal.messaging;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.background.task.internal.lock.BackgroundTaskLockHelper;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
@@ -23,7 +24,12 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Michael C. Han
@@ -55,16 +61,18 @@ public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 
 		int status = (Integer)message.get("status");
 
+		long backgroundTaskId = (Long)message.get(
+			BackgroundTaskConstants.BACKGROUND_TASK_ID);
+
 		if ((status == BackgroundTaskConstants.STATUS_CANCELLED) ||
 			(status == BackgroundTaskConstants.STATUS_FAILED) ||
 			(status == BackgroundTaskConstants.STATUS_SUCCESSFUL)) {
 
+			_queuedBackgroundTaskIds.remove(backgroundTaskId);
+
 			_executeQueuedBackgroundTasks(taskExecutorClassName);
 		}
 		else if (status == BackgroundTaskConstants.STATUS_QUEUED) {
-			long backgroundTaskId = (Long)message.get(
-				BackgroundTaskConstants.BACKGROUND_TASK_ID);
-
 			BackgroundTask backgroundTask =
 				_backgroundTaskManager.fetchBackgroundTask(backgroundTaskId);
 
@@ -97,8 +105,29 @@ public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 			return;
 		}
 
-		_backgroundTaskManager.resumeBackgroundTask(
-			backgroundTask.getBackgroundTaskId());
+		long backgroundTaskId = backgroundTask.getBackgroundTaskId();
+		Date modifiedDate = backgroundTask.getModifiedDate();
+
+		if (_queuedBackgroundTaskIds.containsKey(backgroundTaskId)) {
+			Date queuedModifiedDate = _queuedBackgroundTaskIds.get(
+				backgroundTaskId);
+
+			if (DateUtil.equals(queuedModifiedDate, modifiedDate)) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Background task ", backgroundTaskId,
+							" had been resumed. Stop the current task ",
+							"executed"));
+				}
+
+				return;
+			}
+		}
+
+		_queuedBackgroundTaskIds.put(backgroundTaskId, modifiedDate);
+
+		_backgroundTaskManager.resumeBackgroundTask(backgroundTaskId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -106,5 +135,6 @@ public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 
 	private final BackgroundTaskLockHelper _backgroundTaskLockHelper;
 	private final BackgroundTaskManager _backgroundTaskManager;
+	private final Map<Long, Date> _queuedBackgroundTaskIds = new HashMap<>();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/BackgroundTask.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/BackgroundTask.java
@@ -59,6 +59,8 @@ public interface BackgroundTask {
 
 	public BaseModel<?> getModel();
 
+	public Date getModifiedDate();
+
 	public String getName();
 
 	public String getServletContextNames();

--- a/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 9.0.0


### PR DESCRIPTION
@dantewang, please refer to the below cases:

**Case 1**: Message1 (backgroundTaskId:1), Message2 (backgroundTaskId:2)
1.A: When Message1 (status:4), Message2(status:3), Message1 firstly go to BackgroundTaskQueuingMessageListener, it will resume itself. And Message2 won't resume backgroundTaskId:1. 
1.B:  When Message1 (status:4), Message2(status:3), Message2 firstly go to BackgroundTaskQueuingMessageListener, it will resume backgroundTaskId:1. And Message1 won't resume backgroundTaskId:1 because its modifiedDate is equal.

**Case 2** : Message1 (backgroundTaskId:1), Message2 (backgroundTaskId:2). Message4 (backgroundTaskId:4)
When Message1 (status:3), Message2(status:4),Message4 (status:1). Message1 firstly go to BackgroundTaskQueuingMessageListener. It will resume backgroundTaskId:2, call it **Message3**. And Message2 won't resume backgroundTaskId:2. At that time,  **Message4** owns the lock and it let Message3 QUEUED again (it will update backgroundTaskId:2 modifiedDate). That it to say, Message3 (status:4), Message 4(status:3). When Message3 go to BackgroundTaskQueuingMessageListener, due to the modifiedDate is different, and it resume backgroundTaskId:2. And Message4 won't resume backgroundTaskId:2 because the modifiedDate is equal.

 