### PR TITLE
LPS 137329 8 16 1

### DIFF
--- a/modules/apps/analytics/analytics-message-storage-api/bnd.bnd
+++ b/modules/apps/analytics/analytics-message-storage-api/bnd.bnd
@@ -6,3 +6,9 @@ Export-Package:\
 	com.liferay.analytics.message.storage.model,\
 	com.liferay.analytics.message.storage.service,\
 	com.liferay.analytics.message.storage.service.persistence
+Import-Package:\
+	javassist.util.proxy,\
+	\
+	org.hibernate.proxy,\
+	\
+	*

--- a/modules/apps/batch-engine/batch-engine-api/bnd.bnd
+++ b/modules/apps/batch-engine/batch-engine-api/bnd.bnd
@@ -9,3 +9,9 @@ Export-Package:\
 	com.liferay.batch.engine.pagination,\
 	com.liferay.batch.engine.service,\
 	com.liferay.batch.engine.service.persistence
+Import-Package:\
+	javassist.util.proxy,\
+	\
+	org.hibernate.proxy,\
+	\
+	*

--- a/modules/apps/change-tracking/change-tracking-store-api/bnd.bnd
+++ b/modules/apps/change-tracking/change-tracking-store-api/bnd.bnd
@@ -6,3 +6,9 @@ Export-Package:\
 	com.liferay.change.tracking.store.model,\
 	com.liferay.change.tracking.store.service,\
 	com.liferay.change.tracking.store.service.persistence
+Import-Package:\
+	javassist.util.proxy,\
+	\
+	org.hibernate.proxy,\
+	\
+	*

--- a/modules/apps/document-library/document-library-content-api/bnd.bnd
+++ b/modules/apps/document-library/document-library-content-api/bnd.bnd
@@ -7,3 +7,9 @@ Export-Package:\
 	com.liferay.document.library.content.service,\
 	com.liferay.document.library.content.service.persistence,\
 	com.liferay.document.library.content.util.comparator
+Import-Package:\
+	javassist.util.proxy,\
+	\
+	org.hibernate.proxy,\
+	\
+	*

--- a/modules/core/portal-bootstrap/system.packages.extra.bnd
+++ b/modules/core/portal-bootstrap/system.packages.extra.bnd
@@ -121,6 +121,8 @@ Export-Package:\
 	\
 	java_cup.runtime.*;version='2.7.1',\
 	\
+	javassist.util.proxy;version='3.27.0',\
+	\
 	javax.jws;version='1.1',\
 	javax.jws.soap;version='1.1',\
 	\
@@ -338,6 +340,7 @@ Provide-Capability:\
 	@../../../lib/portal/commons-logging.jar,\
 	@../../../lib/portal/dom4j.jar,\
 	@../../../lib/portal/hibernate-core.jar,\
+	@../../../lib/portal/javassist.jar,\
 	@../../../lib/portal/jaxen.jar,\
 	@../../../lib/portal/jaxrpc.jar,\
 	@../../../lib/portal/jdom.jar!/org/**,\

--- a/modules/util/portal-tools-service-builder-test-api/bnd.bnd
+++ b/modules/util/portal-tools-service-builder-test-api/bnd.bnd
@@ -6,3 +6,9 @@ Export-Package:\
 	com.liferay.portal.tools.service.builder.test.model,\
 	com.liferay.portal.tools.service.builder.test.service,\
 	com.liferay.portal.tools.service.builder.test.service.persistence
+Import-Package:\
+	javassist.util.proxy,\
+	\
+	org.hibernate.proxy,\
+	\
+	*

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8187,9 +8187,7 @@
         com.sun.tools.*,\
         com.sun.xml.*,\
         com.yourkit.*,\
-        javassist.util.proxy,\
         jdk.*,\
-        org.hibernate.proxy,\
         sun.*,\
         weblogic.jndi,\
         weblogic.jndi.*


### PR DESCRIPTION
- LPS=137329 Revert "LPS-130603 Fix ClassNotFoundError in Hibernate lazy proxy creation under JDK 11. Latest Javassist adds Java 11 support to avoid warning/errors when calling protected class loading methods by using MethodHandles. However the new default approach relies on the class loader of the neighbor class of the class being created, which in Liferay is a module class loader which doesn't by default import org.hibernate.proxy and javassist.util.proxy. In contrast, the old version of Javassist uses the class loader of the interface that the created class implements. Will check again if this is needed after we upgrade hibernate."
- LPS-137329 Export the packages from core and manually import them from modules using *DataBlobModel
