### PR TITLE
LPS-125170

### DIFF
--- a/modules/apps/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/BackgroundTaskLocalService.java
+++ b/modules/apps/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/BackgroundTaskLocalService.java
@@ -265,6 +265,21 @@ public interface BackgroundTaskLocalService
 		OrderByComparator<BackgroundTask> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BackgroundTask fetchFirstBackgroundTask(
+		String name, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BackgroundTask fetchFirstBackgroundTaskByCompanyId(
+		long companyId, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BackgroundTask fetchFirstBackgroundTaskByGroupId(
+		long groupId, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	/**

--- a/modules/apps/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/BackgroundTaskLocalServiceUtil.java
+++ b/modules/apps/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/BackgroundTaskLocalServiceUtil.java
@@ -350,6 +350,39 @@ public class BackgroundTaskLocalServiceUtil {
 			taskExecutorClassName, status, orderByComparator);
 	}
 
+	public static com.liferay.portal.background.task.model.BackgroundTask
+		fetchFirstBackgroundTask(
+			String name, String taskExecutorClassName, int status,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.background.task.model.BackgroundTask>
+					orderByComparator) {
+
+		return getService().fetchFirstBackgroundTask(
+			name, taskExecutorClassName, status, orderByComparator);
+	}
+
+	public static com.liferay.portal.background.task.model.BackgroundTask
+		fetchFirstBackgroundTaskByCompanyId(
+			long companyId, String taskExecutorClassName, int status,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.background.task.model.BackgroundTask>
+					orderByComparator) {
+
+		return getService().fetchFirstBackgroundTaskByCompanyId(
+			companyId, taskExecutorClassName, status, orderByComparator);
+	}
+
+	public static com.liferay.portal.background.task.model.BackgroundTask
+		fetchFirstBackgroundTaskByGroupId(
+			long groupId, String taskExecutorClassName, int status,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.background.task.model.BackgroundTask>
+					orderByComparator) {
+
+		return getService().fetchFirstBackgroundTaskByGroupId(
+			groupId, taskExecutorClassName, status, orderByComparator);
+	}
+
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 

--- a/modules/apps/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/BackgroundTaskLocalServiceWrapper.java
+++ b/modules/apps/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/BackgroundTaskLocalServiceWrapper.java
@@ -373,6 +373,42 @@ public class BackgroundTaskLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.background.task.model.BackgroundTask
+		fetchFirstBackgroundTask(
+			String name, String taskExecutorClassName, int status,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.background.task.model.BackgroundTask>
+					orderByComparator) {
+
+		return _backgroundTaskLocalService.fetchFirstBackgroundTask(
+			name, taskExecutorClassName, status, orderByComparator);
+	}
+
+	@Override
+	public com.liferay.portal.background.task.model.BackgroundTask
+		fetchFirstBackgroundTaskByCompanyId(
+			long companyId, String taskExecutorClassName, int status,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.background.task.model.BackgroundTask>
+					orderByComparator) {
+
+		return _backgroundTaskLocalService.fetchFirstBackgroundTaskByCompanyId(
+			companyId, taskExecutorClassName, status, orderByComparator);
+	}
+
+	@Override
+	public com.liferay.portal.background.task.model.BackgroundTask
+		fetchFirstBackgroundTaskByGroupId(
+			long groupId, String taskExecutorClassName, int status,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.background.task.model.BackgroundTask>
+					orderByComparator) {
+
+		return _backgroundTaskLocalService.fetchFirstBackgroundTaskByGroupId(
+			groupId, taskExecutorClassName, status, orderByComparator);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 

--- a/modules/apps/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/persistence/BackgroundTaskPersistence.java
+++ b/modules/apps/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/persistence/BackgroundTaskPersistence.java
@@ -2016,6 +2016,526 @@ public interface BackgroundTaskPersistence
 		long groupId, String[] taskExecutorClassNames, int status);
 
 	/**
+	 * Returns all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status);
+
+	/**
+	 * Returns a range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status, int start,
+		int end);
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	public BackgroundTask findByC_T_S_First(
+			long companyId, String taskExecutorClassName, int status,
+			com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+				orderByComparator)
+		throws NoSuchBackgroundTaskException;
+
+	/**
+	 * Returns the first background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	public BackgroundTask fetchByC_T_S_First(
+		long companyId, String taskExecutorClassName, int status,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator);
+
+	/**
+	 * Returns the last background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	public BackgroundTask findByC_T_S_Last(
+			long companyId, String taskExecutorClassName, int status,
+			com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+				orderByComparator)
+		throws NoSuchBackgroundTaskException;
+
+	/**
+	 * Returns the last background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	public BackgroundTask fetchByC_T_S_Last(
+		long companyId, String taskExecutorClassName, int status,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator);
+
+	/**
+	 * Returns the background tasks before and after the current background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param backgroundTaskId the primary key of the current background task
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next background task
+	 * @throws NoSuchBackgroundTaskException if a background task with the primary key could not be found
+	 */
+	public BackgroundTask[] findByC_T_S_PrevAndNext(
+			long backgroundTaskId, long companyId, String taskExecutorClassName,
+			int status,
+			com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+				orderByComparator)
+		throws NoSuchBackgroundTaskException;
+
+	/**
+	 * Returns all the background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status);
+
+	/**
+	 * Returns a range of all the background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status, int start,
+		int end);
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Removes all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 */
+	public void removeByC_T_S(
+		long companyId, String taskExecutorClassName, int status);
+
+	/**
+	 * Returns the number of background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	public int countByC_T_S(
+		long companyId, String taskExecutorClassName, int status);
+
+	/**
+	 * Returns the number of background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	public int countByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status);
+
+	/**
+	 * Returns all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status);
+
+	/**
+	 * Returns a range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status, int start,
+		int end);
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	public BackgroundTask findByN_T_S_First(
+			String name, String taskExecutorClassName, int status,
+			com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+				orderByComparator)
+		throws NoSuchBackgroundTaskException;
+
+	/**
+	 * Returns the first background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	public BackgroundTask fetchByN_T_S_First(
+		String name, String taskExecutorClassName, int status,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator);
+
+	/**
+	 * Returns the last background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	public BackgroundTask findByN_T_S_Last(
+			String name, String taskExecutorClassName, int status,
+			com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+				orderByComparator)
+		throws NoSuchBackgroundTaskException;
+
+	/**
+	 * Returns the last background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	public BackgroundTask fetchByN_T_S_Last(
+		String name, String taskExecutorClassName, int status,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator);
+
+	/**
+	 * Returns the background tasks before and after the current background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param backgroundTaskId the primary key of the current background task
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next background task
+	 * @throws NoSuchBackgroundTaskException if a background task with the primary key could not be found
+	 */
+	public BackgroundTask[] findByN_T_S_PrevAndNext(
+			long backgroundTaskId, String name, String taskExecutorClassName,
+			int status,
+			com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+				orderByComparator)
+		throws NoSuchBackgroundTaskException;
+
+	/**
+	 * Returns all the background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status);
+
+	/**
+	 * Returns a range of all the background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status, int start,
+		int end);
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	public java.util.List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<BackgroundTask>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Removes all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63; from the database.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 */
+	public void removeByN_T_S(
+		String name, String taskExecutorClassName, int status);
+
+	/**
+	 * Returns the number of background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	public int countByN_T_S(
+		String name, String taskExecutorClassName, int status);
+
+	/**
+	 * Returns the number of background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	public int countByN_T_S(
+		String name, String[] taskExecutorClassNames, int status);
+
+	/**
 	 * Returns all the background tasks where groupId = &#63; and name = &#63; and taskExecutorClassName = &#63; and completed = &#63;.
 	 *
 	 * @param groupId the group ID

--- a/modules/apps/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/persistence/BackgroundTaskUtil.java
+++ b/modules/apps/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/persistence/BackgroundTaskUtil.java
@@ -2528,6 +2528,640 @@ public class BackgroundTaskUtil {
 	}
 
 	/**
+	 * Returns all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	public static List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status) {
+
+		return getPersistence().findByC_T_S(
+			companyId, taskExecutorClassName, status);
+	}
+
+	/**
+	 * Returns a range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status, int start,
+		int end) {
+
+		return getPersistence().findByC_T_S(
+			companyId, taskExecutorClassName, status, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return getPersistence().findByC_T_S(
+			companyId, taskExecutorClassName, status, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_T_S(
+			companyId, taskExecutorClassName, status, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	public static BackgroundTask findByC_T_S_First(
+			long companyId, String taskExecutorClassName, int status,
+			OrderByComparator<BackgroundTask> orderByComparator)
+		throws com.liferay.portal.background.task.exception.
+			NoSuchBackgroundTaskException {
+
+		return getPersistence().findByC_T_S_First(
+			companyId, taskExecutorClassName, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the first background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	public static BackgroundTask fetchByC_T_S_First(
+		long companyId, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return getPersistence().fetchByC_T_S_First(
+			companyId, taskExecutorClassName, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the last background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	public static BackgroundTask findByC_T_S_Last(
+			long companyId, String taskExecutorClassName, int status,
+			OrderByComparator<BackgroundTask> orderByComparator)
+		throws com.liferay.portal.background.task.exception.
+			NoSuchBackgroundTaskException {
+
+		return getPersistence().findByC_T_S_Last(
+			companyId, taskExecutorClassName, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the last background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	public static BackgroundTask fetchByC_T_S_Last(
+		long companyId, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return getPersistence().fetchByC_T_S_Last(
+			companyId, taskExecutorClassName, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the background tasks before and after the current background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param backgroundTaskId the primary key of the current background task
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next background task
+	 * @throws NoSuchBackgroundTaskException if a background task with the primary key could not be found
+	 */
+	public static BackgroundTask[] findByC_T_S_PrevAndNext(
+			long backgroundTaskId, long companyId, String taskExecutorClassName,
+			int status, OrderByComparator<BackgroundTask> orderByComparator)
+		throws com.liferay.portal.background.task.exception.
+			NoSuchBackgroundTaskException {
+
+		return getPersistence().findByC_T_S_PrevAndNext(
+			backgroundTaskId, companyId, taskExecutorClassName, status,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns all the background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	public static List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status) {
+
+		return getPersistence().findByC_T_S(
+			companyId, taskExecutorClassNames, status);
+	}
+
+	/**
+	 * Returns a range of all the background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status, int start,
+		int end) {
+
+		return getPersistence().findByC_T_S(
+			companyId, taskExecutorClassNames, status, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return getPersistence().findByC_T_S(
+			companyId, taskExecutorClassNames, status, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_T_S(
+			companyId, taskExecutorClassNames, status, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Removes all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 */
+	public static void removeByC_T_S(
+		long companyId, String taskExecutorClassName, int status) {
+
+		getPersistence().removeByC_T_S(
+			companyId, taskExecutorClassName, status);
+	}
+
+	/**
+	 * Returns the number of background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	public static int countByC_T_S(
+		long companyId, String taskExecutorClassName, int status) {
+
+		return getPersistence().countByC_T_S(
+			companyId, taskExecutorClassName, status);
+	}
+
+	/**
+	 * Returns the number of background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	public static int countByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status) {
+
+		return getPersistence().countByC_T_S(
+			companyId, taskExecutorClassNames, status);
+	}
+
+	/**
+	 * Returns all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	public static List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status) {
+
+		return getPersistence().findByN_T_S(
+			name, taskExecutorClassName, status);
+	}
+
+	/**
+	 * Returns a range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status, int start,
+		int end) {
+
+		return getPersistence().findByN_T_S(
+			name, taskExecutorClassName, status, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return getPersistence().findByN_T_S(
+			name, taskExecutorClassName, status, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByN_T_S(
+			name, taskExecutorClassName, status, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	public static BackgroundTask findByN_T_S_First(
+			String name, String taskExecutorClassName, int status,
+			OrderByComparator<BackgroundTask> orderByComparator)
+		throws com.liferay.portal.background.task.exception.
+			NoSuchBackgroundTaskException {
+
+		return getPersistence().findByN_T_S_First(
+			name, taskExecutorClassName, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the first background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	public static BackgroundTask fetchByN_T_S_First(
+		String name, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return getPersistence().fetchByN_T_S_First(
+			name, taskExecutorClassName, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the last background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	public static BackgroundTask findByN_T_S_Last(
+			String name, String taskExecutorClassName, int status,
+			OrderByComparator<BackgroundTask> orderByComparator)
+		throws com.liferay.portal.background.task.exception.
+			NoSuchBackgroundTaskException {
+
+		return getPersistence().findByN_T_S_Last(
+			name, taskExecutorClassName, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the last background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	public static BackgroundTask fetchByN_T_S_Last(
+		String name, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return getPersistence().fetchByN_T_S_Last(
+			name, taskExecutorClassName, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the background tasks before and after the current background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param backgroundTaskId the primary key of the current background task
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next background task
+	 * @throws NoSuchBackgroundTaskException if a background task with the primary key could not be found
+	 */
+	public static BackgroundTask[] findByN_T_S_PrevAndNext(
+			long backgroundTaskId, String name, String taskExecutorClassName,
+			int status, OrderByComparator<BackgroundTask> orderByComparator)
+		throws com.liferay.portal.background.task.exception.
+			NoSuchBackgroundTaskException {
+
+		return getPersistence().findByN_T_S_PrevAndNext(
+			backgroundTaskId, name, taskExecutorClassName, status,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns all the background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	public static List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status) {
+
+		return getPersistence().findByN_T_S(
+			name, taskExecutorClassNames, status);
+	}
+
+	/**
+	 * Returns a range of all the background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status, int start,
+		int end) {
+
+		return getPersistence().findByN_T_S(
+			name, taskExecutorClassNames, status, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return getPersistence().findByN_T_S(
+			name, taskExecutorClassNames, status, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	public static List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByN_T_S(
+			name, taskExecutorClassNames, status, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Removes all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63; from the database.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 */
+	public static void removeByN_T_S(
+		String name, String taskExecutorClassName, int status) {
+
+		getPersistence().removeByN_T_S(name, taskExecutorClassName, status);
+	}
+
+	/**
+	 * Returns the number of background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	public static int countByN_T_S(
+		String name, String taskExecutorClassName, int status) {
+
+		return getPersistence().countByN_T_S(
+			name, taskExecutorClassName, status);
+	}
+
+	/**
+	 * Returns the number of background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	public static int countByN_T_S(
+		String name, String[] taskExecutorClassNames, int status) {
+
+		return getPersistence().countByN_T_S(
+			name, taskExecutorClassNames, status);
+	}
+
+	/**
 	 * Returns all the background tasks where groupId = &#63; and name = &#63; and taskExecutorClassName = &#63; and completed = &#63;.
 	 *
 	 * @param groupId the group ID

--- a/modules/apps/portal-background-task/portal-background-task-api/src/main/resources/com/liferay/portal/background/task/service/packageinfo
+++ b/modules/apps/portal-background-task/portal-background-task-api/src/main/resources/com/liferay/portal/background/task/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/modules/apps/portal-background-task/portal-background-task-api/src/main/resources/com/liferay/portal/background/task/service/persistence/packageinfo
+++ b/modules/apps/portal-background-task/portal-background-task-api/src/main/resources/com/liferay/portal/background/task/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.2
+version 3.1.0

--- a/modules/apps/portal-background-task/portal-background-task-service/service.xml
+++ b/modules/apps/portal-background-task/portal-background-task-service/service.xml
@@ -79,6 +79,16 @@
 			<finder-column arrayable-operator="OR" name="taskExecutorClassName" />
 			<finder-column name="status" />
 		</finder>
+		<finder name="C_T_S" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column arrayable-operator="OR" name="taskExecutorClassName" />
+			<finder-column name="status" />
+		</finder>
+		<finder name="N_T_S" return-type="Collection">
+			<finder-column name="name" />
+			<finder-column arrayable-operator="OR" name="taskExecutorClassName" />
+			<finder-column name="status" />
+		</finder>
 		<finder name="G_N_T_C" return-type="Collection">
 			<finder-column arrayable-operator="OR" name="groupId" />
 			<finder-column name="name" />

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
@@ -256,6 +256,54 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 	}
 
 	@Override
+	public BackgroundTask fetchFirstBackgroundTask(
+		String name, String taskExecutorClassName, int status) {
+
+		com.liferay.portal.background.task.model.BackgroundTask
+			bcakgroundTaskModel =
+				_backgroundTaskLocalService.fetchFirstBackgroundTask(
+					name, taskExecutorClassName, status, null);
+
+		if (bcakgroundTaskModel == null) {
+			return null;
+		}
+
+		return new BackgroundTaskImpl(bcakgroundTaskModel);
+	}
+
+	@Override
+	public BackgroundTask fetchFirstBackgroundTaskByCompanyId(
+		long companyId, String taskExecutorClassName, int status) {
+
+		com.liferay.portal.background.task.model.BackgroundTask
+			bcakgroundTaskModel =
+				_backgroundTaskLocalService.fetchFirstBackgroundTaskByCompanyId(
+					companyId, taskExecutorClassName, status, null);
+
+		if (bcakgroundTaskModel == null) {
+			return null;
+		}
+
+		return new BackgroundTaskImpl(bcakgroundTaskModel);
+	}
+
+	@Override
+	public BackgroundTask fetchFirstBackgroundTaskByGroupId(
+		long groupId, String taskExecutorClassName, int status) {
+
+		com.liferay.portal.background.task.model.BackgroundTask
+			bcakgroundTaskModel =
+				_backgroundTaskLocalService.fetchFirstBackgroundTaskByGroupId(
+					groupId, taskExecutorClassName, status, null);
+
+		if (bcakgroundTaskModel == null) {
+			return null;
+		}
+
+		return new BackgroundTaskImpl(bcakgroundTaskModel);
+	}
+
+	@Override
 	public BackgroundTask getBackgroundTask(long backgroundTaskId)
 		throws PortalException {
 

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
@@ -626,7 +626,8 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 
 		BackgroundTaskQueuingMessageListener
 			backgroundTaskQueuingMessageListener =
-				new BackgroundTaskQueuingMessageListener(this, _lockManager);
+				new BackgroundTaskQueuingMessageListener(
+					_backgroundTaskExecutorRegistry, this, _lockManager);
 
 		backgroundTaskStatusDestination.register(
 			backgroundTaskQueuingMessageListener);

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/lock/BackgroundTaskLockHelper.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/lock/BackgroundTaskLockHelper.java
@@ -27,36 +27,7 @@ import com.liferay.portal.kernel.lock.LockManager;
  */
 public class BackgroundTaskLockHelper {
 
-	public BackgroundTaskLockHelper(LockManager lockManager) {
-		_lockManager = lockManager;
-	}
-
-	public boolean isLockedBackgroundTask(BackgroundTask backgroundTask) {
-		return _lockManager.isLocked(
-			BackgroundTaskExecutor.class.getName(), getLockKey(backgroundTask));
-	}
-
-	public Lock lockBackgroundTask(BackgroundTask backgroundTask) {
-		String owner =
-			backgroundTask.getName() + StringPool.POUND +
-				backgroundTask.getBackgroundTaskId();
-
-		return _lockManager.lock(
-			BackgroundTaskExecutor.class.getName(), getLockKey(backgroundTask),
-			owner);
-	}
-
-	public void unlockBackgroundTask(BackgroundTask backgroundTask) {
-		String owner =
-			backgroundTask.getName() + StringPool.POUND +
-				backgroundTask.getBackgroundTaskId();
-
-		_lockManager.unlock(
-			BackgroundTaskExecutor.class.getName(), getLockKey(backgroundTask),
-			owner);
-	}
-
-	protected static String getLockKey(BackgroundTask backgroundTask) {
+	public static String getLockKey(BackgroundTask backgroundTask) {
 		BackgroundTaskExecutor backgroundTaskExecutor =
 			BackgroundTaskExecutorRegistryUtil.getBackgroundTaskExecutor(
 				backgroundTask.getTaskExecutorClassName());
@@ -101,6 +72,35 @@ public class BackgroundTaskLockHelper {
 		}
 
 		return lockKey;
+	}
+
+	public BackgroundTaskLockHelper(LockManager lockManager) {
+		_lockManager = lockManager;
+	}
+
+	public boolean isLockedBackgroundTask(BackgroundTask backgroundTask) {
+		return _lockManager.isLocked(
+			BackgroundTaskExecutor.class.getName(), getLockKey(backgroundTask));
+	}
+
+	public Lock lockBackgroundTask(BackgroundTask backgroundTask) {
+		String owner =
+			backgroundTask.getName() + StringPool.POUND +
+				backgroundTask.getBackgroundTaskId();
+
+		return _lockManager.lock(
+			BackgroundTaskExecutor.class.getName(), getLockKey(backgroundTask),
+			owner);
+	}
+
+	public void unlockBackgroundTask(BackgroundTask backgroundTask) {
+		String owner =
+			backgroundTask.getName() + StringPool.POUND +
+				backgroundTask.getBackgroundTaskId();
+
+		_lockManager.unlock(
+			BackgroundTaskExecutor.class.getName(), getLockKey(backgroundTask),
+			owner);
 	}
 
 	private final LockManager _lockManager;

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
@@ -18,6 +18,7 @@ import com.liferay.petra.lang.SafeClosable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.background.task.internal.SerialBackgroundTaskExecutor;
 import com.liferay.portal.background.task.internal.ThreadLocalAwareBackgroundTaskExecutor;
+import com.liferay.portal.background.task.internal.lock.BackgroundTaskLockHelper;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutorRegistry;
@@ -212,6 +213,15 @@ public class BackgroundTaskMessageListener extends BaseMessageListener {
 				responseMessage.put(
 					"taskExecutorClassName",
 					backgroundTask.getTaskExecutorClassName());
+
+				if (backgroundTaskExecutor.isSerial()) {
+					responseMessage.put(
+						"isolationLevel",
+						backgroundTaskExecutor.getIsolationLevel());
+					responseMessage.put(
+						"lockKey",
+						BackgroundTaskLockHelper.getLockKey(backgroundTask));
+				}
 
 				_messageBus.sendMessage(
 					DestinationNames.BACKGROUND_TASK_STATUS, responseMessage);

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.background.task.internal.messaging;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.background.task.internal.lock.BackgroundTaskLockHelper;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
@@ -25,6 +26,8 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 /**
@@ -77,7 +80,7 @@ public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 			(status == BackgroundTaskConstants.STATUS_FAILED) ||
 			(status == BackgroundTaskConstants.STATUS_SUCCESSFUL)) {
 
-			_executeQueuedBackgroundTasks(taskExecutorClassName);
+			_executeQueuedBackgroundTasks(taskExecutorClassName, message);
 		}
 		else if (status == BackgroundTaskConstants.STATUS_QUEUED) {
 			long backgroundTaskId = (Long)message.get(
@@ -89,21 +92,63 @@ public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 			if (!_backgroundTaskLockHelper.isLockedBackgroundTask(
 					backgroundTask)) {
 
-				_executeQueuedBackgroundTasks(taskExecutorClassName);
+				_executeQueuedBackgroundTasks(taskExecutorClassName, message);
 			}
 		}
 	}
 
-	private void _executeQueuedBackgroundTasks(String taskExecutorClassName) {
+	private void _executeQueuedBackgroundTasks(
+		String taskExecutorClassName, Message message) {
+
+		int isolationLevel = (int)message.get("isolationLevel");
+
+		String lockKey = (String)message.get("lockKey");
+
 		if (_log.isDebugEnabled()) {
-			_log.debug(
-				"Acquiring next queued background task for " +
-					taskExecutorClassName);
+			if (isolationLevel !=
+					BackgroundTaskConstants.ISOLATION_LEVEL_CUSTOM) {
+
+				_log.debug(
+					"Acquiring next queued background task for " + lockKey);
+			}
+			else {
+				_log.debug(
+					"Acquiring next queued background task for " +
+						taskExecutorClassName);
+			}
 		}
 
-		BackgroundTask backgroundTask =
-			_backgroundTaskManager.fetchFirstBackgroundTask(
+		BackgroundTask backgroundTask = null;
+
+		if (isolationLevel == BackgroundTaskConstants.ISOLATION_LEVEL_COMPANY) {
+			backgroundTask =
+				_backgroundTaskManager.fetchFirstBackgroundTaskByCompanyId(
+					GetterUtil.getLong(
+						StringUtil.extractLast(lockKey, CharPool.POUND)),
+					taskExecutorClassName,
+					BackgroundTaskConstants.STATUS_QUEUED);
+		}
+		else if (isolationLevel ==
+					BackgroundTaskConstants.ISOLATION_LEVEL_GROUP) {
+
+			backgroundTask =
+				_backgroundTaskManager.fetchFirstBackgroundTaskByGroupId(
+					GetterUtil.getLong(
+						StringUtil.extractLast(lockKey, CharPool.POUND)),
+					taskExecutorClassName,
+					BackgroundTaskConstants.STATUS_QUEUED);
+		}
+		else if (isolationLevel ==
+					BackgroundTaskConstants.ISOLATION_LEVEL_TASK_NAME) {
+
+			backgroundTask = _backgroundTaskManager.fetchFirstBackgroundTask(
+				StringUtil.extractLast(lockKey, CharPool.POUND),
 				taskExecutorClassName, BackgroundTaskConstants.STATUS_QUEUED);
+		}
+		else {
+			backgroundTask = _backgroundTaskManager.fetchFirstBackgroundTask(
+				taskExecutorClassName, BackgroundTaskConstants.STATUS_QUEUED);
+		}
 
 		if (backgroundTask == null) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskQueuingMessageListener.java
@@ -16,6 +16,8 @@ package com.liferay.portal.background.task.internal.messaging;
 
 import com.liferay.portal.background.task.internal.lock.BackgroundTaskLockHelper;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutorRegistry;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
 import com.liferay.portal.kernel.lock.LockManager;
@@ -31,8 +33,10 @@ import com.liferay.portal.kernel.util.Validator;
 public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 
 	public BackgroundTaskQueuingMessageListener(
+		BackgroundTaskExecutorRegistry backgroundTaskExecutorRegistry,
 		BackgroundTaskManager backgroundTaskManager, LockManager lockManager) {
 
+		_backgroundTaskExecutorRegistry = backgroundTaskExecutorRegistry;
 		_backgroundTaskManager = backgroundTaskManager;
 
 		_backgroundTaskLockHelper = new BackgroundTaskLockHelper(lockManager);
@@ -48,6 +52,20 @@ public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 				_log.debug(
 					"Message " + message +
 						" is missing the key \"taskExecutorClassName\"");
+			}
+
+			return;
+		}
+
+		BackgroundTaskExecutor backgroundTaskExecutor =
+			_backgroundTaskExecutorRegistry.getBackgroundTaskExecutor(
+				taskExecutorClassName);
+
+		if (!backgroundTaskExecutor.isSerial()) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					taskExecutorClassName +
+						" is non-serial BackgroundTaskExecutor ");
 			}
 
 			return;
@@ -104,6 +122,8 @@ public class BackgroundTaskQueuingMessageListener extends BaseMessageListener {
 	private static final Log _log = LogFactoryUtil.getLog(
 		BackgroundTaskQueuingMessageListener.class);
 
+	private final BackgroundTaskExecutorRegistry
+		_backgroundTaskExecutorRegistry;
 	private final BackgroundTaskLockHelper _backgroundTaskLockHelper;
 	private final BackgroundTaskManager _backgroundTaskManager;
 

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
@@ -369,6 +369,33 @@ public class BackgroundTaskLocalServiceImpl
 	}
 
 	@Override
+	public BackgroundTask fetchFirstBackgroundTask(
+		String name, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return backgroundTaskPersistence.fetchByN_T_S_First(
+			name, taskExecutorClassName, status, orderByComparator);
+	}
+
+	@Override
+	public BackgroundTask fetchFirstBackgroundTaskByCompanyId(
+		long companyId, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return backgroundTaskPersistence.fetchByC_T_S_First(
+			companyId, taskExecutorClassName, status, orderByComparator);
+	}
+
+	@Override
+	public BackgroundTask fetchFirstBackgroundTaskByGroupId(
+		long groupId, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return backgroundTaskPersistence.fetchByG_T_S_First(
+			groupId, taskExecutorClassName, status, orderByComparator);
+	}
+
+	@Override
 	public BackgroundTask getBackgroundTask(long backgroundTaskId)
 		throws PortalException {
 

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
@@ -21,6 +21,8 @@ import com.liferay.portal.background.task.internal.BackgroundTaskImpl;
 import com.liferay.portal.background.task.internal.lock.BackgroundTaskLockHelper;
 import com.liferay.portal.background.task.model.BackgroundTask;
 import com.liferay.portal.background.task.service.base.BackgroundTaskLocalServiceBaseImpl;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutorRegistry;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatus;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusRegistry;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocalManager;
@@ -214,9 +216,11 @@ public class BackgroundTaskLocalServiceImpl
 		final BackgroundTask backgroundTask = fetchBackgroundTask(
 			backgroundTaskId);
 
+		final BackgroundTaskImpl backgroundTaskImpl = new BackgroundTaskImpl(
+			backgroundTask);
+
 		try {
-			_backgroundTaskLockHelper.unlockBackgroundTask(
-				new BackgroundTaskImpl(backgroundTask));
+			_backgroundTaskLockHelper.unlockBackgroundTask(backgroundTaskImpl);
 		}
 		catch (Exception exception) {
 		}
@@ -226,6 +230,11 @@ public class BackgroundTaskLocalServiceImpl
 
 				@Override
 				public Void call() throws Exception {
+					BackgroundTaskExecutor backgroundTaskExecutor =
+						_backgroundTaskExecutorRegistry.
+							getBackgroundTaskExecutor(
+								backgroundTask.getTaskExecutorClassName());
+
 					Message message = new Message();
 
 					message.put(
@@ -236,6 +245,16 @@ public class BackgroundTaskLocalServiceImpl
 					message.put(
 						"taskExecutorClassName",
 						backgroundTask.getTaskExecutorClassName());
+
+					if (backgroundTaskExecutor.isSerial()) {
+						message.put(
+							"isolationLevel",
+							backgroundTaskExecutor.getIsolationLevel());
+						message.put(
+							"lockKey",
+							_backgroundTaskLockHelper.getLockKey(
+								backgroundTaskImpl));
+					}
 
 					_messageBus.sendMessage(
 						DestinationNames.BACKGROUND_TASK_STATUS, message);
@@ -780,6 +799,9 @@ public class BackgroundTaskLocalServiceImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BackgroundTaskLocalServiceImpl.class);
+
+	@Reference
+	private BackgroundTaskExecutorRegistry _backgroundTaskExecutorRegistry;
 
 	private BackgroundTaskLockHelper _backgroundTaskLockHelper;
 

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/persistence/impl/BackgroundTaskPersistenceImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/persistence/impl/BackgroundTaskPersistenceImpl.java
@@ -7584,6 +7584,2037 @@ public class BackgroundTaskPersistenceImpl
 	private static final String _FINDER_COLUMN_G_T_S_STATUS_2 =
 		"backgroundTask.status = ?";
 
+	private FinderPath _finderPathWithPaginationFindByC_T_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_T_S;
+	private FinderPath _finderPathCountByC_T_S;
+	private FinderPath _finderPathWithPaginationCountByC_T_S;
+
+	/**
+	 * Returns all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status) {
+
+		return findByC_T_S(
+			companyId, taskExecutorClassName, status, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status, int start,
+		int end) {
+
+		return findByC_T_S(
+			companyId, taskExecutorClassName, status, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return findByC_T_S(
+			companyId, taskExecutorClassName, status, start, end,
+			orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByC_T_S(
+		long companyId, String taskExecutorClassName, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator,
+		boolean useFinderCache) {
+
+		taskExecutorClassName = Objects.toString(taskExecutorClassName, "");
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByC_T_S;
+				finderArgs = new Object[] {
+					companyId, taskExecutorClassName, status
+				};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByC_T_S;
+			finderArgs = new Object[] {
+				companyId, taskExecutorClassName, status, start, end,
+				orderByComparator
+			};
+		}
+
+		List<BackgroundTask> list = null;
+
+		if (useFinderCache) {
+			list = (List<BackgroundTask>)finderCache.getResult(
+				finderPath, finderArgs);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (BackgroundTask backgroundTask : list) {
+					if ((companyId != backgroundTask.getCompanyId()) ||
+						!taskExecutorClassName.equals(
+							backgroundTask.getTaskExecutorClassName()) ||
+						(status != backgroundTask.getStatus())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					5 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(5);
+			}
+
+			sb.append(_SQL_SELECT_BACKGROUNDTASK_WHERE);
+
+			sb.append(_FINDER_COLUMN_C_T_S_COMPANYID_2);
+
+			boolean bindTaskExecutorClassName = false;
+
+			if (taskExecutorClassName.isEmpty()) {
+				sb.append(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_3);
+			}
+			else {
+				bindTaskExecutorClassName = true;
+
+				sb.append(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_2);
+			}
+
+			sb.append(_FINDER_COLUMN_C_T_S_STATUS_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(BackgroundTaskModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				if (bindTaskExecutorClassName) {
+					queryPos.add(taskExecutorClassName);
+				}
+
+				queryPos.add(status);
+
+				list = (List<BackgroundTask>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	@Override
+	public BackgroundTask findByC_T_S_First(
+			long companyId, String taskExecutorClassName, int status,
+			OrderByComparator<BackgroundTask> orderByComparator)
+		throws NoSuchBackgroundTaskException {
+
+		BackgroundTask backgroundTask = fetchByC_T_S_First(
+			companyId, taskExecutorClassName, status, orderByComparator);
+
+		if (backgroundTask != null) {
+			return backgroundTask;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", taskExecutorClassName=");
+		sb.append(taskExecutorClassName);
+
+		sb.append(", status=");
+		sb.append(status);
+
+		sb.append("}");
+
+		throw new NoSuchBackgroundTaskException(sb.toString());
+	}
+
+	/**
+	 * Returns the first background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	@Override
+	public BackgroundTask fetchByC_T_S_First(
+		long companyId, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator) {
+
+		List<BackgroundTask> list = findByC_T_S(
+			companyId, taskExecutorClassName, status, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	@Override
+	public BackgroundTask findByC_T_S_Last(
+			long companyId, String taskExecutorClassName, int status,
+			OrderByComparator<BackgroundTask> orderByComparator)
+		throws NoSuchBackgroundTaskException {
+
+		BackgroundTask backgroundTask = fetchByC_T_S_Last(
+			companyId, taskExecutorClassName, status, orderByComparator);
+
+		if (backgroundTask != null) {
+			return backgroundTask;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", taskExecutorClassName=");
+		sb.append(taskExecutorClassName);
+
+		sb.append(", status=");
+		sb.append(status);
+
+		sb.append("}");
+
+		throw new NoSuchBackgroundTaskException(sb.toString());
+	}
+
+	/**
+	 * Returns the last background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	@Override
+	public BackgroundTask fetchByC_T_S_Last(
+		long companyId, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator) {
+
+		int count = countByC_T_S(companyId, taskExecutorClassName, status);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<BackgroundTask> list = findByC_T_S(
+			companyId, taskExecutorClassName, status, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the background tasks before and after the current background task in the ordered set where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param backgroundTaskId the primary key of the current background task
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next background task
+	 * @throws NoSuchBackgroundTaskException if a background task with the primary key could not be found
+	 */
+	@Override
+	public BackgroundTask[] findByC_T_S_PrevAndNext(
+			long backgroundTaskId, long companyId, String taskExecutorClassName,
+			int status, OrderByComparator<BackgroundTask> orderByComparator)
+		throws NoSuchBackgroundTaskException {
+
+		taskExecutorClassName = Objects.toString(taskExecutorClassName, "");
+
+		BackgroundTask backgroundTask = findByPrimaryKey(backgroundTaskId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			BackgroundTask[] array = new BackgroundTaskImpl[3];
+
+			array[0] = getByC_T_S_PrevAndNext(
+				session, backgroundTask, companyId, taskExecutorClassName,
+				status, orderByComparator, true);
+
+			array[1] = backgroundTask;
+
+			array[2] = getByC_T_S_PrevAndNext(
+				session, backgroundTask, companyId, taskExecutorClassName,
+				status, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected BackgroundTask getByC_T_S_PrevAndNext(
+		Session session, BackgroundTask backgroundTask, long companyId,
+		String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_BACKGROUNDTASK_WHERE);
+
+		sb.append(_FINDER_COLUMN_C_T_S_COMPANYID_2);
+
+		boolean bindTaskExecutorClassName = false;
+
+		if (taskExecutorClassName.isEmpty()) {
+			sb.append(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_3);
+		}
+		else {
+			bindTaskExecutorClassName = true;
+
+			sb.append(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_2);
+		}
+
+		sb.append(_FINDER_COLUMN_C_T_S_STATUS_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(BackgroundTaskModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(companyId);
+
+		if (bindTaskExecutorClassName) {
+			queryPos.add(taskExecutorClassName);
+		}
+
+		queryPos.add(status);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						backgroundTask)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<BackgroundTask> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status) {
+
+		return findByC_T_S(
+			companyId, taskExecutorClassNames, status, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status, int start,
+		int end) {
+
+		return findByC_T_S(
+			companyId, taskExecutorClassNames, status, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return findByC_T_S(
+			companyId, taskExecutorClassNames, status, start, end,
+			orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator,
+		boolean useFinderCache) {
+
+		if (taskExecutorClassNames == null) {
+			taskExecutorClassNames = new String[0];
+		}
+		else if (taskExecutorClassNames.length > 1) {
+			for (int i = 0; i < taskExecutorClassNames.length; i++) {
+				taskExecutorClassNames[i] = Objects.toString(
+					taskExecutorClassNames[i], "");
+			}
+
+			taskExecutorClassNames = ArrayUtil.sortedUnique(
+				taskExecutorClassNames);
+		}
+
+		if (taskExecutorClassNames.length == 1) {
+			return findByC_T_S(
+				companyId, taskExecutorClassNames[0], status, start, end,
+				orderByComparator);
+		}
+
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderArgs = new Object[] {
+					companyId, StringUtil.merge(taskExecutorClassNames), status
+				};
+			}
+		}
+		else if (useFinderCache) {
+			finderArgs = new Object[] {
+				companyId, StringUtil.merge(taskExecutorClassNames), status,
+				start, end, orderByComparator
+			};
+		}
+
+		List<BackgroundTask> list = null;
+
+		if (useFinderCache) {
+			list = (List<BackgroundTask>)finderCache.getResult(
+				_finderPathWithPaginationFindByC_T_S, finderArgs);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (BackgroundTask backgroundTask : list) {
+					if ((companyId != backgroundTask.getCompanyId()) ||
+						!ArrayUtil.contains(
+							taskExecutorClassNames,
+							backgroundTask.getTaskExecutorClassName()) ||
+						(status != backgroundTask.getStatus())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = new StringBundler();
+
+			sb.append(_SQL_SELECT_BACKGROUNDTASK_WHERE);
+
+			sb.append(_FINDER_COLUMN_C_T_S_COMPANYID_2);
+
+			if (taskExecutorClassNames.length > 0) {
+				sb.append("(");
+
+				for (int i = 0; i < taskExecutorClassNames.length; i++) {
+					String taskExecutorClassName = taskExecutorClassNames[i];
+
+					if (taskExecutorClassName.isEmpty()) {
+						sb.append(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_6);
+					}
+					else {
+						sb.append(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_5);
+					}
+
+					if ((i + 1) < taskExecutorClassNames.length) {
+						sb.append(WHERE_OR);
+					}
+				}
+
+				sb.append(")");
+
+				sb.append(WHERE_AND);
+			}
+
+			sb.append(_FINDER_COLUMN_C_T_S_STATUS_2);
+
+			sb.setStringAt(
+				removeConjunction(sb.stringAt(sb.index() - 1)), sb.index() - 1);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(BackgroundTaskModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				for (String taskExecutorClassName : taskExecutorClassNames) {
+					if ((taskExecutorClassName != null) &&
+						!taskExecutorClassName.isEmpty()) {
+
+						queryPos.add(taskExecutorClassName);
+					}
+				}
+
+				queryPos.add(status);
+
+				list = (List<BackgroundTask>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(
+						_finderPathWithPaginationFindByC_T_S, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Removes all the background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 */
+	@Override
+	public void removeByC_T_S(
+		long companyId, String taskExecutorClassName, int status) {
+
+		for (BackgroundTask backgroundTask :
+				findByC_T_S(
+					companyId, taskExecutorClassName, status, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(backgroundTask);
+		}
+	}
+
+	/**
+	 * Returns the number of background tasks where companyId = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	@Override
+	public int countByC_T_S(
+		long companyId, String taskExecutorClassName, int status) {
+
+		taskExecutorClassName = Objects.toString(taskExecutorClassName, "");
+
+		FinderPath finderPath = _finderPathCountByC_T_S;
+
+		Object[] finderArgs = new Object[] {
+			companyId, taskExecutorClassName, status
+		};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_COUNT_BACKGROUNDTASK_WHERE);
+
+			sb.append(_FINDER_COLUMN_C_T_S_COMPANYID_2);
+
+			boolean bindTaskExecutorClassName = false;
+
+			if (taskExecutorClassName.isEmpty()) {
+				sb.append(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_3);
+			}
+			else {
+				bindTaskExecutorClassName = true;
+
+				sb.append(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_2);
+			}
+
+			sb.append(_FINDER_COLUMN_C_T_S_STATUS_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				if (bindTaskExecutorClassName) {
+					queryPos.add(taskExecutorClassName);
+				}
+
+				queryPos.add(status);
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
+	 * Returns the number of background tasks where companyId = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	@Override
+	public int countByC_T_S(
+		long companyId, String[] taskExecutorClassNames, int status) {
+
+		if (taskExecutorClassNames == null) {
+			taskExecutorClassNames = new String[0];
+		}
+		else if (taskExecutorClassNames.length > 1) {
+			for (int i = 0; i < taskExecutorClassNames.length; i++) {
+				taskExecutorClassNames[i] = Objects.toString(
+					taskExecutorClassNames[i], "");
+			}
+
+			taskExecutorClassNames = ArrayUtil.sortedUnique(
+				taskExecutorClassNames);
+		}
+
+		Object[] finderArgs = new Object[] {
+			companyId, StringUtil.merge(taskExecutorClassNames), status
+		};
+
+		Long count = (Long)finderCache.getResult(
+			_finderPathWithPaginationCountByC_T_S, finderArgs);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler();
+
+			sb.append(_SQL_COUNT_BACKGROUNDTASK_WHERE);
+
+			sb.append(_FINDER_COLUMN_C_T_S_COMPANYID_2);
+
+			if (taskExecutorClassNames.length > 0) {
+				sb.append("(");
+
+				for (int i = 0; i < taskExecutorClassNames.length; i++) {
+					String taskExecutorClassName = taskExecutorClassNames[i];
+
+					if (taskExecutorClassName.isEmpty()) {
+						sb.append(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_6);
+					}
+					else {
+						sb.append(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_5);
+					}
+
+					if ((i + 1) < taskExecutorClassNames.length) {
+						sb.append(WHERE_OR);
+					}
+				}
+
+				sb.append(")");
+
+				sb.append(WHERE_AND);
+			}
+
+			sb.append(_FINDER_COLUMN_C_T_S_STATUS_2);
+
+			sb.setStringAt(
+				removeConjunction(sb.stringAt(sb.index() - 1)), sb.index() - 1);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				for (String taskExecutorClassName : taskExecutorClassNames) {
+					if ((taskExecutorClassName != null) &&
+						!taskExecutorClassName.isEmpty()) {
+
+						queryPos.add(taskExecutorClassName);
+					}
+				}
+
+				queryPos.add(status);
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(
+					_finderPathWithPaginationCountByC_T_S, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_C_T_S_COMPANYID_2 =
+		"backgroundTask.companyId = ? AND ";
+
+	private static final String _FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_2 =
+		"backgroundTask.taskExecutorClassName = ? AND ";
+
+	private static final String _FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_3 =
+		"(backgroundTask.taskExecutorClassName IS NULL OR backgroundTask.taskExecutorClassName = '') AND ";
+
+	private static final String _FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_5 =
+		"(" + removeConjunction(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_2) +
+			")";
+
+	private static final String _FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_6 =
+		"(" + removeConjunction(_FINDER_COLUMN_C_T_S_TASKEXECUTORCLASSNAME_3) +
+			")";
+
+	private static final String _FINDER_COLUMN_C_T_S_STATUS_2 =
+		"backgroundTask.status = ?";
+
+	private FinderPath _finderPathWithPaginationFindByN_T_S;
+	private FinderPath _finderPathWithoutPaginationFindByN_T_S;
+	private FinderPath _finderPathCountByN_T_S;
+	private FinderPath _finderPathWithPaginationCountByN_T_S;
+
+	/**
+	 * Returns all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status) {
+
+		return findByN_T_S(
+			name, taskExecutorClassName, status, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status, int start,
+		int end) {
+
+		return findByN_T_S(
+			name, taskExecutorClassName, status, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return findByN_T_S(
+			name, taskExecutorClassName, status, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByN_T_S(
+		String name, String taskExecutorClassName, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator,
+		boolean useFinderCache) {
+
+		name = Objects.toString(name, "");
+		taskExecutorClassName = Objects.toString(taskExecutorClassName, "");
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByN_T_S;
+				finderArgs = new Object[] {name, taskExecutorClassName, status};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByN_T_S;
+			finderArgs = new Object[] {
+				name, taskExecutorClassName, status, start, end,
+				orderByComparator
+			};
+		}
+
+		List<BackgroundTask> list = null;
+
+		if (useFinderCache) {
+			list = (List<BackgroundTask>)finderCache.getResult(
+				finderPath, finderArgs);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (BackgroundTask backgroundTask : list) {
+					if (!name.equals(backgroundTask.getName()) ||
+						!taskExecutorClassName.equals(
+							backgroundTask.getTaskExecutorClassName()) ||
+						(status != backgroundTask.getStatus())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					5 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(5);
+			}
+
+			sb.append(_SQL_SELECT_BACKGROUNDTASK_WHERE);
+
+			boolean bindName = false;
+
+			if (name.isEmpty()) {
+				sb.append(_FINDER_COLUMN_N_T_S_NAME_3);
+			}
+			else {
+				bindName = true;
+
+				sb.append(_FINDER_COLUMN_N_T_S_NAME_2);
+			}
+
+			boolean bindTaskExecutorClassName = false;
+
+			if (taskExecutorClassName.isEmpty()) {
+				sb.append(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_3);
+			}
+			else {
+				bindTaskExecutorClassName = true;
+
+				sb.append(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_2);
+			}
+
+			sb.append(_FINDER_COLUMN_N_T_S_STATUS_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(BackgroundTaskModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				if (bindName) {
+					queryPos.add(name);
+				}
+
+				if (bindTaskExecutorClassName) {
+					queryPos.add(taskExecutorClassName);
+				}
+
+				queryPos.add(status);
+
+				list = (List<BackgroundTask>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	@Override
+	public BackgroundTask findByN_T_S_First(
+			String name, String taskExecutorClassName, int status,
+			OrderByComparator<BackgroundTask> orderByComparator)
+		throws NoSuchBackgroundTaskException {
+
+		BackgroundTask backgroundTask = fetchByN_T_S_First(
+			name, taskExecutorClassName, status, orderByComparator);
+
+		if (backgroundTask != null) {
+			return backgroundTask;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("name=");
+		sb.append(name);
+
+		sb.append(", taskExecutorClassName=");
+		sb.append(taskExecutorClassName);
+
+		sb.append(", status=");
+		sb.append(status);
+
+		sb.append("}");
+
+		throw new NoSuchBackgroundTaskException(sb.toString());
+	}
+
+	/**
+	 * Returns the first background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	@Override
+	public BackgroundTask fetchByN_T_S_First(
+		String name, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator) {
+
+		List<BackgroundTask> list = findByN_T_S(
+			name, taskExecutorClassName, status, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task
+	 * @throws NoSuchBackgroundTaskException if a matching background task could not be found
+	 */
+	@Override
+	public BackgroundTask findByN_T_S_Last(
+			String name, String taskExecutorClassName, int status,
+			OrderByComparator<BackgroundTask> orderByComparator)
+		throws NoSuchBackgroundTaskException {
+
+		BackgroundTask backgroundTask = fetchByN_T_S_Last(
+			name, taskExecutorClassName, status, orderByComparator);
+
+		if (backgroundTask != null) {
+			return backgroundTask;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("name=");
+		sb.append(name);
+
+		sb.append(", taskExecutorClassName=");
+		sb.append(taskExecutorClassName);
+
+		sb.append(", status=");
+		sb.append(status);
+
+		sb.append("}");
+
+		throw new NoSuchBackgroundTaskException(sb.toString());
+	}
+
+	/**
+	 * Returns the last background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching background task, or <code>null</code> if a matching background task could not be found
+	 */
+	@Override
+	public BackgroundTask fetchByN_T_S_Last(
+		String name, String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator) {
+
+		int count = countByN_T_S(name, taskExecutorClassName, status);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<BackgroundTask> list = findByN_T_S(
+			name, taskExecutorClassName, status, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the background tasks before and after the current background task in the ordered set where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param backgroundTaskId the primary key of the current background task
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next background task
+	 * @throws NoSuchBackgroundTaskException if a background task with the primary key could not be found
+	 */
+	@Override
+	public BackgroundTask[] findByN_T_S_PrevAndNext(
+			long backgroundTaskId, String name, String taskExecutorClassName,
+			int status, OrderByComparator<BackgroundTask> orderByComparator)
+		throws NoSuchBackgroundTaskException {
+
+		name = Objects.toString(name, "");
+		taskExecutorClassName = Objects.toString(taskExecutorClassName, "");
+
+		BackgroundTask backgroundTask = findByPrimaryKey(backgroundTaskId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			BackgroundTask[] array = new BackgroundTaskImpl[3];
+
+			array[0] = getByN_T_S_PrevAndNext(
+				session, backgroundTask, name, taskExecutorClassName, status,
+				orderByComparator, true);
+
+			array[1] = backgroundTask;
+
+			array[2] = getByN_T_S_PrevAndNext(
+				session, backgroundTask, name, taskExecutorClassName, status,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected BackgroundTask getByN_T_S_PrevAndNext(
+		Session session, BackgroundTask backgroundTask, String name,
+		String taskExecutorClassName, int status,
+		OrderByComparator<BackgroundTask> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_BACKGROUNDTASK_WHERE);
+
+		boolean bindName = false;
+
+		if (name.isEmpty()) {
+			sb.append(_FINDER_COLUMN_N_T_S_NAME_3);
+		}
+		else {
+			bindName = true;
+
+			sb.append(_FINDER_COLUMN_N_T_S_NAME_2);
+		}
+
+		boolean bindTaskExecutorClassName = false;
+
+		if (taskExecutorClassName.isEmpty()) {
+			sb.append(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_3);
+		}
+		else {
+			bindTaskExecutorClassName = true;
+
+			sb.append(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_2);
+		}
+
+		sb.append(_FINDER_COLUMN_N_T_S_STATUS_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(BackgroundTaskModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		if (bindName) {
+			queryPos.add(name);
+		}
+
+		if (bindTaskExecutorClassName) {
+			queryPos.add(taskExecutorClassName);
+		}
+
+		queryPos.add(status);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						backgroundTask)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<BackgroundTask> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status) {
+
+		return findByN_T_S(
+			name, taskExecutorClassNames, status, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @return the range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status, int start,
+		int end) {
+
+		return findByN_T_S(
+			name, taskExecutorClassNames, status, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator) {
+
+		return findByN_T_S(
+			name, taskExecutorClassNames, status, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>BackgroundTaskModelImpl</code>.
+	 * </p>
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @param start the lower bound of the range of background tasks
+	 * @param end the upper bound of the range of background tasks (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching background tasks
+	 */
+	@Override
+	public List<BackgroundTask> findByN_T_S(
+		String name, String[] taskExecutorClassNames, int status, int start,
+		int end, OrderByComparator<BackgroundTask> orderByComparator,
+		boolean useFinderCache) {
+
+		name = Objects.toString(name, "");
+
+		if (taskExecutorClassNames == null) {
+			taskExecutorClassNames = new String[0];
+		}
+		else if (taskExecutorClassNames.length > 1) {
+			for (int i = 0; i < taskExecutorClassNames.length; i++) {
+				taskExecutorClassNames[i] = Objects.toString(
+					taskExecutorClassNames[i], "");
+			}
+
+			taskExecutorClassNames = ArrayUtil.sortedUnique(
+				taskExecutorClassNames);
+		}
+
+		if (taskExecutorClassNames.length == 1) {
+			return findByN_T_S(
+				name, taskExecutorClassNames[0], status, start, end,
+				orderByComparator);
+		}
+
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderArgs = new Object[] {
+					name, StringUtil.merge(taskExecutorClassNames), status
+				};
+			}
+		}
+		else if (useFinderCache) {
+			finderArgs = new Object[] {
+				name, StringUtil.merge(taskExecutorClassNames), status, start,
+				end, orderByComparator
+			};
+		}
+
+		List<BackgroundTask> list = null;
+
+		if (useFinderCache) {
+			list = (List<BackgroundTask>)finderCache.getResult(
+				_finderPathWithPaginationFindByN_T_S, finderArgs);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (BackgroundTask backgroundTask : list) {
+					if (!name.equals(backgroundTask.getName()) ||
+						!ArrayUtil.contains(
+							taskExecutorClassNames,
+							backgroundTask.getTaskExecutorClassName()) ||
+						(status != backgroundTask.getStatus())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = new StringBundler();
+
+			sb.append(_SQL_SELECT_BACKGROUNDTASK_WHERE);
+
+			boolean bindName = false;
+
+			if (name.isEmpty()) {
+				sb.append(_FINDER_COLUMN_N_T_S_NAME_3);
+			}
+			else {
+				bindName = true;
+
+				sb.append(_FINDER_COLUMN_N_T_S_NAME_2);
+			}
+
+			if (taskExecutorClassNames.length > 0) {
+				sb.append("(");
+
+				for (int i = 0; i < taskExecutorClassNames.length; i++) {
+					String taskExecutorClassName = taskExecutorClassNames[i];
+
+					if (taskExecutorClassName.isEmpty()) {
+						sb.append(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_6);
+					}
+					else {
+						sb.append(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_5);
+					}
+
+					if ((i + 1) < taskExecutorClassNames.length) {
+						sb.append(WHERE_OR);
+					}
+				}
+
+				sb.append(")");
+
+				sb.append(WHERE_AND);
+			}
+
+			sb.append(_FINDER_COLUMN_N_T_S_STATUS_2);
+
+			sb.setStringAt(
+				removeConjunction(sb.stringAt(sb.index() - 1)), sb.index() - 1);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(BackgroundTaskModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				if (bindName) {
+					queryPos.add(name);
+				}
+
+				for (String taskExecutorClassName : taskExecutorClassNames) {
+					if ((taskExecutorClassName != null) &&
+						!taskExecutorClassName.isEmpty()) {
+
+						queryPos.add(taskExecutorClassName);
+					}
+				}
+
+				queryPos.add(status);
+
+				list = (List<BackgroundTask>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(
+						_finderPathWithPaginationFindByN_T_S, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Removes all the background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63; from the database.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 */
+	@Override
+	public void removeByN_T_S(
+		String name, String taskExecutorClassName, int status) {
+
+		for (BackgroundTask backgroundTask :
+				findByN_T_S(
+					name, taskExecutorClassName, status, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(backgroundTask);
+		}
+	}
+
+	/**
+	 * Returns the number of background tasks where name = &#63; and taskExecutorClassName = &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassName the task executor class name
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	@Override
+	public int countByN_T_S(
+		String name, String taskExecutorClassName, int status) {
+
+		name = Objects.toString(name, "");
+		taskExecutorClassName = Objects.toString(taskExecutorClassName, "");
+
+		FinderPath finderPath = _finderPathCountByN_T_S;
+
+		Object[] finderArgs = new Object[] {
+			name, taskExecutorClassName, status
+		};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_COUNT_BACKGROUNDTASK_WHERE);
+
+			boolean bindName = false;
+
+			if (name.isEmpty()) {
+				sb.append(_FINDER_COLUMN_N_T_S_NAME_3);
+			}
+			else {
+				bindName = true;
+
+				sb.append(_FINDER_COLUMN_N_T_S_NAME_2);
+			}
+
+			boolean bindTaskExecutorClassName = false;
+
+			if (taskExecutorClassName.isEmpty()) {
+				sb.append(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_3);
+			}
+			else {
+				bindTaskExecutorClassName = true;
+
+				sb.append(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_2);
+			}
+
+			sb.append(_FINDER_COLUMN_N_T_S_STATUS_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				if (bindName) {
+					queryPos.add(name);
+				}
+
+				if (bindTaskExecutorClassName) {
+					queryPos.add(taskExecutorClassName);
+				}
+
+				queryPos.add(status);
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
+	 * Returns the number of background tasks where name = &#63; and taskExecutorClassName = any &#63; and status = &#63;.
+	 *
+	 * @param name the name
+	 * @param taskExecutorClassNames the task executor class names
+	 * @param status the status
+	 * @return the number of matching background tasks
+	 */
+	@Override
+	public int countByN_T_S(
+		String name, String[] taskExecutorClassNames, int status) {
+
+		name = Objects.toString(name, "");
+
+		if (taskExecutorClassNames == null) {
+			taskExecutorClassNames = new String[0];
+		}
+		else if (taskExecutorClassNames.length > 1) {
+			for (int i = 0; i < taskExecutorClassNames.length; i++) {
+				taskExecutorClassNames[i] = Objects.toString(
+					taskExecutorClassNames[i], "");
+			}
+
+			taskExecutorClassNames = ArrayUtil.sortedUnique(
+				taskExecutorClassNames);
+		}
+
+		Object[] finderArgs = new Object[] {
+			name, StringUtil.merge(taskExecutorClassNames), status
+		};
+
+		Long count = (Long)finderCache.getResult(
+			_finderPathWithPaginationCountByN_T_S, finderArgs);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler();
+
+			sb.append(_SQL_COUNT_BACKGROUNDTASK_WHERE);
+
+			boolean bindName = false;
+
+			if (name.isEmpty()) {
+				sb.append(_FINDER_COLUMN_N_T_S_NAME_3);
+			}
+			else {
+				bindName = true;
+
+				sb.append(_FINDER_COLUMN_N_T_S_NAME_2);
+			}
+
+			if (taskExecutorClassNames.length > 0) {
+				sb.append("(");
+
+				for (int i = 0; i < taskExecutorClassNames.length; i++) {
+					String taskExecutorClassName = taskExecutorClassNames[i];
+
+					if (taskExecutorClassName.isEmpty()) {
+						sb.append(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_6);
+					}
+					else {
+						sb.append(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_5);
+					}
+
+					if ((i + 1) < taskExecutorClassNames.length) {
+						sb.append(WHERE_OR);
+					}
+				}
+
+				sb.append(")");
+
+				sb.append(WHERE_AND);
+			}
+
+			sb.append(_FINDER_COLUMN_N_T_S_STATUS_2);
+
+			sb.setStringAt(
+				removeConjunction(sb.stringAt(sb.index() - 1)), sb.index() - 1);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				if (bindName) {
+					queryPos.add(name);
+				}
+
+				for (String taskExecutorClassName : taskExecutorClassNames) {
+					if ((taskExecutorClassName != null) &&
+						!taskExecutorClassName.isEmpty()) {
+
+						queryPos.add(taskExecutorClassName);
+					}
+				}
+
+				queryPos.add(status);
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(
+					_finderPathWithPaginationCountByN_T_S, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_N_T_S_NAME_2 =
+		"backgroundTask.name = ? AND ";
+
+	private static final String _FINDER_COLUMN_N_T_S_NAME_3 =
+		"(backgroundTask.name IS NULL OR backgroundTask.name = '') AND ";
+
+	private static final String _FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_2 =
+		"backgroundTask.taskExecutorClassName = ? AND ";
+
+	private static final String _FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_3 =
+		"(backgroundTask.taskExecutorClassName IS NULL OR backgroundTask.taskExecutorClassName = '') AND ";
+
+	private static final String _FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_5 =
+		"(" + removeConjunction(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_2) +
+			")";
+
+	private static final String _FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_6 =
+		"(" + removeConjunction(_FINDER_COLUMN_N_T_S_TASKEXECUTORCLASSNAME_3) +
+			")";
+
+	private static final String _FINDER_COLUMN_N_T_S_STATUS_2 =
+		"backgroundTask.status = ?";
+
 	private FinderPath _finderPathWithPaginationFindByG_N_T_C;
 	private FinderPath _finderPathWithoutPaginationFindByG_N_T_C;
 	private FinderPath _finderPathCountByG_N_T_C;
@@ -9448,6 +11479,76 @@ public class BackgroundTaskPersistenceImpl
 				Integer.class.getName()
 			},
 			new String[] {"groupId", "taskExecutorClassName", "status"}, false);
+
+		_finderPathWithPaginationFindByC_T_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_T_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "taskExecutorClassName", "status"},
+			true);
+
+		_finderPathWithoutPaginationFindByC_T_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_T_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"companyId", "taskExecutorClassName", "status"},
+			true);
+
+		_finderPathCountByC_T_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_T_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"companyId", "taskExecutorClassName", "status"},
+			false);
+
+		_finderPathWithPaginationCountByC_T_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_T_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"companyId", "taskExecutorClassName", "status"},
+			false);
+
+		_finderPathWithPaginationFindByN_T_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByN_T_S",
+			new String[] {
+				String.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"name", "taskExecutorClassName", "status"}, true);
+
+		_finderPathWithoutPaginationFindByN_T_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByN_T_S",
+			new String[] {
+				String.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"name", "taskExecutorClassName", "status"}, true);
+
+		_finderPathCountByN_T_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByN_T_S",
+			new String[] {
+				String.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"name", "taskExecutorClassName", "status"}, false);
+
+		_finderPathWithPaginationCountByN_T_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByN_T_S",
+			new String[] {
+				String.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"name", "taskExecutorClassName", "status"}, false);
 
 		_finderPathWithPaginationFindByG_N_T_C = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_N_T_C",

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,8 +1,12 @@
-create index IX_C5A6C78F on BackgroundTask (companyId);
+create index IX_1B4BE3F2 on BackgroundTask (companyId, taskExecutorClassName[$COLUMN_LENGTH:200$], status);
 create index IX_FBF5FAA2 on BackgroundTask (completed);
 create index IX_579C63B0 on BackgroundTask (groupId, name[$COLUMN_LENGTH:255$], taskExecutorClassName[$COLUMN_LENGTH:200$], completed);
 create index IX_C71C3B7 on BackgroundTask (groupId, status);
 create index IX_7A9FF471 on BackgroundTask (groupId, taskExecutorClassName[$COLUMN_LENGTH:200$], completed);
 create index IX_7E757D70 on BackgroundTask (groupId, taskExecutorClassName[$COLUMN_LENGTH:200$], status);
+create index IX_21801669 on BackgroundTask (name[$COLUMN_LENGTH:255$], taskExecutorClassName[$COLUMN_LENGTH:200$], status);
 create index IX_75638CDF on BackgroundTask (status);
+create index IX_B27C416C on BackgroundTask (taskExecutorClassName[$COLUMN_LENGTH:200$], companyId, status);
+create index IX_4F6A0F6E on BackgroundTask (taskExecutorClassName[$COLUMN_LENGTH:200$], groupId, status);
+create index IX_BDFEB687 on BackgroundTask (taskExecutorClassName[$COLUMN_LENGTH:200$], name[$COLUMN_LENGTH:255$], status);
 create index IX_2FCFE748 on BackgroundTask (taskExecutorClassName[$COLUMN_LENGTH:200$], status);

--- a/modules/apps/portal-background-task/portal-background-task-test/build.gradle
+++ b/modules/apps/portal-background-task/portal-background-task-test/build.gradle
@@ -3,5 +3,6 @@ dependencies {
 	testIntegrationCompile project(":apps:portal-background-task:portal-background-task-api")
 	testIntegrationCompile project(":apps:portal-background-task:portal-background-task-service")
 	testIntegrationCompile project(":core:petra:petra-sql-dsl-api")
+	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/internal/messaging/test/BackgroundTaskQueuingMessageListenerTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/internal/messaging/test/BackgroundTaskQueuingMessageListenerTest.java
@@ -1,0 +1,481 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.background.task.internal.messaging.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.background.task.kernel.util.comparator.BackgroundTaskCreateDateComparator;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.background.task.model.BackgroundTask;
+import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
+import com.liferay.portal.background.task.service.BackgroundTaskLocalServiceWrapper;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
+import com.liferay.portal.kernel.backgroundtask.BaseBackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
+import com.liferay.portal.kernel.backgroundtask.display.BackgroundTaskDisplay;
+import com.liferay.portal.kernel.lock.Lock;
+import com.liferay.portal.kernel.lock.LockManager;
+import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Hai Yu
+ */
+@RunWith(Arquillian.class)
+public class BackgroundTaskQueuingMessageListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(
+			BackgroundTaskQueuingMessageListenerTest.class);
+
+		_bundleContext = bundle.getBundleContext();
+
+		_backgroundTaskExecutorServiceRegistrations.add(
+			_bundleContext.registerService(
+				BackgroundTaskExecutor.class.getName(),
+				_testSerialBackgroundTaskExecutor,
+				new HashMapDictionary<String, String>() {
+					{
+						put(
+							"background.task.executor.class.name",
+							TestSerialBackgroundTaskExecutor.class.getName());
+					}
+				}));
+
+		_backgroundTaskExecutorServiceRegistrations.add(
+			_bundleContext.registerService(
+				BackgroundTaskExecutor.class.getName(),
+				_testNoSerialBackgroundTaskExecutor,
+				new HashMapDictionary<String, String>() {
+					{
+						put(
+							"background.task.executor.class.name",
+							TestNoSerialBackgroundTaskExecutor.class.getName());
+					}
+				}));
+
+		_backgroundTaskLocalServiceWrapperServiceRegistration =
+			_bundleContext.registerService(
+				ServiceWrapper.class.getName(),
+				new TestBackgroundTaskLocalServiceWrapper(), null);
+
+		_createQueuedBackgroundTask();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		for (ServiceRegistration<?> backgroundTaskExecutorServiceRegistration :
+				_backgroundTaskExecutorServiceRegistrations) {
+
+			backgroundTaskExecutorServiceRegistration.unregister();
+		}
+
+		_backgroundTaskExecutorServiceRegistrations.clear();
+
+		if (_backgroundTaskLocalServiceWrapperServiceRegistration != null) {
+			_backgroundTaskLocalServiceWrapperServiceRegistration.unregister();
+		}
+
+		if (_company != null) {
+			_companyLocalService.deleteCompany(_company);
+		}
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_user = UserTestUtil.addUser();
+
+		_group = GroupTestUtil.addGroup();
+
+		_actualBackgroundTask = null;
+	}
+
+	@Test
+	public void testResumedBackgroundTaskByCompanyIdFromQueued()
+		throws Exception {
+
+		_testSerialBackgroundTaskExecutor.setIsolationLevel(
+			BackgroundTaskConstants.ISOLATION_LEVEL_COMPANY);
+
+		_assertResumedBackgroundTaskFromQueued(
+			BackgroundTaskConstants.ISOLATION_LEVEL_COMPANY,
+			TestSerialBackgroundTaskExecutor.class.getName() +
+				StringPool.POUND + _user.getCompanyId());
+	}
+
+	@Test
+	public void testResumedBackgroundTaskByGroupIdFromQueued()
+		throws Exception {
+
+		_testSerialBackgroundTaskExecutor.setIsolationLevel(
+			BackgroundTaskConstants.ISOLATION_LEVEL_GROUP);
+
+		_assertResumedBackgroundTaskFromQueued(
+			BackgroundTaskConstants.ISOLATION_LEVEL_GROUP,
+			TestSerialBackgroundTaskExecutor.class.getName() +
+				StringPool.POUND + _group.getGroupId());
+	}
+
+	@Test
+	public void testResumedBackgroundTaskByLevelClassFromQueued()
+		throws Exception {
+
+		_testSerialBackgroundTaskExecutor.setIsolationLevel(
+			BackgroundTaskConstants.ISOLATION_LEVEL_CLASS);
+
+		_assertResumedBackgroundTaskFromQueued(
+			BackgroundTaskConstants.ISOLATION_LEVEL_CLASS,
+			TestSerialBackgroundTaskExecutor.class.getName());
+	}
+
+	@Test
+	public void testResumedBackgroundTaskByLevelCustomFromQueued()
+		throws Exception {
+
+		_testSerialBackgroundTaskExecutor.setIsolationLevel(
+			BackgroundTaskConstants.ISOLATION_LEVEL_CUSTOM);
+
+		_assertResumedBackgroundTaskFromQueued(
+			BackgroundTaskConstants.ISOLATION_LEVEL_CUSTOM,
+			TestSerialBackgroundTaskExecutor.class.getName() +
+				StringPool.POUND +
+					BackgroundTaskConstants.ISOLATION_LEVEL_CUSTOM);
+	}
+
+	@Test
+	public void testResumedBackgroundTaskByNameFromQueued() throws Exception {
+		_testSerialBackgroundTaskExecutor.setIsolationLevel(
+			BackgroundTaskConstants.ISOLATION_LEVEL_TASK_NAME);
+
+		_assertResumedBackgroundTaskFromQueued(
+			BackgroundTaskConstants.ISOLATION_LEVEL_TASK_NAME,
+			TestSerialBackgroundTaskExecutor.class.getName() +
+				StringPool.POUND + _EXPECT_NAME);
+	}
+
+	@Test
+	public void testResumedBackgroundTaskByNotIsolatedFromQueued()
+		throws Exception {
+
+		_assertResumedBackgroundTaskFromQueued(
+			BackgroundTaskConstants.ISOLATION_LEVEL_NOT_ISOLATED, null);
+	}
+
+	private static void _createQueuedBackgroundTask() throws Exception {
+		_testSerialBackgroundTaskExecutor.setIsolationLevel(
+			BackgroundTaskConstants.ISOLATION_LEVEL_CLASS);
+
+		_company = CompanyTestUtil.addCompany();
+
+		User defaultUser = _company.getDefaultUser();
+
+		String taskExecutorClassName =
+			TestSerialBackgroundTaskExecutor.class.getName();
+
+		_lockManager.lock(
+			BackgroundTaskExecutor.class.getName(), taskExecutorClassName,
+			_OWNER);
+
+		int count = 3;
+
+		try {
+			for (int i = 0; i < count; i++) {
+				_backgroundTaskLocalService.addBackgroundTask(
+					defaultUser.getUserId(), _company.getGroupId(), _TEST_NAME,
+					taskExecutorClassName,
+					HashMapBuilder.<String, Serializable>put(
+						"key", i
+					).build(),
+					null);
+			}
+		}
+		finally {
+			_lockManager.unlock(
+				BackgroundTaskExecutor.class.getName(), taskExecutorClassName,
+				_OWNER);
+		}
+	}
+
+	private void _assertResumedBackgroundTaskFromQueued(
+			int isolationLevel, String lockKey)
+		throws Exception {
+
+		String taskExecutorClassName =
+			TestSerialBackgroundTaskExecutor.class.getName();
+
+		Lock lock = null;
+
+		if (lockKey != null) {
+			lock = _lockManager.lock(
+				BackgroundTaskExecutor.class.getName(), lockKey, _OWNER);
+		}
+		else {
+			taskExecutorClassName =
+				TestNoSerialBackgroundTaskExecutor.class.getName();
+		}
+
+		BackgroundTask expectedBackgroundTask = null;
+
+		try {
+			expectedBackgroundTask =
+				_backgroundTaskLocalService.addBackgroundTask(
+					_user.getUserId(), _group.getGroupId(), _EXPECT_NAME,
+					taskExecutorClassName, null, null);
+		}
+		finally {
+			if (lock != null) {
+				_lockManager.unlock(
+					BackgroundTaskExecutor.class.getName(), lockKey, _OWNER);
+			}
+		}
+
+		long expectedBackgroundTaskId =
+			expectedBackgroundTask.getBackgroundTaskId();
+
+		Message message = new Message();
+
+		if (isolationLevel !=
+				BackgroundTaskConstants.ISOLATION_LEVEL_NOT_ISOLATED) {
+
+			message.put("status", BackgroundTaskConstants.STATUS_QUEUED);
+			message.put("isolationLevel", isolationLevel);
+			message.put("lockKey", lockKey);
+		}
+		else {
+			message.put("status", BackgroundTaskConstants.STATUS_SUCCESSFUL);
+		}
+
+		message.put(
+			BackgroundTaskConstants.BACKGROUND_TASK_ID,
+			expectedBackgroundTaskId);
+		message.put("taskExecutorClassName", taskExecutorClassName);
+
+		_messageBus.sendMessage(
+			DestinationNames.BACKGROUND_TASK_STATUS, message);
+
+		if (isolationLevel ==
+				BackgroundTaskConstants.ISOLATION_LEVEL_NOT_ISOLATED) {
+
+			Assert.assertNull(
+				"Non-serial BackgroundTaskExecutor resumed one queued " +
+					"BackgroundTask",
+				_actualBackgroundTask);
+
+			return;
+		}
+		else if ((isolationLevel !=
+					BackgroundTaskConstants.ISOLATION_LEVEL_COMPANY) &&
+				 (isolationLevel !=
+					 BackgroundTaskConstants.ISOLATION_LEVEL_GROUP) &&
+				 (isolationLevel !=
+					 BackgroundTaskConstants.ISOLATION_LEVEL_TASK_NAME)) {
+
+			Assert.assertEquals(_TEST_NAME, _actualBackgroundTask.getName());
+
+			com.liferay.portal.kernel.backgroundtask.BackgroundTask
+				actualLastBackgroundTask =
+					_backgroundTaskManager.fetchFirstBackgroundTask(
+						taskExecutorClassName,
+						BackgroundTaskConstants.STATUS_QUEUED,
+						new BackgroundTaskCreateDateComparator(false));
+
+			Assert.assertTrue(
+				actualLastBackgroundTask.getBackgroundTaskId() ==
+					expectedBackgroundTaskId);
+			Assert.assertEquals(
+				_EXPECT_NAME, actualLastBackgroundTask.getName());
+
+			return;
+		}
+
+		Assert.assertTrue(
+			"BackgroundTask status is not QUEUED(4)",
+			_actualBackgroundTask.getStatus() ==
+				BackgroundTaskConstants.STATUS_QUEUED);
+		Assert.assertTrue(
+			_actualBackgroundTask.getBackgroundTaskId() ==
+				expectedBackgroundTaskId);
+		Assert.assertEquals(_EXPECT_NAME, _actualBackgroundTask.getName());
+	}
+
+	private static final String _EXPECT_NAME = "_EXPECT_NAME";
+
+	private static final String _OWNER = "OWNER";
+
+	private static final String _TEST_NAME = "_TEST_NAME";
+
+	private static BackgroundTask _actualBackgroundTask;
+	private static final List<ServiceRegistration<?>>
+		_backgroundTaskExecutorServiceRegistrations =
+			new CopyOnWriteArrayList<>();
+
+	@Inject
+	private static BackgroundTaskLocalService _backgroundTaskLocalService;
+
+	private static ServiceRegistration<?>
+		_backgroundTaskLocalServiceWrapperServiceRegistration;
+	private static BundleContext _bundleContext;
+	private static Company _company;
+
+	@Inject
+	private static CompanyLocalService _companyLocalService;
+
+	@Inject
+	private static LockManager _lockManager;
+
+	private static final TestNoSerialBackgroundTaskExecutor
+		_testNoSerialBackgroundTaskExecutor =
+			new TestNoSerialBackgroundTaskExecutor();
+	private static final TestSerialBackgroundTaskExecutor
+		_testSerialBackgroundTaskExecutor =
+			new TestSerialBackgroundTaskExecutor();
+
+	@Inject
+	private BackgroundTaskManager _backgroundTaskManager;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MessageBus _messageBus;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+	private static class TestBackgroundTaskLocalServiceWrapper
+		extends BackgroundTaskLocalServiceWrapper {
+
+		public TestBackgroundTaskLocalServiceWrapper() {
+			super(null);
+		}
+
+		@Override
+		public void resumeBackgroundTask(long backgroundTaskId) {
+			BackgroundTask backgroundTask =
+				_backgroundTaskLocalService.fetchBackgroundTask(
+					backgroundTaskId);
+
+			String name = backgroundTask.getName();
+
+			if (name.equals(_EXPECT_NAME) || name.equals(_TEST_NAME)) {
+				_actualBackgroundTask = backgroundTask;
+
+				return;
+			}
+
+			_backgroundTaskLocalService.resumeBackgroundTask(backgroundTaskId);
+		}
+
+	}
+
+	private static class TestNoSerialBackgroundTaskExecutor
+		extends BaseBackgroundTaskExecutor {
+
+		@Override
+		public BackgroundTaskExecutor clone() {
+			return this;
+		}
+
+		@Override
+		public BackgroundTaskResult execute(
+			com.liferay.portal.kernel.backgroundtask.BackgroundTask
+				backgroundTask) {
+
+			return BackgroundTaskResult.SUCCESS;
+		}
+
+		@Override
+		public BackgroundTaskDisplay getBackgroundTaskDisplay(
+			com.liferay.portal.kernel.backgroundtask.BackgroundTask
+				backgroundTask) {
+
+			return null;
+		}
+
+	}
+
+	private static class TestSerialBackgroundTaskExecutor
+		extends BaseBackgroundTaskExecutor {
+
+		@Override
+		public BackgroundTaskExecutor clone() {
+			return this;
+		}
+
+		@Override
+		public BackgroundTaskResult execute(
+			com.liferay.portal.kernel.backgroundtask.BackgroundTask
+				backgroundTask) {
+
+			return BackgroundTaskResult.SUCCESS;
+		}
+
+		@Override
+		public BackgroundTaskDisplay getBackgroundTaskDisplay(
+			com.liferay.portal.kernel.backgroundtask.BackgroundTask
+				backgroundTask) {
+
+			return null;
+		}
+
+		@Override
+		protected void setIsolationLevel(int isolationLevel) {
+			super.setIsolationLevel(isolationLevel);
+		}
+
+	}
+
+}

--- a/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/persistence/test/BackgroundTaskPersistenceTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/persistence/test/BackgroundTaskPersistenceTest.java
@@ -341,6 +341,45 @@ public class BackgroundTaskPersistenceTest {
 	}
 
 	@Test
+	public void testCountByC_T_S() throws Exception {
+		_persistence.countByC_T_S(
+			RandomTestUtil.nextLong(), "", RandomTestUtil.nextInt());
+
+		_persistence.countByC_T_S(0L, "null", 0);
+
+		_persistence.countByC_T_S(0L, (String)null, 0);
+	}
+
+	@Test
+	public void testCountByC_T_SArrayable() throws Exception {
+		_persistence.countByC_T_S(
+			RandomTestUtil.nextLong(),
+			new String[] {
+				RandomTestUtil.randomString(), "", "null", null, null
+			},
+			RandomTestUtil.nextInt());
+	}
+
+	@Test
+	public void testCountByN_T_S() throws Exception {
+		_persistence.countByN_T_S("", "", RandomTestUtil.nextInt());
+
+		_persistence.countByN_T_S("null", "null", 0);
+
+		_persistence.countByN_T_S((String)null, (String)null, 0);
+	}
+
+	@Test
+	public void testCountByN_T_SArrayable() throws Exception {
+		_persistence.countByN_T_S(
+			RandomTestUtil.randomString(),
+			new String[] {
+				RandomTestUtil.randomString(), "", "null", null, null
+			},
+			RandomTestUtil.nextInt());
+	}
+
+	@Test
 	public void testCountByG_N_T_C() throws Exception {
 		_persistence.countByG_N_T_C(
 			RandomTestUtil.nextLong(), "", "", RandomTestUtil.randomBoolean());

--- a/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/BackgroundTaskManager.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/BackgroundTaskManager.java
@@ -94,6 +94,15 @@ public interface BackgroundTaskManager {
 		String taskExecutorClassName, int status,
 		OrderByComparator<BackgroundTask> orderByComparator);
 
+	public BackgroundTask fetchFirstBackgroundTask(
+		String name, String taskExecutorClassName, int status);
+
+	public BackgroundTask fetchFirstBackgroundTaskByCompanyId(
+		long companyId, String taskExecutorClassName, int status);
+
+	public BackgroundTask fetchFirstBackgroundTaskByGroupId(
+		long groupId, String taskExecutorClassName, int status);
+
 	public BackgroundTask getBackgroundTask(long backgroundTaskId)
 		throws PortalException;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0


### PR DESCRIPTION
@dantewang, I foundd one issue. BackgroundTaskExecutorRegistryUtil.getBackgroundTaskExecutor() can't get the BackgroundTaskExecutor from war defination. Only BackgroundTaskMessageListener took care the case. (BackgroundTaskMessageListener.getBackgroundTaskExecutor()). In other usages, we are missing the function, for example, BackgroundTaskLockHelper.getLockKey().  Should we take care the case in the PR? 