### PR TITLE
Lps 125421 1 4 v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,10 +33,11 @@
 /api
 /app.server.*.properties
 /baseline-reports
-/benchmarks/*.csv
 /benchmarks/*.sql
-/benchmarks/lib
-/benchmarks/log
+/benchmarks/benchmarks.*.properties
+/benchmarks/benchmarks-actual.properties
+/benchmarks/build
+/benchmarks/liferay
 /bin
 /build
 /build.*.properties

--- a/benchmarks/benchmarks.properties
+++ b/benchmarks/benchmarks.properties
@@ -208,7 +208,7 @@
     #
     # Specify the directory to output the generated SQL files.
     #
-    sample.sql.output.dir=.
+    sample.sql.output.dir=./generated
 
     #
     # Specify whether the output should be merged into a single SQL file.

--- a/benchmarks/benchmarks.properties
+++ b/benchmarks/benchmarks.properties
@@ -206,11 +206,6 @@
     sample.sql.output.csv.file.names=assetPublisher,blog,company,documentLibrary,dynamicDataList,fragment,layout,mbCategory,mbThread,repository,wiki
 
     #
-    # Specify the directory to output the generated SQL files.
-    #
-    sample.sql.output.dir=./generated
-
-    #
     # Specify whether the output should be merged into a single SQL file.
     #
     sample.sql.output.merge=true

--- a/benchmarks/benchmarks.properties
+++ b/benchmarks/benchmarks.properties
@@ -196,6 +196,11 @@
     sample.sql.max.wiki.page.count=10
 
     #
+    # Set the Bnd File Paths of Modules
+    #
+    sample.sql.module.bnd.files=${project.dir}/modules/apps/asset/asset-entry-rel-service/bnd.bnd,${project.dir}/modules/apps/blogs/blogs-service/bnd.bnd,${project.dir}/modules/apps/commerce/commerce-currency-service/bnd.bnd,${project.dir}/modules/apps/commerce/commerce-product-service/bnd.bnd,${project.dir}/modules/apps/dynamic-data-lists/dynamic-data-lists-service/bnd.bnd,${project.dir}/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd,${project.dir}/modules/apps/fragment/fragment-service/bnd.bnd,${project.dir}/modules/apps/friendly-url/friendly-url-service/bnd.bnd,${project.dir}/modules/apps/journal/journal-service/bnd.bnd,${project.dir}/modules/apps/layout/layout-page-template-service/bnd.bnd,${project.dir}/modules/apps/message-boards/message-boards-service/bnd.bnd,${project.dir}/modules/apps/subscription/subscription-service/bnd.bnd,${project.dir}/modules/apps/view-count/view-count-service/bnd.bnd,${project.dir}/modules/apps/wiki/wiki-service/bnd.bnd
+
+    #
     # Specify the optimize buffer size.
     #
     sample.sql.optimize.buffer.size=8192
@@ -224,27 +229,3 @@
     # Specify the virtual host name.
     #
     sample.sql.virtual.hostname=localhost
-
-##
-## Build Properties
-##
-
-    #
-    # Set the Path of Module Sql for SampleSQLBuilder Generate Data
-    #
-
-    portal.module.dir.list=\
-        ${project.dir}/modules/apps/blogs/blogs-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/commerce/commerce-currency-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/commerce/commerce-product-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/dynamic-data-lists/dynamic-data-lists-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/fragment/fragment-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/friendly-url/friendly-url-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/layout/layout-page-template-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/message-boards/message-boards-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/subscription/subscription-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/asset/asset-entry-rel-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/view-count/view-count-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/wiki/wiki-service/classes/META-INF/sql,\
-        ${project.dir}/modules/apps/journal/journal-service/classes/META-INF/sql

--- a/benchmarks/benchmarks.properties
+++ b/benchmarks/benchmarks.properties
@@ -229,3 +229,27 @@
     # Specify the virtual host name.
     #
     sample.sql.virtual.hostname=localhost
+
+##
+## Build Properties
+##
+
+    #
+    # Set the Path of Module Sql for SampleSQLBuilder Generate Data
+    #
+
+    portal.module.dir.list=\
+        ${project.dir}/modules/apps/blogs/blogs-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/commerce/commerce-currency-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/commerce/commerce-product-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/dynamic-data-lists/dynamic-data-lists-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/fragment/fragment-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/friendly-url/friendly-url-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/layout/layout-page-template-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/message-boards/message-boards-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/subscription/subscription-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/asset/asset-entry-rel-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/view-count/view-count-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/wiki/wiki-service/classes/META-INF/sql,\
+        ${project.dir}/modules/apps/journal/journal-service/classes/META-INF/sql

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -117,27 +117,32 @@
 		</for>
 
 		<if>
-			<equals arg1="${sample.sql.output.merge}" arg2="false" />
+			<isfalse value="${benchmark.usage}" />
 			<then>
-				<for param="sql-file-filename">
-					<path>
-						<fileset
-							dir="${sample.sql.output.dir}/output"
-							includes="*.sql"
-						/>
-					</path>
-					<sequential>
+				<if>
+					<equals arg1="${sample.sql.output.merge}" arg2="false" />
+					<then>
+						<for param="sql-file-filename">
+							<path>
+								<fileset
+									dir="${sample.sql.output.dir}/output"
+									includes="*.sql"
+								/>
+							</path>
+							<sequential>
+								<concat append="true" destfile="${sample-data-sql}">
+									<filelist dir="${sample.sql.output.dir}/output" files="@{sql-file-filename}" />
+								</concat>
+							</sequential>
+						</for>
+					</then>
+					<else>
 						<concat append="true" destfile="${sample-data-sql}">
-							<filelist dir="${sample.sql.output.dir}/output" files="@{sql-file-filename}" />
+							<filelist dir="${sample.sql.output.dir}" files="sample-${sample.sql.db.type}.sql" />
 						</concat>
-					</sequential>
-				</for>
+					</else>
+				</if>
 			</then>
-			<else>
-				<concat append="true" destfile="${sample-data-sql}">
-					<filelist dir="${sample.sql.output.dir}" files="sample-${sample.sql.db.type}.sql" />
-				</concat>
-			</else>
 		</if>
 	</target>
 

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -3,7 +3,24 @@
 <project basedir="." default="run" name="benchmarks">
 	<import file="../build-common.xml" />
 
-	<target name="build-sample-sql">
+	<property name="sample-data-sql" value="sample-data-${sample.sql.db.type}.sql" />
+	<property name="build-db-file" value="../sql/build.xml" />
+
+	<macrodef name="build-sql">
+		<attribute name="dir" />
+		<sequential>
+			<ant antfile="${build-db-file}" inheritall="false" target="build-db">
+				<property name="db.sql.dir" value="@{dir}" />
+			</ant>
+
+			<concat append="true" destfile="${sample-data-sql}">
+				<filelist dir="@{dir}/tables/" files="tables-${sample.sql.db.type}.sql" />
+				<filelist dir="@{dir}/indexes/" files="indexes-${sample.sql.db.type}.sql" />
+			</concat>
+		</sequential>
+	</macrodef>
+
+	<target depends="clean" name="build-sample-sql">
 		<gradle-execute dir="../modules/util/portal-tools-sample-sql-builder" task="jar" />
 
 		<path id="sample.sql.builder.classpath">
@@ -87,6 +104,41 @@
 			<sysproperty key="external-properties" value="com/liferay/portal/tools/dependencies/portal-tools.properties" />
 			<sysproperty key="sample-sql-properties" value="${sample.sql.properties.file}" />
 		</java>
+
+		<concat append="true" destfile="${sample-data-sql}">
+			<filelist dir="../sql/portal/" files="portal-${sample.sql.db.type}.sql" />
+			<filelist dir="../sql/indexes/" files="indexes-${sample.sql.db.type}.sql" />
+		</concat>
+
+		<for list="${portal.module.dir.list}" param="module">
+			<sequential>
+				<build-sql dir="@{module}" />
+			</sequential>
+		</for>
+
+		<if>
+			<equals arg1="${sample.sql.output.merge}" arg2="false" />
+			<then>
+				<for param="sql-file-filename">
+					<path>
+						<fileset
+							dir="${sample.sql.output.dir}/output"
+							includes="*.sql"
+						/>
+					</path>
+					<sequential>
+						<concat append="true" destfile="${sample-data-sql}">
+							<filelist dir="${sample.sql.output.dir}/output" files="@{sql-file-filename}" />
+						</concat>
+					</sequential>
+				</for>
+			</then>
+			<else>
+				<concat append="true" destfile="${sample-data-sql}">
+					<filelist dir="${sample.sql.output.dir}" files="sample-${sample.sql.db.type}.sql" />
+				</concat>
+			</else>
+		</if>
 	</target>
 
 	<target name="clean">

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -62,7 +62,7 @@
 			<path refid="project.classpath" />
 		</path>
 
-		<echoproperties prefix="sample.sql." destfile="benchmarks-merged.properties"/>
+		<echoproperties destfile="benchmarks-merged.properties" prefix="sample.sql." />
 
 		<java
 			classname="com.liferay.portal.tools.sample.sql.builder.SampleSQLBuilder"
@@ -126,7 +126,7 @@
 		<delete includeemptydirs="true">
 			<fileset
 				dir="."
-				includes="*.csv,*.sql, benchmarks-merged.properties, liferay/**, output/**,temp/**"
+				includes="*.sql, benchmarks-merged.properties, liferay/**, generated/**,temp/**"
 			/>
 		</delete>
 	</target>

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -4,16 +4,16 @@
 	<import file="../build-common.xml" />
 
 	<macrodef name="build-sql">
-		<attribute name="dir" />
+		<attribute name="sql.dir" />
 		<attribute name="output.sql.file" />
 		<sequential>
 			<ant antfile="../sql/build.xml" inheritall="false" target="build-db">
-				<property name="db.sql.dir" value="@{dir}" />
+				<property name="db.sql.dir" value="@{sql.dir}" />
 			</ant>
 
 			<concat append="true" destfile="@{output.sql.file}">
-				<filelist dir="@{dir}/tables/" files="tables-${sample.sql.db.type}.sql" />
-				<filelist dir="@{dir}/indexes/" files="indexes-${sample.sql.db.type}.sql" />
+				<filelist dir="@{sql.dir}/tables/" files="tables-${sample.sql.db.type}.sql" />
+				<filelist dir="@{sql.dir}/indexes/" files="indexes-${sample.sql.db.type}.sql" />
 			</concat>
 		</sequential>
 	</macrodef>
@@ -112,7 +112,7 @@
 
 		<for list="${portal.module.dir.list}" param="module">
 			<sequential>
-				<build-sql dir="@{module}" output.sql.file="${sample-data-sql}"/>
+				<build-sql sql.dir="@{module}" output.sql.file="${sample-data-sql}"/>
 			</sequential>
 		</for>
 

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -120,7 +120,9 @@
 				</if>
 			</then>
 		</if>
-		<echo>Here is the sql file contains all the data that SampleSQLBuilder generated: ${basedir}/${output.sql.file}</echo>
+		<echo>
+Sample SQL Build Successful
+Use ${basedir}/${output.sql.file} to insert into database.</echo>
 	</target>
 
 	<target name="clean">

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -116,12 +116,19 @@
 			</sequential>
 		</for>
 
+		<property name="sample.sql.create.single.file" value="true" />
+
 		<if>
-			<isfalse value="${benchmark.usage}" />
+			<istrue value="${sample.sql.create.single.file}" />
 			<then>
 				<if>
-					<equals arg1="${sample.sql.output.merge}" arg2="false" />
+					<istrue value="${sample.sql.output.merge}" />
 					<then>
+						<concat append="true" destfile="${sample-data-sql}">
+							<filelist dir="${sample.sql.output.dir}" files="sample-${sample.sql.db.type}.sql" />
+						</concat>
+					</then>
+					<else>
 						<for param="sql-file-filename">
 							<path>
 								<fileset
@@ -135,11 +142,6 @@
 								</concat>
 							</sequential>
 						</for>
-					</then>
-					<else>
-						<concat append="true" destfile="${sample-data-sql}">
-							<filelist dir="${sample.sql.output.dir}" files="sample-${sample.sql.db.type}.sql" />
-						</concat>
 					</else>
 				</if>
 			</then>

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -3,16 +3,15 @@
 <project basedir="." default="run" name="benchmarks">
 	<import file="../build-common.xml" />
 
-	<property name="sample-data-sql" value="sample-data-${sample.sql.db.type}.sql" />
-
 	<macrodef name="build-sql">
 		<attribute name="dir" />
+		<attribute name="output.sql.file" />
 		<sequential>
 			<ant antfile="../sql/build.xml" inheritall="false" target="build-db">
 				<property name="db.sql.dir" value="@{dir}" />
 			</ant>
 
-			<concat append="true" destfile="${sample-data-sql}">
+			<concat append="true" destfile="@{output.sql.file}">
 				<filelist dir="@{dir}/tables/" files="tables-${sample.sql.db.type}.sql" />
 				<filelist dir="@{dir}/indexes/" files="indexes-${sample.sql.db.type}.sql" />
 			</concat>
@@ -20,6 +19,8 @@
 	</macrodef>
 
 	<target depends="clean" name="build-sample-sql">
+		<property name="sample-data-sql" value="sample-data-${sample.sql.db.type}.sql" />
+
 		<gradle-execute dir="../modules/util/portal-tools-sample-sql-builder" task="jar" />
 
 		<path id="sample.sql.builder.classpath">
@@ -111,7 +112,7 @@
 
 		<for list="${portal.module.dir.list}" param="module">
 			<sequential>
-				<build-sql dir="@{module}" />
+				<build-sql dir="@{module}" output.sql.file="${sample-data-sql}"/>
 			</sequential>
 		</for>
 

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -77,32 +77,14 @@
 			<path refid="project.classpath" />
 		</path>
 
-		<beanshell>
-			InputStream inputStream = new FileInputStream("benchmarks.properties");
-			OutputStream outputStream = new FileOutputStream("benchmarks-merged.properties");
-
-			Properties properties = new Properties();
-
-			properties.load(inputStream);
-
-			for (String propertyKey : properties.stringPropertyNames()) {
-				properties.setProperty(propertyKey, project.getProperty(propertyKey));
-			}
-
-			properties.store(outputStream, "");
-
-			inputStream.close();
-			outputStream.close();
-		</beanshell>
-
-		<property name="sample.sql.properties.file" value="benchmarks-merged.properties" />
+		<echoproperties prefix="sample.sql." destfile="benchmarks-merged.properties"/>
 
 		<java
 			classname="com.liferay.portal.tools.sample.sql.builder.SampleSQLBuilder"
 			classpathref="sample.sql.builder.classpath"
 		>
 			<sysproperty key="external-properties" value="com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<sysproperty key="sample-sql-properties" value="${sample.sql.properties.file}" />
+			<sysproperty key="sample-sql-properties" value="benchmarks-merged.properties" />
 		</java>
 
 		<concat append="true" destfile="${output.sql.file}">

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -126,7 +126,7 @@
 		<delete includeemptydirs="true">
 			<fileset
 				dir="."
-				includes="*.csv,*.sql,benchmarks-actual.properties, benchmarks-merged.properties, liferay/**, output/**,temp/**"
+				includes="*.csv,*.sql, benchmarks-merged.properties, liferay/**, output/**,temp/**"
 			/>
 		</delete>
 	</target>

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -62,14 +62,14 @@
 			<path refid="project.classpath" />
 		</path>
 
-		<echoproperties destfile="benchmarks-merged.properties" prefix="sample.sql." />
+		<echoproperties destfile="benchmarks-actual.properties" prefix="sample.sql." />
 
 		<java
 			classname="com.liferay.portal.tools.sample.sql.builder.SampleSQLBuilder"
 			classpathref="sample.sql.builder.classpath"
 		>
 			<sysproperty key="external-properties" value="com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<sysproperty key="sample-sql-properties" value="${basedir}/benchmarks-merged.properties" />
+			<sysproperty key="sample-sql-properties" value="${basedir}/benchmarks-actual.properties" />
 		</java>
 
 		<concat append="true" destfile="${output.sql.file}">
@@ -129,7 +129,7 @@ Use ${basedir}/${output.sql.file} to insert into database.</echo>
 		<delete includeemptydirs="true">
 			<fileset
 				dir="."
-				includes="*.sql, benchmarks-merged.properties, liferay/**, generated/**,temp/**"
+				includes="*.sql, benchmarks-actual.properties, liferay/**, generated/**,temp/**"
 			/>
 		</delete>
 	</target>

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -60,7 +60,25 @@
 			<path refid="project.classpath" />
 		</path>
 
-		<property name="sample.sql.properties.file" value="${basedir}/benchmarks.properties" />
+		<beanshell>
+			InputStream inputStream = new FileInputStream("benchmarks.properties");
+			OutputStream outputStream = new FileOutputStream("benchmarks-merged.properties");
+
+			Properties properties = new Properties();
+
+			properties.load(inputStream);
+
+			for (String propertyKey : properties.stringPropertyNames()) {
+				properties.setProperty(propertyKey, project.getProperty(propertyKey));
+			}
+
+			properties.store(outputStream, "");
+
+			inputStream.close();
+			outputStream.close();
+		</beanshell>
+
+		<property name="sample.sql.properties.file" value="benchmarks-merged.properties" />
 
 		<java
 			classname="com.liferay.portal.tools.sample.sql.builder.SampleSQLBuilder"

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -93,7 +93,7 @@
 		<delete includeemptydirs="true">
 			<fileset
 				dir="."
-				includes="*.csv,*.sql,benchmarks-actual.properties,output/**,temp/**"
+				includes="*.csv,*.sql,benchmarks-actual.properties, benchmarks-merged.properties, liferay/**, output/**,temp/**"
 			/>
 		</delete>
 	</target>

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -120,6 +120,7 @@
 				</if>
 			</then>
 		</if>
+		<echo>Here is the sql file contains all the data that SampleSQLBuilder generated: ${basedir}/${output.sql.file}</echo>
 	</target>
 
 	<target name="clean">

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -130,7 +130,7 @@ Use ${basedir}/${output.sql.file} and sql files in ${sample.sql.output.dir} to i
 	<target name="clean">
 		<delete includeemptydirs="true">
 			<fileset
-				dir="."
+				dir="${basedir}"
 				includes="benchmarks-actual.properties, liferay/**, ${build.dir}/**, ${output.sql.file}"
 			/>
 		</delete>

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -4,11 +4,10 @@
 	<import file="../build-common.xml" />
 
 	<property name="build.dir" value="build" />
+	<property name="output.sql.file" value="sample-data-${sample.sql.db.type}.sql" />
 
 	<target depends="clean" name="build-sample-sql">
 		<property name="sample.sql.output.dir" value="${basedir}/${build.dir}" />
-
-		<property name="output.sql.file" value="sample-data-${sample.sql.db.type}.sql" />
 
 		<gradle-execute dir="../modules/util/portal-tools-sample-sql-builder" task="jar" />
 
@@ -132,7 +131,7 @@ Use ${basedir}/${output.sql.file} and sql files in ${sample.sql.output.dir} to i
 		<delete includeemptydirs="true">
 			<fileset
 				dir="."
-				includes="benchmarks-actual.properties, liferay/**, ${build.dir}/**"
+				includes="benchmarks-actual.properties, liferay/**, ${build.dir}/**, ${output.sql.file}"
 			/>
 		</delete>
 	</target>

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -3,21 +3,6 @@
 <project basedir="." default="run" name="benchmarks">
 	<import file="../build-common.xml" />
 
-	<macrodef name="build-sql">
-		<attribute name="sql.dir" />
-		<attribute name="output.sql.file" />
-		<sequential>
-			<ant antfile="../sql/build.xml" inheritall="false" target="build-db">
-				<property name="db.sql.dir" value="@{sql.dir}" />
-			</ant>
-
-			<concat append="true" destfile="@{output.sql.file}">
-				<filelist dir="@{sql.dir}/tables/" files="tables-${sample.sql.db.type}.sql" />
-				<filelist dir="@{sql.dir}/indexes/" files="indexes-${sample.sql.db.type}.sql" />
-			</concat>
-		</sequential>
-	</macrodef>
-
 	<target depends="clean" name="build-sample-sql">
 		<property name="output.sql.file" value="sample-data-${sample.sql.db.type}.sql" />
 
@@ -94,7 +79,14 @@
 
 		<for list="${portal.module.dir.list}" param="module">
 			<sequential>
-				<build-sql sql.dir="@{module}" output.sql.file="${output.sql.file}"/>
+				<ant antfile="../sql/build.xml" inheritall="false" target="build-db">
+					<property name="db.sql.dir" value="@{module}" />
+				</ant>
+
+				<concat append="true" destfile="${output.sql.file}">
+					<filelist dir="@{module}/tables/" files="tables-${sample.sql.db.type}.sql" />
+					<filelist dir="@{module}/indexes/" files="indexes-${sample.sql.db.type}.sql" />
+				</concat>
 			</sequential>
 		</for>
 

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -4,12 +4,11 @@
 	<import file="../build-common.xml" />
 
 	<property name="sample-data-sql" value="sample-data-${sample.sql.db.type}.sql" />
-	<property name="build-db-file" value="../sql/build.xml" />
 
 	<macrodef name="build-sql">
 		<attribute name="dir" />
 		<sequential>
-			<ant antfile="${build-db-file}" inheritall="false" target="build-db">
+			<ant antfile="../sql/build.xml" inheritall="false" target="build-db">
 				<property name="db.sql.dir" value="@{dir}" />
 			</ant>
 

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -69,7 +69,7 @@
 			classpathref="sample.sql.builder.classpath"
 		>
 			<sysproperty key="external-properties" value="com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<sysproperty key="sample-sql-properties" value="benchmarks-merged.properties" />
+			<sysproperty key="sample-sql-properties" value="${basedir}/benchmarks-merged.properties" />
 		</java>
 
 		<concat append="true" destfile="${output.sql.file}">

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -94,39 +94,38 @@
 			</sequential>
 		</for>
 
-		<property name="sample.sql.create.single.file" value="true" />
-
 		<if>
-			<istrue value="${sample.sql.create.single.file}" />
+			<istrue value="${sample.sql.output.merge}" />
 			<then>
-				<if>
-					<istrue value="${sample.sql.output.merge}" />
-					<then>
+				<for param="sql-file-filename">
+					<path>
+						<fileset
+							dir="${sample.sql.output.dir}"
+							excludes="misc.sql"
+							includes="*.sql"
+						/>
+					</path>
+					<sequential>
 						<concat append="true" destfile="${output.sql.file}">
-							<filelist dir="${sample.sql.output.dir}" files="sample-${sample.sql.db.type}.sql" />
+							<filelist dir="${sample.sql.output.dir}" files="@{sql-file-filename}" />
 						</concat>
-					</then>
-					<else>
-						<for param="sql-file-filename">
-							<path>
-								<fileset
-									dir="${sample.sql.output.dir}/output"
-									includes="*.sql"
-								/>
-							</path>
-							<sequential>
-								<concat append="true" destfile="${output.sql.file}">
-									<filelist dir="${sample.sql.output.dir}/output" files="@{sql-file-filename}" />
-								</concat>
-							</sequential>
-						</for>
-					</else>
-				</if>
-			</then>
-		</if>
-		<echo>
+					</sequential>
+				</for>
+
+				<concat append="true" destfile="${output.sql.file}">
+					<filelist dir="${sample.sql.output.dir}" files="misc.sql" />
+				</concat>
+
+				<echo>
 Sample SQL Build Successful
 Use ${basedir}/${output.sql.file} to insert into database.</echo>
+			</then>
+			<else>
+				<echo>
+Sample SQL Build Successful
+Use ${basedir}/${output.sql.file} and sql files in ${sample.sql.output.dir} to insert into database.</echo>
+			</else>
+		</if>
 	</target>
 
 	<target name="clean">

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -19,7 +19,7 @@
 	</macrodef>
 
 	<target depends="clean" name="build-sample-sql">
-		<property name="sample-data-sql" value="sample-data-${sample.sql.db.type}.sql" />
+		<property name="output.sql.file" value="sample-data-${sample.sql.db.type}.sql" />
 
 		<gradle-execute dir="../modules/util/portal-tools-sample-sql-builder" task="jar" />
 
@@ -105,14 +105,14 @@
 			<sysproperty key="sample-sql-properties" value="${sample.sql.properties.file}" />
 		</java>
 
-		<concat append="true" destfile="${sample-data-sql}">
+		<concat append="true" destfile="${output.sql.file}">
 			<filelist dir="../sql/portal/" files="portal-${sample.sql.db.type}.sql" />
 			<filelist dir="../sql/indexes/" files="indexes-${sample.sql.db.type}.sql" />
 		</concat>
 
 		<for list="${portal.module.dir.list}" param="module">
 			<sequential>
-				<build-sql sql.dir="@{module}" output.sql.file="${sample-data-sql}"/>
+				<build-sql sql.dir="@{module}" output.sql.file="${output.sql.file}"/>
 			</sequential>
 		</for>
 
@@ -124,7 +124,7 @@
 				<if>
 					<istrue value="${sample.sql.output.merge}" />
 					<then>
-						<concat append="true" destfile="${sample-data-sql}">
+						<concat append="true" destfile="${output.sql.file}">
 							<filelist dir="${sample.sql.output.dir}" files="sample-${sample.sql.db.type}.sql" />
 						</concat>
 					</then>
@@ -137,7 +137,7 @@
 								/>
 							</path>
 							<sequential>
-								<concat append="true" destfile="${sample-data-sql}">
+								<concat append="true" destfile="${output.sql.file}">
 									<filelist dir="${sample.sql.output.dir}/output" files="@{sql-file-filename}" />
 								</concat>
 							</sequential>

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -3,7 +3,11 @@
 <project basedir="." default="run" name="benchmarks">
 	<import file="../build-common.xml" />
 
+	<property name="build.dir" value="build" />
+
 	<target depends="clean" name="build-sample-sql">
+		<property name="sample.sql.output.dir" value="${basedir}/${build.dir}" />
+
 		<property name="output.sql.file" value="sample-data-${sample.sql.db.type}.sql" />
 
 		<gradle-execute dir="../modules/util/portal-tools-sample-sql-builder" task="jar" />
@@ -129,7 +133,7 @@ Use ${basedir}/${output.sql.file} to insert into database.</echo>
 		<delete includeemptydirs="true">
 			<fileset
 				dir="."
-				includes="*.sql, benchmarks-actual.properties, liferay/**, generated/**,temp/**"
+				includes="benchmarks-actual.properties, liferay/**, ${build.dir}/**"
 			/>
 		</delete>
 	</target>

--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -4,10 +4,11 @@
 	<import file="../build-common.xml" />
 
 	<property name="build.dir" value="build" />
-	<property name="output.sql.file" value="sample-data-${sample.sql.db.type}.sql" />
+	<property name="sample.sql.output.sql.file" value="${basedir}/sample-data-${sample.sql.db.type}.sql" />
 
 	<target depends="clean" name="build-sample-sql">
 		<property name="sample.sql.output.dir" value="${basedir}/${build.dir}" />
+		<property name="sample.sql.service.jars.dir" value="${project.dir}/tools/sdk/dist/" />
 
 		<gradle-execute dir="../modules/util/portal-tools-sample-sql-builder" task="jar" />
 
@@ -75,24 +76,6 @@
 			<sysproperty key="sample-sql-properties" value="${basedir}/benchmarks-actual.properties" />
 		</java>
 
-		<concat append="true" destfile="${output.sql.file}">
-			<filelist dir="../sql/portal/" files="portal-${sample.sql.db.type}.sql" />
-			<filelist dir="../sql/indexes/" files="indexes-${sample.sql.db.type}.sql" />
-		</concat>
-
-		<for list="${portal.module.dir.list}" param="module">
-			<sequential>
-				<ant antfile="../sql/build.xml" inheritall="false" target="build-db">
-					<property name="db.sql.dir" value="@{module}" />
-				</ant>
-
-				<concat append="true" destfile="${output.sql.file}">
-					<filelist dir="@{module}/tables/" files="tables-${sample.sql.db.type}.sql" />
-					<filelist dir="@{module}/indexes/" files="indexes-${sample.sql.db.type}.sql" />
-				</concat>
-			</sequential>
-		</for>
-
 		<if>
 			<istrue value="${sample.sql.output.merge}" />
 			<then>
@@ -105,24 +88,24 @@
 						/>
 					</path>
 					<sequential>
-						<concat append="true" destfile="${output.sql.file}">
+						<concat append="true" destfile="${sample.sql.output.sql.file}">
 							<filelist dir="${sample.sql.output.dir}" files="@{sql-file-filename}" />
 						</concat>
 					</sequential>
 				</for>
 
-				<concat append="true" destfile="${output.sql.file}">
+				<concat append="true" destfile="${sample.sql.output.sql.file}">
 					<filelist dir="${sample.sql.output.dir}" files="misc.sql" />
 				</concat>
 
 				<echo>
 Sample SQL Build Successful
-Use ${basedir}/${output.sql.file} to insert into database.</echo>
+Use ${sample.sql.output.sql.file} to insert into database.</echo>
 			</then>
 			<else>
 				<echo>
 Sample SQL Build Successful
-Use ${basedir}/${output.sql.file} and sql files in ${sample.sql.output.dir} to insert into database.</echo>
+Use ${sample.sql.output.sql.file} and sql files in ${sample.sql.output.dir} to insert into database.</echo>
 			</else>
 		</if>
 	</target>
@@ -131,7 +114,7 @@ Use ${basedir}/${output.sql.file} and sql files in ${sample.sql.output.dir} to i
 		<delete includeemptydirs="true">
 			<fileset
 				dir="${basedir}"
-				includes="benchmarks-actual.properties, liferay/**, ${build.dir}/**, ${output.sql.file}"
+				includes="benchmarks-actual.properties, liferay/**, ${build.dir}/**, ${sample.sql.output.sql.file}"
 			/>
 		</delete>
 	</target>

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsKeys.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsKeys.java
@@ -115,6 +115,8 @@ public interface BenchmarksPropsKeys {
 	public static final String MAX_WIKI_PAGE_COUNT =
 		"sample.sql.max.wiki.page.count";
 
+	public static final String MODULE_BND_FILES = "sample.sql.module.bnd.files";
+
 	public static final String OPTIMIZE_BUFFER_SIZE =
 		"sample.sql.optimize.buffer.size";
 
@@ -123,10 +125,14 @@ public interface BenchmarksPropsKeys {
 
 	public static final String OUTPUT_DIR = "sample.sql.output.dir";
 
+	public static final String OUTPUT_FILE = "sample.sql.output.sql.file";
+
 	public static final String SCRIPT = "sample.sql.script";
 
 	public static final String SEARCH_BAR_ENABLED =
 		"sample.sql.search.bar.enabled";
+
+	public static final String SERVICE_JARS_DIR = "sample.sql.service.jars.dir";
 
 	public static final String VIRTUAL_HOST_NAME =
 		"sample.sql.virtual.hostname";

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsKeys.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsKeys.java
@@ -123,8 +123,6 @@ public interface BenchmarksPropsKeys {
 
 	public static final String OUTPUT_DIR = "sample.sql.output.dir";
 
-	public static final String OUTPUT_MERGE = "sample.sql.output.merge";
-
 	public static final String SCRIPT = "sample.sql.script";
 
 	public static final String SEARCH_BAR_ENABLED =

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
@@ -157,9 +157,6 @@ public class BenchmarksPropsValues {
 	public static final String OUTPUT_DIR = PropertiesHolder._get(
 		BenchmarksPropsKeys.OUTPUT_DIR);
 
-	public static final boolean OUTPUT_MERGE = GetterUtil.getBoolean(
-		PropertiesHolder._get(BenchmarksPropsKeys.OUTPUT_MERGE));
-
 	public static final String SCRIPT = PropertiesHolder._get(
 		BenchmarksPropsKeys.SCRIPT);
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.tools.sample.sql.builder;
 
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -26,8 +24,6 @@ import java.io.Reader;
 
 import java.time.ZoneId;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -205,24 +201,6 @@ public class BenchmarksPropsValues {
 			}
 			catch (Exception exception) {
 				throw new ExceptionInInitializerError(exception);
-			}
-
-			List<String> propertyNames = new ArrayList<>(
-				properties.stringPropertyNames());
-
-			propertyNames.sort(null);
-
-			StringBundler sb = new StringBundler(propertyNames.size() * 4);
-
-			for (String propertyName : propertyNames) {
-				if (!propertyName.startsWith("sample.sql")) {
-					continue;
-				}
-
-				sb.append(propertyName);
-				sb.append(StringPool.EQUAL);
-				sb.append(properties.getProperty(propertyName));
-				sb.append(StringPool.NEW_LINE);
 			}
 
 			_properties = properties;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
@@ -36,9 +36,6 @@ import java.util.TimeZone;
  */
 public class BenchmarksPropsValues {
 
-	public static final String ACTUAL_PROPERTIES_CONTENT =
-		PropertiesHolder._ACTUAL_PROPERTIES_CONTENT;
-
 	public static final DBType DB_TYPE = DBType.valueOf(
 		StringUtil.toUpperCase(
 			PropertiesHolder._get(BenchmarksPropsKeys.DB_TYPE)));
@@ -182,8 +179,6 @@ public class BenchmarksPropsValues {
 			return _properties.getProperty(key);
 		}
 
-		private static final String _ACTUAL_PROPERTIES_CONTENT;
-
 		private static final Properties _properties;
 
 		static {
@@ -229,8 +224,6 @@ public class BenchmarksPropsValues {
 				sb.append(properties.getProperty(propertyName));
 				sb.append(StringPool.NEW_LINE);
 			}
-
-			_ACTUAL_PROPERTIES_CONTENT = sb.toString();
 
 			_properties = properties;
 		}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/BenchmarksPropsValues.java
@@ -148,6 +148,9 @@ public class BenchmarksPropsValues {
 	public static final int MAX_WIKI_PAGE_COUNT = GetterUtil.getInteger(
 		PropertiesHolder._get(BenchmarksPropsKeys.MAX_WIKI_PAGE_COUNT));
 
+	public static final String[] MODULE_BND_FILES = StringUtil.split(
+		PropertiesHolder._get(BenchmarksPropsKeys.MODULE_BND_FILES));
+
 	public static final int OPTIMIZE_BUFFER_SIZE = GetterUtil.getInteger(
 		PropertiesHolder._get(BenchmarksPropsKeys.OPTIMIZE_BUFFER_SIZE));
 
@@ -157,11 +160,17 @@ public class BenchmarksPropsValues {
 	public static final String OUTPUT_DIR = PropertiesHolder._get(
 		BenchmarksPropsKeys.OUTPUT_DIR);
 
+	public static final String OUTPUT_FILE = PropertiesHolder._get(
+		BenchmarksPropsKeys.OUTPUT_FILE);
+
 	public static final String SCRIPT = PropertiesHolder._get(
 		BenchmarksPropsKeys.SCRIPT);
 
 	public static final boolean SEARCH_BAR_ENABLED = GetterUtil.getBoolean(
 		PropertiesHolder._get(BenchmarksPropsKeys.SEARCH_BAR_ENABLED));
+
+	public static final String SERVICE_JARS_DIR = PropertiesHolder._get(
+		BenchmarksPropsKeys.SERVICE_JARS_DIR);
 
 	public static final String VIRTUAL_HOST_NAME = PropertiesHolder._get(
 		BenchmarksPropsKeys.VIRTUAL_HOST_NAME);

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilder.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilder.java
@@ -108,12 +108,6 @@ public class SampleSQLBuilder {
 		finally {
 			FileUtil.deltree(tempDir);
 		}
-
-		FileUtil.write(
-			new File(
-				BenchmarksPropsValues.OUTPUT_DIR,
-				"benchmarks-actual.properties"),
-			BenchmarksPropsValues.ACTUAL_PROPERTIES_CONTENT);
 	}
 
 	protected void compressSQL(

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilder.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilder.java
@@ -23,15 +23,22 @@ import com.liferay.portal.freemarker.FreeMarkerUtil;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.tools.ToolDependencies;
 import com.liferay.portal.tools.sample.sql.builder.io.CharPipe;
 import com.liferay.portal.tools.sample.sql.builder.io.UnsyncTeeWriter;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Writer;
 
@@ -41,6 +48,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 /**
  * @author Brian Wing Shun Chan
@@ -69,6 +78,14 @@ public class SampleSQLBuilder {
 		compressSQL(generateSQL(sampleSQLFile), outputDir);
 
 		sampleSQLFile.delete();
+
+		File createSQLFile = new File(BenchmarksPropsValues.OUTPUT_FILE);
+
+		try (BufferedWriter createSQLFileBufferWriter = new BufferedWriter(
+				new FileWriter(createSQLFile.getAbsoluteFile()))) {
+
+			_mergeCreateSQLStatements(createSQLFileBufferWriter);
+		}
 	}
 
 	protected void compressSQL(
@@ -252,6 +269,265 @@ public class SampleSQLBuilder {
 
 		insertSQLWriter.write(insertSQL);
 	}
+
+	private List<String> _getModuleServiceJarNames() throws Exception {
+		List<String> moduleServiceJarNames = new ArrayList<>();
+
+		for (String bndFile : BenchmarksPropsValues.MODULE_BND_FILES) {
+			String bndContent = FileUtil.read(bndFile);
+
+			int index1 = bndContent.indexOf("Bundle-SymbolicName: ");
+			int index2 = bndContent.indexOf("Bundle-Version:");
+
+			String bundleSymbolicName = bndContent.substring(
+				index1 + 21, index2 - 1);
+
+			String bundleVersion = bndContent.substring(
+				index2 + 16, index2 + 21);
+
+			moduleServiceJarNames.add(
+				StringBundler.concat(
+					bundleSymbolicName, "-", bundleVersion, ".jar"));
+		}
+
+		return moduleServiceJarNames;
+	}
+
+	private void _mergeCreateSQLStatements(Writer writer) throws Exception {
+		Class<?> clazz = getClass();
+
+		ClassLoader classLoader = clazz.getClassLoader();
+
+		StringBundler sb1 = new StringBundler();
+
+		try (BufferedReader reader = new BufferedReader(
+				new InputStreamReader(
+					classLoader.getResourceAsStream(
+						_CORE_DEPENDENCIES_DIR + _CORE_SQL_FILE_NAME +
+							".sql")))) {
+
+			String line;
+
+			while ((line = reader.readLine()) != null) {
+				sb1.append(line);
+				sb1.append(System.lineSeparator());
+			}
+		}
+
+		try (BufferedReader reader = new BufferedReader(
+				new InputStreamReader(
+					classLoader.getResourceAsStream(
+						_CORE_DEPENDENCIES_DIR + _CORE_COMMON_SQL_FILE_NAME +
+							".sql")))) {
+
+			String line;
+
+			while ((line = reader.readLine()) != null) {
+				sb1.append(line);
+				sb1.append(System.lineSeparator());
+			}
+		}
+
+		try (BufferedReader reader = new BufferedReader(
+				new InputStreamReader(
+					classLoader.getResourceAsStream(
+						_CORE_DEPENDENCIES_DIR + _CORE_CUNTER_SQL_FILE_NAME +
+							".sql")))) {
+
+			String line;
+
+			while ((line = reader.readLine()) != null) {
+				sb1.append(line);
+				sb1.append(System.lineSeparator());
+			}
+		}
+
+		_translateCreateSQLFile(writer, sb1.toString());
+
+		StringBundler sb2 = new StringBundler();
+
+		try (BufferedReader reader = new BufferedReader(
+				new InputStreamReader(
+					classLoader.getResourceAsStream(
+						_CORE_DEPENDENCIES_DIR + _INDEX_SQL_FILE_NAME +
+							".sql")))) {
+
+			String line;
+
+			while ((line = reader.readLine()) != null) {
+				sb2.append(line);
+				sb2.append(System.lineSeparator());
+			}
+		}
+
+		_translateCreateSQLFile(writer, sb1.toString(), sb2.toString());
+
+		List<String> moduleServiceJarNames = _getModuleServiceJarNames();
+
+		for (String jarName : moduleServiceJarNames) {
+			JarFile jarFile = new JarFile(
+				BenchmarksPropsValues.SERVICE_JARS_DIR + jarName);
+
+			JarEntry tableEntry = jarFile.getJarEntry(
+				StringBundler.concat(
+					_MODULE_SQL_PATH, _MODULE_SQL_FILE_NAME, ".sql"));
+			JarEntry indexEntry = jarFile.getJarEntry(
+				StringBundler.concat(
+					_MODULE_SQL_PATH, _INDEX_SQL_FILE_NAME, ".sql"));
+
+			StringBundler sb3 = new StringBundler();
+
+			if (tableEntry != null) {
+				BufferedReader reader = new BufferedReader(
+					new InputStreamReader(jarFile.getInputStream(tableEntry)));
+				String line;
+
+				while ((line = reader.readLine()) != null) {
+					sb3.append(line);
+					sb3.append(System.lineSeparator());
+				}
+
+				reader.close();
+			}
+
+			_translateCreateSQLFile(writer, sb3.toString());
+
+			StringBundler sb4 = new StringBundler();
+
+			if (indexEntry != null) {
+				BufferedReader reader = new BufferedReader(
+					new InputStreamReader(jarFile.getInputStream(indexEntry)));
+				String line;
+
+				while ((line = reader.readLine()) != null) {
+					sb4.append(line);
+					sb4.append(System.lineSeparator());
+				}
+
+				reader.close();
+			}
+
+			_translateCreateSQLFile(writer, sb3.toString(), sb4.toString());
+
+			jarFile.close();
+		}
+	}
+
+	private String _removeBooleanIndexes(String portalData, String indexData)
+		throws Exception {
+
+		if (Validator.isNull(portalData)) {
+			return StringPool.BLANK;
+		}
+
+		try (UnsyncBufferedReader unsyncBufferedReader =
+				new UnsyncBufferedReader(new UnsyncStringReader(indexData))) {
+
+			StringBundler sb = new StringBundler();
+
+			String line = null;
+
+			while ((line = unsyncBufferedReader.readLine()) != null) {
+				boolean append = true;
+
+				int x = line.indexOf(" on ");
+
+				if (x != -1) {
+					int y = line.indexOf(" (", x);
+
+					String table = line.substring(x + 4, y);
+
+					x = y + 2;
+
+					y = line.indexOf(")", x);
+
+					String[] columns = StringUtil.split(line.substring(x, y));
+
+					x = portalData.indexOf("create table " + table + " (");
+
+					y = portalData.indexOf(");", x);
+
+					String portalTableData = portalData.substring(x, y);
+
+					for (String column : columns) {
+						if (portalTableData.contains(
+								column.trim() + " BOOLEAN")) {
+
+							append = false;
+
+							break;
+						}
+					}
+				}
+
+				if (append) {
+					sb.append(line);
+					sb.append("\n");
+				}
+			}
+
+			return sb.toString();
+		}
+	}
+
+	private void _translateCreateSQLFile(Writer writer, String... templates)
+		throws Exception {
+
+		String template = "";
+
+		if (templates.length == 1) {
+			StringBundler sb = new StringBundler();
+
+			try (UnsyncBufferedReader unsyncBufferedReader =
+					new UnsyncBufferedReader(
+						new UnsyncStringReader(templates[0]))) {
+
+				String line = null;
+
+				while ((line = unsyncBufferedReader.readLine()) != null) {
+					sb.append(line);
+					sb.append("\n");
+				}
+			}
+
+			template = sb.toString();
+		}
+		else if (templates.length == 2) {
+			if (BenchmarksPropsValues.DB_TYPE == DBType.SYBASE) {
+				template = _removeBooleanIndexes(templates[0], templates[1]);
+			}
+			else {
+				template = templates[1];
+			}
+		}
+
+		if (Validator.isNull(template)) {
+			return;
+		}
+
+		DB db = DBManagerUtil.getDB(BenchmarksPropsValues.DB_TYPE, null);
+
+		template = db.buildSQL(template);
+
+		writer.write(template);
+	}
+
+	private static final String _CORE_COMMON_SQL_FILE_NAME =
+		"portal-data-common";
+
+	private static final String _CORE_CUNTER_SQL_FILE_NAME =
+		"portal-data-counter";
+
+	private static final String _CORE_DEPENDENCIES_DIR =
+		"com/liferay/portal/tools/sql/dependencies/";
+
+	private static final String _CORE_SQL_FILE_NAME = "portal-tables";
+
+	private static final String _INDEX_SQL_FILE_NAME = "indexes";
+
+	private static final String _MODULE_SQL_FILE_NAME = "tables";
+
+	private static final String _MODULE_SQL_PATH = "META-INF/sql/";
 
 	private static final int _PIPE_BUFFER_SIZE = 16 * 1024 * 1024;
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilder.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilder.java
@@ -23,21 +23,17 @@ import com.liferay.portal.freemarker.FreeMarkerUtil;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.tools.ToolDependencies;
 import com.liferay.portal.tools.sample.sql.builder.io.CharPipe;
 import com.liferay.portal.tools.sample.sql.builder.io.UnsyncTeeWriter;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
-
-import java.nio.channels.FileChannel;
 
 import java.sql.SQLException;
 
@@ -64,50 +60,11 @@ public class SampleSQLBuilder {
 	}
 
 	public SampleSQLBuilder() throws Exception {
+		File outputDir = new File(BenchmarksPropsValues.OUTPUT_DIR);
 
-		// Generic
+		outputDir.mkdirs();
 
-		File tempDir = new File(BenchmarksPropsValues.OUTPUT_DIR, "temp");
-
-		tempDir.mkdirs();
-
-		Reader reader = generateSQL();
-
-		try {
-
-			// Specific
-
-			compressSQL(reader, tempDir);
-
-			// Merge
-
-			if (BenchmarksPropsValues.OUTPUT_MERGE) {
-				File sqlFile = new File(
-					BenchmarksPropsValues.OUTPUT_DIR,
-					"sample-" + BenchmarksPropsValues.DB_TYPE + ".sql");
-
-				FileUtil.delete(sqlFile);
-
-				mergeSQL(tempDir, sqlFile);
-			}
-			else {
-				File outputDir = new File(
-					BenchmarksPropsValues.OUTPUT_DIR, "output");
-
-				FileUtil.deltree(outputDir);
-
-				if (!tempDir.renameTo(outputDir)) {
-
-					// This will only happen when temp and output directories
-					// are on different file systems
-
-					FileUtil.copyDirectory(tempDir, outputDir);
-				}
-			}
-		}
-		finally {
-			FileUtil.deltree(tempDir);
-		}
+		compressSQL(generateSQL(), outputDir);
 	}
 
 	protected void compressSQL(
@@ -275,48 +232,6 @@ public class SampleSQLBuilder {
 		thread.start();
 
 		return charPipe.getReader();
-	}
-
-	protected void mergeSQL(File inputDir, File outputSQLFile)
-		throws IOException {
-
-		FileOutputStream outputSQLFileOutputStream = new FileOutputStream(
-			outputSQLFile);
-
-		try (FileChannel outputFileChannel =
-				outputSQLFileOutputStream.getChannel()) {
-
-			File miscSQLFile = null;
-
-			for (File inputFile : inputDir.listFiles()) {
-				String inputFileName = inputFile.getName();
-
-				if (inputFileName.equals("misc.sql")) {
-					miscSQLFile = inputFile;
-
-					continue;
-				}
-
-				mergeSQL(inputFile, outputFileChannel);
-			}
-
-			if (miscSQLFile != null) {
-				mergeSQL(miscSQLFile, outputFileChannel);
-			}
-		}
-	}
-
-	protected void mergeSQL(File inputFile, FileChannel outputFileChannel)
-		throws IOException {
-
-		FileInputStream inputFileInputStream = new FileInputStream(inputFile);
-
-		try (FileChannel inputFileChannel = inputFileInputStream.getChannel()) {
-			inputFileChannel.transferTo(
-				0, inputFileChannel.size(), outputFileChannel);
-		}
-
-		inputFile.delete();
 	}
 
 	protected void writeToInsertSQLFile(

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilder.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilder.java
@@ -64,7 +64,11 @@ public class SampleSQLBuilder {
 
 		outputDir.mkdirs();
 
-		compressSQL(generateSQL(), outputDir);
+		File sampleSQLFile = new File(outputDir, "sample.sql");
+
+		compressSQL(generateSQL(sampleSQLFile), outputDir);
+
+		sampleSQLFile.delete();
 	}
 
 	protected void compressSQL(
@@ -198,7 +202,7 @@ public class SampleSQLBuilder {
 		return new UnsyncBufferedWriter(writer, _WRITER_BUFFER_SIZE);
 	}
 
-	protected Reader generateSQL() {
+	protected Reader generateSQL(File sampleSQLFile) {
 		final CharPipe charPipe = new CharPipe(_PIPE_BUFFER_SIZE);
 
 		Thread thread = new Thread(
@@ -207,10 +211,7 @@ public class SampleSQLBuilder {
 					Writer sampleSQLWriter = new UnsyncTeeWriter(
 						new UnsyncBufferedWriter(
 							charPipe.getWriter(), _WRITER_BUFFER_SIZE),
-						createFileWriter(
-							new File(
-								BenchmarksPropsValues.OUTPUT_DIR,
-								"sample.sql")))) {
+						createFileWriter(sampleSQLFile))) {
 
 					FreeMarkerUtil.process(
 						BenchmarksPropsValues.SCRIPT,

--- a/modules/util/portal-tools-sample-sql-builder/src/test/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilderTest.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/test/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilderTest.java
@@ -168,7 +168,6 @@ public class SampleSQLBuilderTest {
 			"assetPublisher,blog,company,documentLibrary,dynamicDataList," +
 				"fragment,layout,mbCategory,mbThread,repository,wiki");
 		properties.put(BenchmarksPropsKeys.OUTPUT_DIR, outputDir);
-		properties.put(BenchmarksPropsKeys.OUTPUT_MERGE, "true");
 		properties.put(
 			BenchmarksPropsKeys.SCRIPT,
 			"com/liferay/portal/tools/sample/sql/builder/dependencies" +
@@ -191,8 +190,26 @@ public class SampleSQLBuilderTest {
 
 			_loadServiceComponentsSQL(connection);
 
-			HypersonicLoader.loadHypersonic(
-				connection, outputDir + "/sample-hypersonic.sql");
+			File dir = new File(outputDir);
+
+			boolean miscSQLFile = false;
+
+			for (File file : dir.listFiles()) {
+				String fileName = file.getName();
+
+				if (fileName.equals("misc.sql")) {
+					miscSQLFile = true;
+				}
+				else if (fileName.endsWith(".sql")) {
+					HypersonicLoader.loadHypersonic(
+						connection, outputDir + "/" + fileName);
+				}
+			}
+
+			if (miscSQLFile) {
+				HypersonicLoader.loadHypersonic(
+					connection, outputDir + "/misc.sql");
+			}
 
 			try (Statement statement = connection.createStatement()) {
 				statement.execute("SHUTDOWN COMPACT");

--- a/modules/util/portal-tools-sample-sql-builder/src/test/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilderTest.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/test/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilderTest.java
@@ -14,12 +14,11 @@
 
 package com.liferay.portal.tools.sample.sql.builder;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.util.FileUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.test.rule.LogAssertionTestRule;
 import com.liferay.portal.tools.HypersonicLoader;
@@ -38,7 +37,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 
-import java.util.Enumeration;
 import java.util.Properties;
 
 import org.junit.Assert;
@@ -82,7 +80,17 @@ public class SampleSQLBuilderTest {
 			SystemProperties.get(SystemProperties.TMP_DIR),
 			String.valueOf(System.currentTimeMillis()));
 
-		_initProperties(properties, tempDir.getAbsolutePath());
+		tempDir.mkdir();
+
+		File createDir = new File(tempDir, "create");
+
+		createDir.mkdir();
+
+		File outputFile = new File(createDir, "create.sql");
+
+		_initProperties(
+			properties, tempDir.getAbsolutePath(),
+			outputFile.getAbsolutePath());
 
 		File tempPropertiesFile = File.createTempFile("test", ".properties");
 
@@ -94,36 +102,22 @@ public class SampleSQLBuilderTest {
 
 			new SampleSQLBuilder();
 
-			_loadHypersonic("../../../sql", tempDir.getAbsolutePath());
+			_loadHypersonic(
+				tempDir.getAbsolutePath(), outputFile.getAbsolutePath());
 		}
 		finally {
 			FileUtil.deltree(tempDir);
 		}
 	}
 
-	private ClassLoader _getClassLoader() {
-		Class<?> clazz = getClass();
+	private void _initProperties(
+		Properties properties, String outputDir, String outputFile) {
 
-		return clazz.getClassLoader();
-	}
+		String currentWorkingDir = System.getProperty("user.dir");
 
-	private Enumeration<URL> _getServiceComponentsIndexesSQLURLs()
-		throws Exception {
+		String rootDir = currentWorkingDir.substring(
+			0, currentWorkingDir.lastIndexOf("modules"));
 
-		ClassLoader classLoader = _getClassLoader();
-
-		return classLoader.getResources("META-INF/sql/indexes.sql");
-	}
-
-	private Enumeration<URL> _getServiceComponentsTablesSQLURLs()
-		throws Exception {
-
-		ClassLoader classLoader = _getClassLoader();
-
-		return classLoader.getResources("META-INF/sql/tables.sql");
-	}
-
-	private void _initProperties(Properties properties, String outputDir) {
 		properties.put(BenchmarksPropsKeys.DB_TYPE, "hypersonic");
 		properties.put(BenchmarksPropsKeys.MAX_ASSET_CATEGORY_COUNT, "1");
 		properties.put(
@@ -162,33 +156,52 @@ public class SampleSQLBuilderTest {
 		properties.put(BenchmarksPropsKeys.MAX_WIKI_NODE_COUNT, "1");
 		properties.put(BenchmarksPropsKeys.MAX_WIKI_PAGE_COMMENT_COUNT, "1");
 		properties.put(BenchmarksPropsKeys.MAX_WIKI_PAGE_COUNT, "1");
+
+		properties.put(
+			BenchmarksPropsKeys.MODULE_BND_FILES,
+			StringBundler.concat(
+				rootDir, "modules/apps/asset/asset-entry-rel-service/bnd.bnd,",
+				rootDir, "modules/apps/blogs/blogs-service/bnd.bnd,", rootDir,
+				"modules/apps/commerce/commerce-currency-service/bnd.bnd,",
+				rootDir, "modules/apps/commerce/commerce-product-service",
+				"/bnd.bnd,", rootDir, "modules/apps/dynamic-data-lists",
+				"/dynamic-data-lists-service/bnd.bnd,", rootDir,
+				"modules/apps/dynamic-data-mapping",
+				"/dynamic-data-mapping-service/bnd.bnd,", rootDir,
+				"modules/apps/fragment/fragment-service/bnd.bnd,", rootDir,
+				"modules/apps/friendly-url/friendly-url-service/bnd.bnd,",
+				rootDir, "modules/apps/journal/journal-service/bnd.bnd,",
+				rootDir, "modules/apps/layout/layout-page-template-service",
+				"/bnd.bnd,", rootDir, "modules/apps/message-boards",
+				"/message-boards-service/bnd.bnd,", rootDir, "modules/apps",
+				"/subscription/subscription-service/bnd.bnd,", rootDir,
+				"modules/apps/view-count/view-count-service/bnd.bnd,", rootDir,
+				"modules/apps/wiki/wiki-service/bnd.bnd"));
 		properties.put(BenchmarksPropsKeys.OPTIMIZE_BUFFER_SIZE, "8192");
 		properties.put(
 			BenchmarksPropsKeys.OUTPUT_CSV_FILE_NAMES,
 			"assetPublisher,blog,company,documentLibrary,dynamicDataList," +
 				"fragment,layout,mbCategory,mbThread,repository,wiki");
 		properties.put(BenchmarksPropsKeys.OUTPUT_DIR, outputDir);
+		properties.put(BenchmarksPropsKeys.OUTPUT_FILE, outputFile);
 		properties.put(
 			BenchmarksPropsKeys.SCRIPT,
 			"com/liferay/portal/tools/sample/sql/builder/dependencies" +
 				"/sample.ftl");
 		properties.put(BenchmarksPropsKeys.SEARCH_BAR_ENABLED, "true");
+		properties.put(
+			BenchmarksPropsKeys.SERVICE_JARS_DIR, rootDir + "tools/sdk/dist/");
 		properties.put(BenchmarksPropsKeys.VIRTUAL_HOST_NAME, "localhost");
 	}
 
-	private void _loadHypersonic(String sqlDir, String outputDir)
+	private void _loadHypersonic(String outputDir, String outputFile)
 		throws Exception {
 
 		try (Connection connection = DriverManager.getConnection(
 				"jdbc:hsqldb:mem:testSampleSQLBuilderDB;shutdown=true", "sa",
 				"")) {
 
-			HypersonicLoader.loadHypersonic(
-				connection, sqlDir + "/portal/portal-hypersonic.sql");
-			HypersonicLoader.loadHypersonic(
-				connection, sqlDir + "/indexes/indexes-hypersonic.sql");
-
-			_loadServiceComponentsSQL(connection);
+			HypersonicLoader.loadHypersonic(connection, outputFile);
 
 			File dir = new File(outputDir);
 
@@ -215,34 +228,6 @@ public class SampleSQLBuilderTest {
 				statement.execute("SHUTDOWN COMPACT");
 			}
 		}
-	}
-
-	private void _loadServiceComponentsSQL(Connection connection)
-		throws Exception {
-
-		DBManagerUtil.setDB(DBType.HYPERSONIC, null);
-
-		Enumeration<URL> tablesURLEnumeration =
-			_getServiceComponentsTablesSQLURLs();
-
-		while (tablesURLEnumeration.hasMoreElements()) {
-			_runSQL(connection, tablesURLEnumeration.nextElement());
-		}
-
-		Enumeration<URL> indexesURLEnumeration =
-			_getServiceComponentsIndexesSQLURLs();
-
-		while (indexesURLEnumeration.hasMoreElements()) {
-			_runSQL(connection, indexesURLEnumeration.nextElement());
-		}
-	}
-
-	private void _runSQL(Connection connection, URL url) throws Exception {
-		DB db = DBManagerUtil.getDB();
-
-		String sql = StringUtil.read(url.openStream());
-
-		db.runSQLTemplateString(connection, sql, true);
 	}
 
 	private static final String _SAMPLE_FTL_END =


### PR DESCRIPTION
Hi @dantewang 

I moved all the translate sql processes from the build file to java, but we need to pass a module list to SampleSQLBuilder to specify which module's generic SQL templates will be translated.

Benchmark side changes please see: https://github.com/dantewang/liferay-benchmark-ee/pull/455

I also try another way to do the move avoid the module list,  please see way2: https://github.com/dantewang/liferay-portal/pull/1859

Which one do you prefer? Currently, the way1 in this pull worked well, but way2 caused some other issues and I'm still working on it.

/cc  @tinatian

Lily