### PR TITLE
LPS-118542 Log4JUtilTest

### DIFF
--- a/modules/apps/petra/petra-log4j/build.gradle
+++ b/modules/apps/petra/petra-log4j/build.gradle
@@ -4,4 +4,6 @@ dependencies {
 	compileOnly group: "org.dom4j", name: "dom4j", version: "2.1.3"
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-string")
+
+	testCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 }

--- a/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/Log4JUtil.java
+++ b/modules/apps/petra/petra-log4j/src/main/java/com/liferay/petra/log4j/Log4JUtil.java
@@ -234,16 +234,24 @@ public class Log4JUtil {
 	}
 
 	private static java.util.logging.Level _getJdkLevel(String priority) {
-		if (StringUtil.equalsIgnoreCase(priority, Level.DEBUG.toString())) {
+		if (StringUtil.equalsIgnoreCase(priority, Level.ALL.toString())) {
+			return java.util.logging.Level.ALL;
+		}
+		else if (StringUtil.equalsIgnoreCase(
+					priority, Level.DEBUG.toString())) {
+
 			return java.util.logging.Level.FINE;
+		}
+		else if (StringUtil.equalsIgnoreCase(priority, Level.WARN.toString())) {
+			return java.util.logging.Level.WARNING;
 		}
 		else if (StringUtil.equalsIgnoreCase(
 					priority, Level.ERROR.toString())) {
 
 			return java.util.logging.Level.SEVERE;
 		}
-		else if (StringUtil.equalsIgnoreCase(priority, Level.WARN.toString())) {
-			return java.util.logging.Level.WARNING;
+		else if (StringUtil.equalsIgnoreCase(priority, Level.OFF.toString())) {
+			return java.util.logging.Level.OFF;
 		}
 
 		return java.util.logging.Level.INFO;

--- a/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
+++ b/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.apache.log4j.Appender;
 import org.apache.log4j.Logger;
@@ -74,6 +75,8 @@ public class Log4JUtilTest {
 		_assertLogLevel("WARN", log);
 
 		_assertLogEnable();
+
+		_assertJDKLogEnable();
 	}
 
 	@Test
@@ -83,6 +86,8 @@ public class Log4JUtilTest {
 		Log4JUtil.configureLog4J(url);
 
 		_assertLogEnable();
+
+		_assertJDKLogEnable();
 	}
 
 	@Test
@@ -179,6 +184,66 @@ public class Log4JUtilTest {
 		Assert.assertFalse(
 			"The root logger should not own appenders after shutting down",
 			appendersEnumeration.hasMoreElements());
+	}
+
+	private void _assertJDKLogEnable() {
+		_assertJDKLogLevel(
+			"INFO",
+			java.util.logging.Logger.getLogger(
+				LoggerName.LOGGER_ALL.toString()));
+		_assertJDKLogLevel(
+			"INFO",
+			java.util.logging.Logger.getLogger(
+				LoggerName.LOGGER_OFF.toString()));
+		_assertJDKLogLevel(
+			"INFO",
+			java.util.logging.Logger.getLogger(
+				LoggerName.LOGGER_FATAL.toString()));
+		_assertJDKLogLevel(
+			"SEVERE",
+			java.util.logging.Logger.getLogger(
+				LoggerName.LOGGER_ERROR.toString()));
+		_assertJDKLogLevel(
+			"WARNING",
+			java.util.logging.Logger.getLogger(
+				LoggerName.LOGGER_WARN.toString()));
+		_assertJDKLogLevel(
+			"INFO",
+			java.util.logging.Logger.getLogger(
+				LoggerName.LOGGER_INFO.toString()));
+		_assertJDKLogLevel(
+			"FINE",
+			java.util.logging.Logger.getLogger(
+				LoggerName.LOGGER_DEBUG.toString()));
+		_assertJDKLogLevel(
+			"INFO",
+			java.util.logging.Logger.getLogger(
+				LoggerName.LOGGER_TRACE.toString()));
+	}
+
+	private void _assertJDKLogLevel(
+		String expectedLevel, java.util.logging.Logger jdkLog) {
+
+		String actualLevel = null;
+
+		if (jdkLog.isLoggable(Level.FINE)) {
+			actualLevel = "FINE";
+		}
+		else if (jdkLog.isLoggable(Level.INFO)) {
+			actualLevel = "INFO";
+		}
+		else if (jdkLog.isLoggable(Level.WARNING)) {
+			actualLevel = "WARNING";
+		}
+		else if (jdkLog.isLoggable(Level.SEVERE)) {
+			actualLevel = "SEVERE";
+		}
+		else {
+			actualLevel = "INFO";
+		}
+
+		Assert.assertEquals(
+			"Logging level is wrong", expectedLevel, actualLevel);
 	}
 
 	private void _assertLogEnable() {

--- a/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
+++ b/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
@@ -79,16 +79,13 @@ public class Log4JUtilTest {
 		Log log = LogFactoryUtil.getLog(
 			"com.liferay.portal.internal.servlet.MainServlet");
 
-		Assert.assertTrue(
-			"The logger MainServlet should be INFO level", log.isInfoEnabled());
+		_assertLogLevel("INFO", log);
 
 		tempFile.renameTo(file);
 
 		Log4JUtil.configureLog4J(_classLoader);
 
-		Assert.assertTrue(
-			"The logger MainServlet should be WARN level",
-			log.isWarnEnabled() && !log.isInfoEnabled());
+		_assertLogLevel("WARN", log);
 
 		_assertLogEnable();
 	}
@@ -146,23 +143,15 @@ public class Log4JUtilTest {
 				logName, "WARN"
 			).build());
 
-		Log log = LogFactoryUtil.getLog(logName);
+		_assertLogLevel("WARN", LogFactoryUtil.getLog(logName));
 
-		Assert.assertTrue(
-			logName + " logger level should be WARN", log.isWarnEnabled());
+		_assertLogLevel(
+			"INFO", LogFactoryUtil.getLog(LoggerName.LOGGER_INFO.toString()));
 
-		log = LogFactoryUtil.getLog(LoggerName.LOGGER_INFO.toString());
-
-		Assert.assertTrue(
-			"The logger of ServerDetector should be INFO level",
-			log.isInfoEnabled());
-
-		log = LogFactoryUtil.getLog(
-			"com.liferay.portal.internal.servlet.MainServlet");
-
-		Assert.assertTrue(
-			"The logger MainServlet should be WARN level",
-			log.isWarnEnabled() && !log.isInfoEnabled());
+		_assertLogLevel(
+			"WARN",
+			LogFactoryUtil.getLog(
+				"com.liferay.portal.internal.servlet.MainServlet"));
 	}
 
 	@Test
@@ -171,24 +160,19 @@ public class Log4JUtilTest {
 
 		Log log = LogFactoryUtil.getLog(LoggerName.LOGGER_WARN.toString());
 
-		Assert.assertTrue("Warn level should be enabled", log.isWarnEnabled());
+		_assertLogLevel("WARN", log);
 
 		Log4JUtil.setLevel(LoggerName.LOGGER_WARN.toString(), "DEBUG", false);
 
-		Assert.assertTrue(
-			"DEBUG level should be enabled", log.isDebugEnabled());
+		_assertLogLevel("DEBUG", log);
 
 		Log childLog = LogFactoryUtil.getLog("com.test.parent.child");
 
-		Assert.assertTrue(
-			"INFO level should be enabled", childLog.isInfoEnabled());
-		Assert.assertFalse(
-			"DEBUG level should be not enabled", childLog.isDebugEnabled());
+		_assertLogLevel("INFO", childLog);
 
 		Log4JUtil.setLevel("com.test.parent", "DEBUG", false);
 
-		Assert.assertTrue(
-			"DEBUG level should be enabled", childLog.isDebugEnabled());
+		_assertLogLevel("DEBUG", childLog);
 	}
 
 	@Test
@@ -211,51 +195,59 @@ public class Log4JUtilTest {
 	}
 
 	private void _assertLogEnable() {
-		Log log = LogFactoryUtil.getLog(LoggerName.LOGGER_ALL.toString());
+		_assertLogLevel(
+			"ALL", LogFactoryUtil.getLog(LoggerName.LOGGER_ALL.toString()));
+		_assertLogLevel(
+			"OFF", LogFactoryUtil.getLog(LoggerName.LOGGER_OFF.toString()));
+		_assertLogLevel(
+			"FATAL", LogFactoryUtil.getLog(LoggerName.LOGGER_FATAL.toString()));
+		_assertLogLevel(
+			"ERROR", LogFactoryUtil.getLog(LoggerName.LOGGER_ERROR.toString()));
+		_assertLogLevel(
+			"WARN", LogFactoryUtil.getLog(LoggerName.LOGGER_WARN.toString()));
+		_assertLogLevel(
+			"INFO", LogFactoryUtil.getLog(LoggerName.LOGGER_INFO.toString()));
+		_assertLogLevel(
+			"DEBUG", LogFactoryUtil.getLog(LoggerName.LOGGER_DEBUG.toString()));
+		_assertLogLevel(
+			"TRACE", LogFactoryUtil.getLog(LoggerName.LOGGER_TRACE.toString()));
+	}
 
-		Assert.assertTrue("Logger should be all enabled", log.isTraceEnabled());
+	private void _assertLogLevel(String expectedLevel, Log log) {
+		if (expectedLevel.equals("ALL")) {
+			Assert.assertTrue(
+				"TRACE should be enabled if logging level is ALL",
+				log.isTraceEnabled());
 
-		log = LogFactoryUtil.getLog(LoggerName.LOGGER_OFF.toString());
+			return;
+		}
 
-		Assert.assertFalse(
-			"Setting logger level OFF does not take effect",
-			log.isFatalEnabled());
+		String actualLevel = null;
 
-		log = LogFactoryUtil.getLog(LoggerName.LOGGER_FATAL.toString());
+		if (log.isTraceEnabled()) {
+			actualLevel = "TRACE";
+		}
+		else if (log.isDebugEnabled()) {
+			actualLevel = "DEBUG";
+		}
+		else if (log.isInfoEnabled()) {
+			actualLevel = "INFO";
+		}
+		else if (log.isWarnEnabled()) {
+			actualLevel = "WARN";
+		}
+		else if (log.isErrorEnabled()) {
+			actualLevel = "ERROR";
+		}
+		else if (log.isFatalEnabled()) {
+			actualLevel = "FATAL";
+		}
+		else {
+			actualLevel = "OFF";
+		}
 
-		Assert.assertTrue(
-			"Setting logger level FATAL does not take effect",
-			log.isFatalEnabled() && !log.isErrorEnabled());
-
-		log = LogFactoryUtil.getLog(LoggerName.LOGGER_ERROR.toString());
-
-		Assert.assertTrue(
-			"Setting logger level ERROR does not take effect",
-			log.isErrorEnabled() && !log.isWarnEnabled());
-
-		log = LogFactoryUtil.getLog(LoggerName.LOGGER_WARN.toString());
-
-		Assert.assertTrue(
-			"Setting logger level WARN does not take effect",
-			log.isWarnEnabled() && !log.isInfoEnabled());
-
-		log = LogFactoryUtil.getLog(LoggerName.LOGGER_INFO.toString());
-
-		Assert.assertTrue(
-			"Setting logger level INFO does not take effect",
-			log.isInfoEnabled() && !log.isDebugEnabled());
-
-		log = LogFactoryUtil.getLog(LoggerName.LOGGER_DEBUG.toString());
-
-		Assert.assertTrue(
-			"Setting logger level DEBUG does not take effect",
-			log.isDebugEnabled() && !log.isTraceEnabled());
-
-		log = LogFactoryUtil.getLog(LoggerName.LOGGER_TRACE.toString());
-
-		Assert.assertTrue(
-			"Setting logger level TRACE does not take effect",
-			log.isTraceEnabled());
+		Assert.assertEquals(
+			"Logging level is wrong", expectedLevel, actualLevel);
 	}
 
 	private static final ClassLoader _classLoader =

--- a/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
+++ b/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
@@ -129,21 +129,20 @@ public class Log4JUtilTest {
 			HashMapBuilder.putAll(
 				new HashMap<String, String>()
 			).put(
-				com.liferay.portal.util.PropsUtil.class.getName(), "WARN"
+				"com.liferay.portal.util.PropsUtil", "WARN"
 			).build());
 
 		_assertLogLevel(
-			"WARN",
-			LogFactoryUtil.getLog(
-				com.liferay.portal.util.PropsUtil.class.getName()));
-
-		_assertLogLevel(
-			"INFO", LogFactoryUtil.getLog(LoggerName.LOGGER_INFO.toString()));
+			"WARN", LogFactoryUtil.getLog("com.liferay.portal.util.PropsUtil"));
 
 		_assertLogLevel(
 			"WARN",
 			LogFactoryUtil.getLog(
 				"com.liferay.portal.internal.servlet.MainServlet"));
+
+		_assertLogEnable();
+
+		_assertJDKLogEnable();
 	}
 
 	@Test

--- a/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
+++ b/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
@@ -20,14 +20,14 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ServerDetector;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.log.Log4jLogFactoryImpl;
 import com.liferay.portal.util.PropsImpl;
 
-import java.io.File;
+import java.io.IOException;
 
 import java.net.URL;
 
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -62,26 +62,12 @@ public class Log4JUtilTest {
 
 	@Test
 	public void testConfigureLog4JWithClassLoader() {
-		URL url = _classLoader.getResource("META-INF/portal-log4j-ext.xml");
-
-		String path = url.getPath();
-
-		File file = new File(path);
-
-		File tempFile = new File(
-			StringUtil.replace(
-				path, "portal-log4j-ext.xml", "portal-log4j-ext-temp.xml"));
-
-		file.renameTo(tempFile);
-
-		Log4JUtil.configureLog4J(_classLoader);
+		Log4JUtil.configureLog4J(new TestClassLoader());
 
 		Log log = LogFactoryUtil.getLog(
 			"com.liferay.portal.internal.servlet.MainServlet");
 
 		_assertLogLevel("INFO", log);
-
-		tempFile.renameTo(file);
 
 		Log4JUtil.configureLog4J(_classLoader);
 
@@ -271,6 +257,23 @@ public class Log4JUtilTest {
 		}
 
 		private final String _name;
+
+	}
+
+	private class TestClassLoader extends ClassLoader {
+
+		@Override
+		public Enumeration<URL> getResources(String name) throws IOException {
+			if (name.equals("META-INF/portal-log4j-ext.xml")) {
+				return Collections.enumeration(Collections.<URL>emptyList());
+			}
+
+			return super.getResources(name);
+		}
+
+		private TestClassLoader() {
+			super(_classLoader);
+		}
 
 	}
 

--- a/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
+++ b/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
@@ -152,19 +152,28 @@ public class Log4JUtilTest {
 
 		Log log = LogFactoryUtil.getLog(LoggerName.LOGGER_WARN.toString());
 
+		java.util.logging.Logger jdkLogger = java.util.logging.Logger.getLogger(
+			LoggerName.LOGGER_WARN.toString());
+
 		_assertLogLevel("WARN", log);
+		_assertJDKLogLevel("WARNING", jdkLogger);
 
 		Log4JUtil.setLevel(LoggerName.LOGGER_WARN.toString(), "DEBUG", false);
 
 		_assertLogLevel("DEBUG", log);
+		_assertJDKLogLevel("FINE", jdkLogger);
 
 		Log childLog = LogFactoryUtil.getLog("com.test.parent.child");
+		java.util.logging.Logger childJDKLogger =
+			java.util.logging.Logger.getLogger("com.test.parent.child");
 
 		_assertLogLevel("INFO", childLog);
+		_assertJDKLogLevel("INFO", childJDKLogger);
 
 		Log4JUtil.setLevel("com.test.parent", "DEBUG", false);
 
 		_assertLogLevel("DEBUG", childLog);
+		_assertJDKLogLevel("FINE", childJDKLogger);
 	}
 
 	@Test

--- a/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
+++ b/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
@@ -196,11 +196,11 @@ public class Log4JUtilTest {
 
 	private void _assertJDKLogEnable() {
 		_assertJDKLogLevel(
-			"INFO",
+			"ALL",
 			java.util.logging.Logger.getLogger(
 				LoggerName.LOGGER_ALL.toString()));
 		_assertJDKLogLevel(
-			"INFO",
+			"OFF",
 			java.util.logging.Logger.getLogger(
 				LoggerName.LOGGER_OFF.toString()));
 		_assertJDKLogLevel(
@@ -234,7 +234,10 @@ public class Log4JUtilTest {
 
 		String actualLevel = null;
 
-		if (jdkLog.isLoggable(Level.FINE)) {
+		if (jdkLog.isLoggable(Level.ALL)) {
+			actualLevel = "ALL";
+		}
+		else if (jdkLog.isLoggable(Level.FINE)) {
 			actualLevel = "FINE";
 		}
 		else if (jdkLog.isLoggable(Level.INFO)) {
@@ -245,6 +248,9 @@ public class Log4JUtilTest {
 		}
 		else if (jdkLog.isLoggable(Level.SEVERE)) {
 			actualLevel = "SEVERE";
+		}
+		else if (!jdkLog.isLoggable(Level.SEVERE)) {
+			actualLevel = "OFF";
 		}
 		else {
 			actualLevel = "INFO";

--- a/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
+++ b/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
@@ -72,8 +72,6 @@ public class Log4JUtilTest {
 
 		Log4JUtil.configureLog4J(_classLoader);
 
-		_assertLogLevel("WARN", log);
-
 		_assertLogEnable();
 
 		_assertJDKLogEnable();
@@ -134,11 +132,6 @@ public class Log4JUtilTest {
 
 		_assertLogLevel(
 			"WARN", LogFactoryUtil.getLog("com.liferay.portal.util.PropsUtil"));
-
-		_assertLogLevel(
-			"WARN",
-			LogFactoryUtil.getLog(
-				"com.liferay.portal.internal.servlet.MainServlet"));
 
 		_assertLogEnable();
 
@@ -261,6 +254,11 @@ public class Log4JUtilTest {
 	}
 
 	private void _assertLogEnable() {
+		_assertLogLevel(
+			"WARN",
+			LogFactoryUtil.getLog(
+				"com.liferay.portal.internal.servlet.MainServlet"));
+
 		_assertLogLevel(
 			"ALL", LogFactoryUtil.getLog(LoggerName.LOGGER_ALL.toString()));
 		_assertLogLevel(

--- a/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
+++ b/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.petra.log4j;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.ServerDetector;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.log.Log4jLogFactoryImpl;
+import com.liferay.portal.util.PropsImpl;
+
+import java.io.File;
+
+import java.net.URL;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.Logger;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Hai Yu
+ */
+public class Log4JUtilTest {
+
+	@BeforeClass
+	public static void setUpClass() {
+		PropsUtil.setProps(new PropsImpl());
+
+		LogFactoryUtil.setLogFactory(new Log4jLogFactoryImpl());
+	}
+
+	@After
+	public void tearDown() {
+		Log4JUtil.setLevel(
+			"com.liferay.portal.internal.servlet.MainServlet", "INFO", false);
+
+		Log4JUtil.shutdownLog4J();
+	}
+
+	@Test
+	public void testConfigureLog4JWithClassLoader() {
+		URL url = _classLoader.getResource("META-INF/portal-log4j-ext.xml");
+
+		String path = url.getPath();
+
+		File file = new File(path);
+
+		File tempFile = new File(
+			StringUtil.replace(
+				path, "portal-log4j-ext.xml", "portal-log4j-ext-temp.xml"));
+
+		file.renameTo(tempFile);
+
+		Log4JUtil.configureLog4J(_classLoader);
+
+		Log log = LogFactoryUtil.getLog(
+			"com.liferay.portal.internal.servlet.MainServlet");
+
+		Assert.assertTrue(
+			"The logger MainServlet should be INFO level", log.isInfoEnabled());
+
+		tempFile.renameTo(file);
+
+		Log4JUtil.configureLog4J(_classLoader);
+
+		Assert.assertTrue(
+			"The logger MainServlet should be WARN level",
+			log.isWarnEnabled() && !log.isInfoEnabled());
+
+		_assertLogEnable();
+	}
+
+	@Test
+	public void testConfigureLog4JWithURL() {
+		URL url = _classLoader.getResource("META-INF/portal-log4j-ext.xml");
+
+		Log4JUtil.configureLog4J(url);
+
+		_assertLogEnable();
+	}
+
+	@Test
+	public void testGetCustomLogSettings() {
+		Log4JUtil.configureLog4J(_classLoader);
+
+		Log4JUtil.setLevel("com.custom.log1", "INFO", true);
+		Log4JUtil.setLevel("com.custom.log2", "WARN", true);
+
+		Map<String, String> customLogMap = Log4JUtil.getCustomLogSettings();
+
+		Assert.assertEquals(
+			"The logger com.custom.log1 level should be INFO", "INFO",
+			customLogMap.get("com.custom.log1"));
+		Assert.assertEquals(
+			"The logger com.custom.log2 level should be WARN", "WARN",
+			customLogMap.get("com.custom.log2"));
+	}
+
+	@Test
+	public void testGetOriginalLevel() {
+		Log4JUtil.configureLog4J(_classLoader);
+
+		String level = Log4JUtil.getOriginalLevel(
+			"com.liferay.portal.internal.servlet.MainServlet");
+
+		Assert.assertEquals("The original level should be WARN", "WARN", level);
+
+		level = Log4JUtil.getOriginalLevel(LoggerName.LOGGER_WARN.toString());
+
+		Assert.assertEquals("The original level should be WARN", "WARN", level);
+	}
+
+	@Test
+	public void testInitLog4J() {
+		String logName = com.liferay.portal.util.PropsUtil.class.getName();
+
+		Log4JUtil.initLog4J(
+			ServerDetector.getServerId(), PropsUtil.get(PropsKeys.LIFERAY_HOME),
+			_classLoader, new Log4jLogFactoryImpl(),
+			HashMapBuilder.putAll(
+				new HashMap<String, String>()
+			).put(
+				logName, "WARN"
+			).build());
+
+		Log log = LogFactoryUtil.getLog(logName);
+
+		Assert.assertTrue(
+			logName + " logger level should be WARN", log.isWarnEnabled());
+
+		log = LogFactoryUtil.getLog(LoggerName.LOGGER_INFO.toString());
+
+		Assert.assertTrue(
+			"The logger of ServerDetector should be INFO level",
+			log.isInfoEnabled());
+
+		log = LogFactoryUtil.getLog(
+			"com.liferay.portal.internal.servlet.MainServlet");
+
+		Assert.assertTrue(
+			"The logger MainServlet should be WARN level",
+			log.isWarnEnabled() && !log.isInfoEnabled());
+	}
+
+	@Test
+	public void testSetLevel() {
+		Log4JUtil.configureLog4J(_classLoader);
+
+		Log log = LogFactoryUtil.getLog(LoggerName.LOGGER_WARN.toString());
+
+		Assert.assertTrue("Warn level should be enabled", log.isWarnEnabled());
+
+		Log4JUtil.setLevel(LoggerName.LOGGER_WARN.toString(), "DEBUG", false);
+
+		Assert.assertTrue(
+			"DEBUG level should be enabled", log.isDebugEnabled());
+
+		Log childLog = LogFactoryUtil.getLog("com.test.parent.child");
+
+		Assert.assertTrue(
+			"INFO level should be enabled", childLog.isInfoEnabled());
+		Assert.assertFalse(
+			"DEBUG level should be not enabled", childLog.isDebugEnabled());
+
+		Log4JUtil.setLevel("com.test.parent", "DEBUG", false);
+
+		Assert.assertTrue(
+			"DEBUG level should be enabled", childLog.isDebugEnabled());
+	}
+
+	@Test
+	public void testShutdownLog4J() {
+		Log4JUtil.configureLog4J(_classLoader);
+
+		Logger logger = Logger.getRootLogger();
+
+		Enumeration<Appender> appendersEnumeration = logger.getAllAppenders();
+
+		Assert.assertTrue(
+			"The root logger should include appenders",
+			appendersEnumeration.hasMoreElements());
+
+		Log4JUtil.shutdownLog4J();
+
+		Assert.assertFalse(
+			"The root logger should not own appenders after shutting down",
+			appendersEnumeration.hasMoreElements());
+	}
+
+	private void _assertLogEnable() {
+		Log log = LogFactoryUtil.getLog(LoggerName.LOGGER_ALL.toString());
+
+		Assert.assertTrue("Logger should be all enabled", log.isTraceEnabled());
+
+		log = LogFactoryUtil.getLog(LoggerName.LOGGER_OFF.toString());
+
+		Assert.assertFalse(
+			"Setting logger level OFF does not take effect",
+			log.isFatalEnabled());
+
+		log = LogFactoryUtil.getLog(LoggerName.LOGGER_FATAL.toString());
+
+		Assert.assertTrue(
+			"Setting logger level FATAL does not take effect",
+			log.isFatalEnabled() && !log.isErrorEnabled());
+
+		log = LogFactoryUtil.getLog(LoggerName.LOGGER_ERROR.toString());
+
+		Assert.assertTrue(
+			"Setting logger level ERROR does not take effect",
+			log.isErrorEnabled() && !log.isWarnEnabled());
+
+		log = LogFactoryUtil.getLog(LoggerName.LOGGER_WARN.toString());
+
+		Assert.assertTrue(
+			"Setting logger level WARN does not take effect",
+			log.isWarnEnabled() && !log.isInfoEnabled());
+
+		log = LogFactoryUtil.getLog(LoggerName.LOGGER_INFO.toString());
+
+		Assert.assertTrue(
+			"Setting logger level INFO does not take effect",
+			log.isInfoEnabled() && !log.isDebugEnabled());
+
+		log = LogFactoryUtil.getLog(LoggerName.LOGGER_DEBUG.toString());
+
+		Assert.assertTrue(
+			"Setting logger level DEBUG does not take effect",
+			log.isDebugEnabled() && !log.isTraceEnabled());
+
+		log = LogFactoryUtil.getLog(LoggerName.LOGGER_TRACE.toString());
+
+		Assert.assertTrue(
+			"Setting logger level TRACE does not take effect",
+			log.isTraceEnabled());
+	}
+
+	private static final ClassLoader _classLoader =
+		Log4JUtilTest.class.getClassLoader();
+
+	private enum LoggerName {
+
+		LOGGER_ALL("logger.all"), LOGGER_DEBUG("logger.debug"),
+		LOGGER_ERROR("logger.error"), LOGGER_FATAL("logger.fatal"),
+		LOGGER_INFO("logger.info"), LOGGER_OFF("logger.off"),
+		LOGGER_TRACE("logger.trace"), LOGGER_WARN("logger.warn");
+
+		@Override
+		public String toString() {
+			return _name;
+		}
+
+		private LoggerName(String name) {
+			_name = name;
+		}
+
+		private final String _name;
+
+	}
+
+}

--- a/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
+++ b/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
@@ -16,6 +16,8 @@ package com.liferay.petra.log4j;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.test.rule.NewEnv;
+import com.liferay.portal.kernel.test.rule.NewEnvTestRule;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -35,29 +37,27 @@ import java.util.Map;
 import org.apache.log4j.Appender;
 import org.apache.log4j.Logger;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * @author Hai Yu
  */
+@NewEnv(type = NewEnv.Type.JVM)
 public class Log4JUtilTest {
 
-	@BeforeClass
-	public static void setUpClass() {
+	@ClassRule
+	@Rule
+	public static final NewEnvTestRule newEnvTestRule = NewEnvTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
 		PropsUtil.setProps(new PropsImpl());
 
 		LogFactoryUtil.setLogFactory(new Log4jLogFactoryImpl());
-	}
-
-	@After
-	public void tearDown() {
-		Log4JUtil.setLevel(
-			"com.liferay.portal.internal.servlet.MainServlet", "INFO", false);
-
-		Log4JUtil.shutdownLog4J();
 	}
 
 	@Test

--- a/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
+++ b/modules/apps/petra/petra-log4j/src/test/java/com/liferay/petra/log4j/Log4JUtilTest.java
@@ -120,30 +120,31 @@ public class Log4JUtilTest {
 	public void testGetOriginalLevel() {
 		Log4JUtil.configureLog4J(_classLoader);
 
-		String level = Log4JUtil.getOriginalLevel(
-			"com.liferay.portal.internal.servlet.MainServlet");
+		Assert.assertEquals(
+			"The original level should be WARN", "WARN",
+			Log4JUtil.getOriginalLevel(
+				"com.liferay.portal.internal.servlet.MainServlet"));
 
-		Assert.assertEquals("The original level should be WARN", "WARN", level);
-
-		level = Log4JUtil.getOriginalLevel(LoggerName.LOGGER_WARN.toString());
-
-		Assert.assertEquals("The original level should be WARN", "WARN", level);
+		Assert.assertEquals(
+			"The original level should be WARN", "WARN",
+			Log4JUtil.getOriginalLevel(LoggerName.LOGGER_WARN.toString()));
 	}
 
 	@Test
 	public void testInitLog4J() {
-		String logName = com.liferay.portal.util.PropsUtil.class.getName();
-
 		Log4JUtil.initLog4J(
 			ServerDetector.getServerId(), PropsUtil.get(PropsKeys.LIFERAY_HOME),
 			_classLoader, new Log4jLogFactoryImpl(),
 			HashMapBuilder.putAll(
 				new HashMap<String, String>()
 			).put(
-				logName, "WARN"
+				com.liferay.portal.util.PropsUtil.class.getName(), "WARN"
 			).build());
 
-		_assertLogLevel("WARN", LogFactoryUtil.getLog(logName));
+		_assertLogLevel(
+			"WARN",
+			LogFactoryUtil.getLog(
+				com.liferay.portal.util.PropsUtil.class.getName()));
 
 		_assertLogLevel(
 			"INFO", LogFactoryUtil.getLog(LoggerName.LOGGER_INFO.toString()));

--- a/modules/apps/petra/petra-log4j/src/test/resources/META-INF/portal-log4j-ext.xml
+++ b/modules/apps/petra/petra-log4j/src/test/resources/META-INF/portal-log4j-ext.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<category name="logger.all">
+		<priority value="ALL" />
+	</category>
+
+	<category name="logger.off">
+		<priority value="OFF" />
+	</category>
+
+	<category name="logger.fatal">
+		<priority value="FATAL" />
+	</category>
+
+	<category name="logger.error">
+		<priority value="ERROR" />
+	</category>
+
+	<category name="logger.warn">
+		<priority value="WARN" />
+	</category>
+
+	<category name="logger.info">
+		<priority value="INFO" />
+	</category>
+
+	<category name="logger.debug">
+		<priority value="DEBUG" />
+	</category>
+
+	<category name="logger.trace">
+		<priority value="TRACE" />
+	</category>
+
+	<category name="com.liferay.portal.internal.servlet.MainServlet">
+		<priority value="WARN" />
+	</category>
+</log4j:configuration>


### PR DESCRIPTION
@dantewang, I revert your last sf. Because if we don't define one logger's level in config file, it will inherited from its parent level, but its level is null. For example, the logger "com.liferay.hello.world", and we didn't config it in config file. For log4j, it will use root logger's level to judge, for jdkLogger, its parent logger default level is INFO, but its level is null. 