### PR TITLE
LPS 135570 8 25 1

### DIFF
--- a/modules/core/portal-web/build.gradle
+++ b/modules/core/portal-web/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.java", version: "default"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:shielded-container-api")
 }
 

--- a/modules/core/portal-web/build.gradle
+++ b/modules/core/portal-web/build.gradle
@@ -7,6 +7,8 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:shielded-container-api")
+
+	testCompile project(":core:petra:petra-process")
 }
 
 liferay {

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/PortalWebShieldedContainerInitializer.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/PortalWebShieldedContainerInitializer.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.AxisServlet;
 import com.liferay.portal.servlet.PortalSessionListener;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.web.internal.session.replication.SessionReplicationFilter;
 import com.liferay.shielded.container.Ordered;
 import com.liferay.shielded.container.ShieldedContainerInitializer;
 
@@ -60,6 +61,17 @@ public class PortalWebShieldedContainerInitializer
 	@Override
 	public void initialize(ServletContext servletContext)
 		throws ServletException {
+
+		if (PropsValues.PORTLET_SESSION_REPLICATE_ENABLED) {
+			FilterRegistration.Dynamic dynamic = servletContext.addFilter(
+				SessionReplicationFilter.class.getName(),
+				new SessionReplicationFilter());
+
+			dynamic.setAsyncSupported(true);
+
+			dynamic.addMappingForUrlPatterns(
+				EnumSet.of(DispatcherType.REQUEST), false, "/*");
+		}
 
 		DocumentBuilderFactory documentBuilderFactory =
 			DocumentBuilderFactory.newInstance();

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.web.internal.session.replication;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Dante Wang
+ */
+public class SessionReplicationFilter implements Filter {
+
+	@Override
+	public void destroy() {
+	}
+
+	@Override
+	public void doFilter(
+			ServletRequest servletRequest, ServletResponse servletResponse,
+			FilterChain filterChain)
+		throws IOException, ServletException {
+
+		if ((servletRequest instanceof HttpServletRequest) &&
+			!(servletRequest instanceof SessionReplicationHttpServletRequest)) {
+
+			servletRequest = new SessionReplicationHttpServletRequest(
+				(HttpServletRequest)servletRequest);
+		}
+
+		filterChain.doFilter(servletRequest, servletResponse);
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+	}
+
+}

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.web.internal.session.replication;
 
+import com.liferay.portal.kernel.util.StringBundler;
+
 import java.io.IOException;
 
 import javax.servlet.Filter;
@@ -55,13 +57,14 @@ public class SessionReplicationFilter implements Filter {
 						lastHttpServletRequestWrapper.getRequest();
 			}
 
-			if (!(httpServletRequest instanceof
-					SessionReplicationHttpServletRequest)) {
+			Class<?> clazz = httpServletRequest.getClass();
 
-				SessionReplicationHttpServletRequest
-					sessionReplicationHttpServletRequest =
-						new SessionReplicationHttpServletRequest(
-							httpServletRequest);
+			String className = clazz.getName();
+
+			if (!className.equals(_ASM_WRAPPER_CLASS_NAME)) {
+				HttpServletRequest sessionReplicationHttpServletRequest =
+					SessionReplicationHttpServletRequestDelegate.create(
+						httpServletRequest);
 
 				if (lastHttpServletRequestWrapper == null) {
 					servletRequest = sessionReplicationHttpServletRequest;
@@ -78,6 +81,22 @@ public class SessionReplicationFilter implements Filter {
 
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {
+	}
+
+	private static final String _ASM_WRAPPER_CLASS_NAME;
+
+	static {
+		Package pkg =
+			SessionReplicationHttpServletRequestDelegate.class.getPackage();
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(pkg.getName());
+		sb.append(".");
+		sb.append(HttpServletRequest.class.getSimpleName());
+		sb.append("ASMWrapper");
+
+		_ASM_WRAPPER_CLASS_NAME = sb.toString();
 	}
 
 }

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
@@ -23,6 +23,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 
 /**
  * @author Dante Wang
@@ -39,11 +40,37 @@ public class SessionReplicationFilter implements Filter {
 			FilterChain filterChain)
 		throws IOException, ServletException {
 
-		if ((servletRequest instanceof HttpServletRequest) &&
-			!(servletRequest instanceof SessionReplicationHttpServletRequest)) {
+		if (servletRequest instanceof HttpServletRequest) {
+			HttpServletRequest httpServletRequest =
+				(HttpServletRequest)servletRequest;
 
-			servletRequest = new SessionReplicationHttpServletRequest(
-				(HttpServletRequest)servletRequest);
+			HttpServletRequestWrapper lastHttpServletRequestWrapper = null;
+
+			while (httpServletRequest instanceof HttpServletRequestWrapper) {
+				lastHttpServletRequestWrapper =
+					(HttpServletRequestWrapper)httpServletRequest;
+
+				httpServletRequest =
+					(HttpServletRequest)
+						lastHttpServletRequestWrapper.getRequest();
+			}
+
+			if (!(httpServletRequest instanceof
+					SessionReplicationHttpServletRequest)) {
+
+				SessionReplicationHttpServletRequest
+					sessionReplicationHttpServletRequest =
+						new SessionReplicationHttpServletRequest(
+							httpServletRequest);
+
+				if (lastHttpServletRequestWrapper == null) {
+					servletRequest = sessionReplicationHttpServletRequest;
+				}
+				else {
+					lastHttpServletRequestWrapper.setRequest(
+						sessionReplicationHttpServletRequest);
+				}
+			}
 		}
 
 		filterChain.doFilter(servletRequest, servletResponse);

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequest.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.web.internal.session.replication;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpSession;
+
+/**
+ * @author Dante Wang
+ */
+public class SessionReplicationHttpServletRequest
+	extends HttpServletRequestWrapper {
+
+	public SessionReplicationHttpServletRequest(
+		HttpServletRequest httpServletRequest) {
+
+		super(httpServletRequest);
+	}
+
+	@Override
+	public HttpSession getSession() {
+		return new SessionReplicationHttpSessionWrapper(super.getSession());
+	}
+
+	@Override
+	public HttpSession getSession(boolean create) {
+		return new SessionReplicationHttpSessionWrapper(
+			super.getSession(create));
+	}
+
+}

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequest.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequest.java
@@ -32,13 +32,24 @@ public class SessionReplicationHttpServletRequest
 
 	@Override
 	public HttpSession getSession() {
-		return new SessionReplicationHttpSessionWrapper(super.getSession());
+		HttpSession httpSession = super.getSession();
+
+		if (httpSession == null) {
+			return null;
+		}
+
+		return new SessionReplicationHttpSessionWrapper(httpSession);
 	}
 
 	@Override
 	public HttpSession getSession(boolean create) {
-		return new SessionReplicationHttpSessionWrapper(
-			super.getSession(create));
+		HttpSession httpSession = super.getSession(create);
+
+		if (httpSession == null) {
+			return null;
+		}
+
+		return new SessionReplicationHttpSessionWrapper(httpSession);
 	}
 
 }

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequestDelegate.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequestDelegate.java
@@ -14,25 +14,50 @@
 
 package com.liferay.portal.web.internal.session.replication;
 
+import com.liferay.portal.asm.ASMWrapperUtil;
+
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpSession;
 
 /**
  * @author Dante Wang
  */
-public class SessionReplicationHttpServletRequest
-	extends HttpServletRequestWrapper {
+public class SessionReplicationHttpServletRequestDelegate {
 
-	public SessionReplicationHttpServletRequest(
+	public static HttpServletRequest create(
 		HttpServletRequest httpServletRequest) {
 
-		super(httpServletRequest);
+		return ASMWrapperUtil.createASMWrapper(
+			SessionReplicationHttpServletRequestDelegate.class.getClassLoader(),
+			HttpServletRequest.class,
+			new SessionReplicationHttpServletRequestDelegate(
+				httpServletRequest),
+			httpServletRequest);
 	}
 
 	@Override
+	public boolean equals(Object object) {
+		if (!(object instanceof HttpServletRequest)) {
+			return false;
+		}
+
+		HttpServletRequest httpServletRequest = (HttpServletRequest)object;
+
+		return httpServletRequest.equals(_httpServletRequest);
+	}
+
 	public HttpSession getSession() {
-		HttpSession httpSession = super.getSession();
+		HttpSession httpSession = _httpServletRequest.getSession();
+
+		if (httpSession == null) {
+			return null;
+		}
+
+		return new SessionReplicationHttpSessionWrapper(httpSession);
+	}
+
+	public HttpSession getSession(boolean create) {
+		HttpSession httpSession = _httpServletRequest.getSession(create);
 
 		if (httpSession == null) {
 			return null;
@@ -42,14 +67,16 @@ public class SessionReplicationHttpServletRequest
 	}
 
 	@Override
-	public HttpSession getSession(boolean create) {
-		HttpSession httpSession = super.getSession(create);
-
-		if (httpSession == null) {
-			return null;
-		}
-
-		return new SessionReplicationHttpSessionWrapper(httpSession);
+	public int hashCode() {
+		return _httpServletRequest.hashCode();
 	}
+
+	private SessionReplicationHttpServletRequestDelegate(
+		HttpServletRequest httpServletRequest) {
+
+		_httpServletRequest = httpServletRequest;
+	}
+
+	private final HttpServletRequest _httpServletRequest;
 
 }

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
@@ -90,7 +90,7 @@ public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
 	}
 
 	private static final String _SERIALIZED_ATTRIBUTE_PREFIX =
-		SessionReplicationHttpSessionWrapper.class.getName() + "_";
+		"SERIALIZED_ATTRIBUTE_PREFIX_";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SessionReplicationHttpSessionWrapper.class);

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.web.internal.session.replication;
+
+import com.liferay.petra.io.Deserializer;
+import com.liferay.petra.io.Serializer;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
+
+import java.io.Serializable;
+
+import java.nio.ByteBuffer;
+
+import javax.servlet.http.HttpSession;
+
+/**
+ * @author Dante Wang
+ */
+public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
+
+	public SessionReplicationHttpSessionWrapper(HttpSession session) {
+		super(session);
+	}
+
+	@Override
+	public Object getAttribute(String name) {
+		Object value = super.getAttribute(
+			_SERIALIZED_ATTRIBUTE_PREFIX.concat(name));
+
+		if (value == null) {
+			return super.getAttribute(name);
+		}
+
+		Deserializer deserializer = new Deserializer(
+			ByteBuffer.wrap((byte[])value));
+
+		try {
+			return deserializer.readObject();
+		}
+		catch (ClassNotFoundException classNotFoundException) {
+			_log.error("Unable to deserialize object", classNotFoundException);
+
+			return null;
+		}
+	}
+
+	@Override
+	public void setAttribute(String name, Object value) {
+		if (!(value instanceof Serializable) ||
+			_isSafeClass(value.getClass())) {
+
+			super.setAttribute(name, value);
+
+			return;
+		}
+
+		Serializer serializer = new Serializer();
+
+		serializer.writeObject((Serializable)value);
+
+		ByteBuffer byteBuffer = serializer.toByteBuffer();
+
+		super.setAttribute(
+			_SERIALIZED_ATTRIBUTE_PREFIX.concat(name), byteBuffer.array());
+	}
+
+	private boolean _isSafeClass(Class<?> clazz) {
+		ClassLoader classLoader = clazz.getClassLoader();
+
+		if ((classLoader == String.class.getClassLoader()) ||
+			(classLoader == HttpSession.class.getClassLoader())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final String _SERIALIZED_ATTRIBUTE_PREFIX =
+		SessionReplicationHttpSessionWrapper.class.getName() + "_";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SessionReplicationHttpSessionWrapper.class);
+
+}

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
@@ -84,6 +84,13 @@ public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
 	}
 
 	@Override
+	public void removeAttribute(String name) {
+		super.removeAttribute(name);
+
+		super.removeAttribute(_SERIALIZED_ATTRIBUTE_PREFIX.concat(name));
+	}
+
+	@Override
 	public void setAttribute(String name, Object value) {
 		if (!(value instanceof Serializable) ||
 			_isSafeClass(value.getClass())) {

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
@@ -58,8 +58,8 @@ public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
 		try {
 			return deserializer.readObject();
 		}
-		catch (ClassNotFoundException classNotFoundException) {
-			_log.error("Unable to deserialize object", classNotFoundException);
+		catch (Exception exception) {
+			_log.error("Unable to deserialize object", exception);
 
 			return null;
 		}

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
@@ -19,7 +19,6 @@ import com.liferay.petra.io.Serializer;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
-import com.liferay.portal.kernel.util.JavaDetector;
 
 import java.io.Serializable;
 
@@ -28,7 +27,9 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
 
 import javax.servlet.http.HttpSession;
@@ -94,36 +95,25 @@ public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
 
 	@Override
 	public void setAttribute(String name, Object value) {
-		if (!(value instanceof Serializable) ||
-			_isSafeClass(value.getClass())) {
+		if (value instanceof Serializable) {
+			Class<?> clazz = value.getClass();
 
-			super.setAttribute(name, value);
+			if (!_safeClassLoaders.contains(clazz.getClassLoader())) {
+				Serializer serializer = new Serializer();
 
-			return;
+				serializer.writeObject((Serializable)value);
+
+				ByteBuffer byteBuffer = serializer.toByteBuffer();
+
+				super.setAttribute(
+					_SERIALIZED_ATTRIBUTE_PREFIX.concat(name),
+					byteBuffer.array());
+
+				return;
+			}
 		}
 
-		Serializer serializer = new Serializer();
-
-		serializer.writeObject((Serializable)value);
-
-		ByteBuffer byteBuffer = serializer.toByteBuffer();
-
-		super.setAttribute(
-			_SERIALIZED_ATTRIBUTE_PREFIX.concat(name), byteBuffer.array());
-	}
-
-	private boolean _isSafeClass(Class<?> clazz) {
-		ClassLoader classLoader = clazz.getClassLoader();
-
-		if ((classLoader == String.class.getClassLoader()) ||
-			(classLoader == HttpSession.class.getClassLoader()) ||
-			(JavaDetector.isJDK11() &&
-			 (classLoader == Logger.class.getClassLoader()))) {
-
-			return true;
-		}
-
-		return false;
+		super.setAttribute(name, value);
 	}
 
 	private static final String _SERIALIZED_ATTRIBUTE_PREFIX =
@@ -131,5 +121,14 @@ public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SessionReplicationHttpSessionWrapper.class);
+
+	private static final Set<ClassLoader> _safeClassLoaders =
+		new HashSet<ClassLoader>() {
+			{
+				add(String.class.getClassLoader());
+				add(HttpSession.class.getClassLoader());
+				add(Logger.class.getClassLoader());
+			}
+		};
 
 }

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
@@ -24,6 +24,11 @@ import java.io.Serializable;
 
 import java.nio.ByteBuffer;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
 import javax.servlet.http.HttpSession;
 
 /**
@@ -55,6 +60,27 @@ public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
 
 			return null;
 		}
+	}
+
+	@Override
+	public Enumeration<String> getAttributeNames() {
+		Enumeration<String> attributeNameEnumeration =
+			super.getAttributeNames();
+
+		List<String> attributeNames = new ArrayList<>();
+
+		while (attributeNameEnumeration.hasMoreElements()) {
+			String attributeName = attributeNameEnumeration.nextElement();
+
+			if (attributeName.startsWith(_SERIALIZED_ATTRIBUTE_PREFIX)) {
+				attributeName = attributeName.substring(
+					_SERIALIZED_ATTRIBUTE_PREFIX.length());
+			}
+
+			attributeNames.add(attributeName);
+		}
+
+		return Collections.enumeration(attributeNames);
 	}
 
 	@Override

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
@@ -19,6 +19,7 @@ import com.liferay.petra.io.Serializer;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
+import com.liferay.portal.kernel.util.JavaDetector;
 
 import java.io.Serializable;
 
@@ -28,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.logging.Logger;
 
 import javax.servlet.http.HttpSession;
 
@@ -114,7 +116,9 @@ public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
 		ClassLoader classLoader = clazz.getClassLoader();
 
 		if ((classLoader == String.class.getClassLoader()) ||
-			(classLoader == HttpSession.class.getClassLoader())) {
+			(classLoader == HttpSession.class.getClassLoader()) ||
+			(JavaDetector.isJDK11() &&
+			 (classLoader == Logger.class.getClassLoader()))) {
 
 			return true;
 		}

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
@@ -14,21 +14,15 @@
 
 package com.liferay.portal.web.internal.session.replication;
 
-import com.liferay.petra.io.Deserializer;
-import com.liferay.petra.io.Serializer;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
+import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
 import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
 
 import java.io.Serializable;
 
-import java.nio.ByteBuffer;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -45,52 +39,20 @@ public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
 
 	@Override
 	public Object getAttribute(String name) {
-		Object value = super.getAttribute(
-			_SERIALIZED_ATTRIBUTE_PREFIX.concat(name));
+		Object value = super.getAttribute(name);
 
-		if (value == null) {
-			return super.getAttribute(name);
+		if (Objects.equals(value, _PLACE_HOLDER_VALUE)) {
+			return _portalCache.get(name);
 		}
 
-		Deserializer deserializer = new Deserializer(
-			ByteBuffer.wrap((byte[])value));
-
-		try {
-			return deserializer.readObject();
-		}
-		catch (Exception exception) {
-			_log.error("Unable to deserialize object", exception);
-
-			return null;
-		}
-	}
-
-	@Override
-	public Enumeration<String> getAttributeNames() {
-		Enumeration<String> attributeNameEnumeration =
-			super.getAttributeNames();
-
-		List<String> attributeNames = new ArrayList<>();
-
-		while (attributeNameEnumeration.hasMoreElements()) {
-			String attributeName = attributeNameEnumeration.nextElement();
-
-			if (attributeName.startsWith(_SERIALIZED_ATTRIBUTE_PREFIX)) {
-				attributeName = attributeName.substring(
-					_SERIALIZED_ATTRIBUTE_PREFIX.length());
-			}
-
-			attributeNames.add(attributeName);
-		}
-
-		return Collections.enumeration(attributeNames);
+		return value;
 	}
 
 	@Override
 	public void removeAttribute(String name) {
 		super.removeAttribute(name);
 
-		super.removeAttribute(_SERIALIZED_ATTRIBUTE_PREFIX.concat(name));
+		_portalCache.remove(name);
 	}
 
 	@Override
@@ -99,15 +61,9 @@ public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
 			Class<?> clazz = value.getClass();
 
 			if (!_safeClassLoaders.contains(clazz.getClassLoader())) {
-				Serializer serializer = new Serializer();
+				_portalCache.put(name, value);
 
-				serializer.writeObject((Serializable)value);
-
-				ByteBuffer byteBuffer = serializer.toByteBuffer();
-
-				super.setAttribute(
-					_SERIALIZED_ATTRIBUTE_PREFIX.concat(name),
-					byteBuffer.array());
+				super.setAttribute(name, _PLACE_HOLDER_VALUE);
 
 				return;
 			}
@@ -116,11 +72,7 @@ public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
 		super.setAttribute(name, value);
 	}
 
-	private static final String _SERIALIZED_ATTRIBUTE_PREFIX =
-		"SERIALIZED_ATTRIBUTE_PREFIX_";
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		SessionReplicationHttpSessionWrapper.class);
+	private static final String _PLACE_HOLDER_VALUE = "PLACE_HOLDER_VALUE";
 
 	private static final Set<ClassLoader> _safeClassLoaders =
 		new HashSet<ClassLoader>() {
@@ -130,5 +82,10 @@ public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
 				add(Logger.class.getClassLoader());
 			}
 		};
+
+	private final PortalCache<String, Object> _portalCache =
+		PortalCacheHelperUtil.getPortalCache(
+			PortalCacheManagerNames.MULTI_VM,
+			SessionReplicationHttpSessionWrapper.class.getName());
 
 }

--- a/modules/core/portal-web/src/test/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapperTest.java
+++ b/modules/core/portal-web/src/test/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapperTest.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.web.internal.session.replication;
+
+import com.liferay.petra.process.ClassPathUtil;
+import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.util.ProxyFactory;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.lang.reflect.Constructor;
+
+import java.net.URLClassLoader;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+import javax.servlet.http.HttpSession;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Tina Tian
+ */
+public class SessionReplicationHttpSessionWrapperTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_testHttpSession = new TestHttpSession();
+
+		ClassLoader classLoader = new URLClassLoader(
+			ClassPathUtil.getClassPathURLs(_CLASS_PATH), null);
+
+		Class<?> clazz = classLoader.loadClass(
+			SessionReplicationHttpSessionWrapperTestValue.class.getName());
+
+		Constructor<?> constructor = clazz.getDeclaredConstructor(String.class);
+
+		_testValue1 = constructor.newInstance(_TEST_VALUE_1);
+
+		_testValue2 = "TEST_VALUE_2";
+		_testValue3 = new Object();
+
+		_sessionReplicationHttpSessionWrapper =
+			new SessionReplicationHttpSessionWrapper(_testHttpSession);
+
+		_sessionReplicationHttpSessionWrapper.setAttribute(
+			_TEST_KEY_1, _testValue1);
+		_sessionReplicationHttpSessionWrapper.setAttribute(
+			_TEST_KEY_2, _testValue2);
+		_sessionReplicationHttpSessionWrapper.setAttribute(
+			_TEST_KEY_3, _testValue3);
+	}
+
+	@Test
+	public void testGetAttribute() {
+		_testGetAttribute(_TEST_KEY_1, _testValue1, false);
+		_testGetAttribute(_TEST_KEY_2, _testValue2, true);
+		_testGetAttribute(_TEST_KEY_3, _testValue3, true);
+	}
+
+	@Test
+	public void testGetAttributeNames() {
+		List<String> keys = Collections.list(
+			_sessionReplicationHttpSessionWrapper.getAttributeNames());
+
+		Assert.assertEquals(keys.toString(), 3, keys.size());
+		Assert.assertTrue(keys.contains(_TEST_KEY_1));
+		Assert.assertTrue(keys.contains(_TEST_KEY_2));
+		Assert.assertTrue(keys.contains(_TEST_KEY_3));
+
+		keys = Collections.list(_testHttpSession.getAttributeNames());
+
+		Assert.assertEquals(keys.toString(), 3, keys.size());
+		Assert.assertFalse(keys.contains(_TEST_KEY_1));
+		Assert.assertTrue(keys.contains(_TEST_KEY_2));
+		Assert.assertTrue(keys.contains(_TEST_KEY_3));
+	}
+
+	@Test
+	public void testGetAttributeWithException() {
+		SessionReplicationHttpSessionWrapper
+			sessionReplicationHttpSessionWrapper =
+				new SessionReplicationHttpSessionWrapper(_testHttpSession);
+
+		_testHttpSession.setAttribute(
+			"SERIALIZED_ATTRIBUTE_PREFIX_test.value", new byte[0]);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureJDKLogger(
+				SessionReplicationHttpSessionWrapper.class.getName(),
+				Level.SEVERE)) {
+
+			sessionReplicationHttpSessionWrapper.getAttribute("test.value");
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Unable to deserialize object", logEntry.getMessage());
+		}
+	}
+
+	@Test
+	public void testRemoveAttribute() {
+		_testRemoveAttribute(_TEST_KEY_1);
+		_testRemoveAttribute(_TEST_KEY_2);
+		_testRemoveAttribute(_TEST_KEY_3);
+	}
+
+	private void _testGetAttribute(String key, Object value, boolean safe) {
+		if (safe) {
+			Assert.assertEquals(value, _testHttpSession.getAttribute(key));
+		}
+		else {
+			Assert.assertNull(_testHttpSession.getAttribute(key));
+
+			SessionReplicationHttpSessionWrapperTestValue
+				sessionReplicationHttpSessionWrapperTestValue =
+					(SessionReplicationHttpSessionWrapperTestValue)
+						_sessionReplicationHttpSessionWrapper.getAttribute(key);
+
+			Assert.assertNotNull(sessionReplicationHttpSessionWrapperTestValue);
+			Assert.assertNotSame(
+				value, sessionReplicationHttpSessionWrapperTestValue);
+			Assert.assertEquals(
+				_TEST_VALUE_1,
+				sessionReplicationHttpSessionWrapperTestValue.getValue());
+		}
+	}
+
+	private void _testRemoveAttribute(String key) {
+		Assert.assertNotNull(
+			_sessionReplicationHttpSessionWrapper.getAttribute(key));
+
+		_sessionReplicationHttpSessionWrapper.removeAttribute(key);
+
+		Assert.assertNull(
+			_sessionReplicationHttpSessionWrapper.getAttribute(key));
+	}
+
+	private static final String _CLASS_PATH = ClassPathUtil.getJVMClassPath(
+		true);
+
+	private static final String _TEST_KEY_1 = "TEST_KEY_1";
+
+	private static final String _TEST_KEY_2 = "TEST_KEY_2";
+
+	private static final String _TEST_KEY_3 = "TEST_KEY_3";
+
+	private static final String _TEST_VALUE_1 = "TEST_VALUE_1";
+
+	private SessionReplicationHttpSessionWrapper
+		_sessionReplicationHttpSessionWrapper;
+	private TestHttpSession _testHttpSession;
+	private Object _testValue1;
+	private Object _testValue2;
+	private Object _testValue3;
+
+	private class TestHttpSession extends HttpSessionWrapper {
+
+		@Override
+		public Object getAttribute(String name) {
+			return _attributes.get(name);
+		}
+
+		@Override
+		public Enumeration<String> getAttributeNames() {
+			return Collections.enumeration(_attributes.keySet());
+		}
+
+		@Override
+		public void removeAttribute(String name) {
+			_attributes.remove(name);
+		}
+
+		@Override
+		public void setAttribute(String name, Object value) {
+			_attributes.put(name, value);
+		}
+
+		private TestHttpSession() {
+			super(ProxyFactory.newDummyInstance(HttpSession.class));
+		}
+
+		private Map<String, Object> _attributes = new HashMap<>();
+
+	}
+
+}

--- a/modules/core/portal-web/src/test/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapperTestValue.java
+++ b/modules/core/portal-web/src/test/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapperTestValue.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.web.internal.session.replication;
+
+import java.io.Serializable;
+
+/**
+ * @author Tina Tian
+ */
+public class SessionReplicationHttpSessionWrapperTestValue
+	implements Serializable {
+
+	public SessionReplicationHttpSessionWrapperTestValue(String value) {
+		_value = value;
+	}
+
+	public String getValue() {
+		return _value;
+	}
+
+	private final String _value;
+
+}

--- a/portal-impl/src/com/liferay/portlet/internal/PortletSessionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletSessionImpl.java
@@ -16,23 +16,8 @@ package com.liferay.portlet.internal;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.io.Deserializer;
-import com.liferay.portal.kernel.io.Serializer;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletSession;
-import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
-import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.PortletSessionAttributeMap;
-
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.io.Serializable;
-
-import java.nio.ByteBuffer;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,7 +40,7 @@ public class PortletSessionImpl implements LiferayPortletSession {
 		HttpSession session, PortletContext portletContext, String portletName,
 		long plid) {
 
-		this.session = _wrapHttpSession(session);
+		this.session = session;
 		this.portletContext = portletContext;
 
 		scopePrefix = StringBundler.concat(
@@ -214,7 +199,7 @@ public class PortletSessionImpl implements LiferayPortletSession {
 
 	@Override
 	public void setHttpSession(HttpSession session) {
-		this.session = _wrapHttpSession(session);
+		this.session = session;
 	}
 
 	@Override
@@ -226,164 +211,6 @@ public class PortletSessionImpl implements LiferayPortletSession {
 	protected final String scopePrefix;
 	protected HttpSession session;
 
-	private HttpSession _wrapHttpSession(HttpSession session) {
-		if (PropsValues.PORTLET_SESSION_REPLICATE_ENABLED &&
-			!(session instanceof SerializableHttpSessionWrapper)) {
-
-			return new SerializableHttpSessionWrapper(session);
-		}
-
-		return session;
-	}
-
 	private boolean _invalidated;
-
-	private static class LazySerializable implements Serializable {
-
-		public byte[] getData() {
-			return _data;
-		}
-
-		public Serializable getSerializable() {
-			Deserializer deserializer = new Deserializer(
-				ByteBuffer.wrap(_data));
-
-			try {
-				return deserializer.readObject();
-			}
-			catch (ClassNotFoundException classNotFoundException) {
-				_log.error(
-					"Unable to deserialize object", classNotFoundException);
-
-				return null;
-			}
-		}
-
-		private LazySerializable(byte[] data) {
-			_data = data;
-		}
-
-		private static final Log _log = LogFactoryUtil.getLog(
-			LazySerializable.class);
-
-		private final byte[] _data;
-
-	}
-
-	private static class LazySerializableObjectWrapper
-		implements Externalizable {
-
-		/**
-		 * The empty constructor is required by {@link Externalizable}. Do not
-		 * use this for any other purpose.
-		 */
-		public LazySerializableObjectWrapper() {
-		}
-
-		public Serializable getSerializable() {
-			if (_serializable instanceof LazySerializable) {
-				LazySerializable lazySerializable =
-					(LazySerializable)_serializable;
-
-				Serializable serializable = lazySerializable.getSerializable();
-
-				if (serializable == null) {
-					return null;
-				}
-
-				_serializable = serializable;
-			}
-
-			return _serializable;
-		}
-
-		@Override
-		public void readExternal(ObjectInput objectInput) throws IOException {
-			byte[] data = new byte[objectInput.readInt()];
-
-			objectInput.readFully(data);
-
-			_serializable = new LazySerializable(data);
-		}
-
-		@Override
-		public void writeExternal(ObjectOutput objectOutput)
-			throws IOException {
-
-			byte[] data = _getData();
-
-			objectOutput.writeInt(data.length);
-
-			objectOutput.write(data, 0, data.length);
-		}
-
-		private LazySerializableObjectWrapper(Serializable serializable) {
-			_serializable = serializable;
-		}
-
-		private byte[] _getData() {
-			if (_serializable instanceof LazySerializable) {
-				LazySerializable lazySerializable =
-					(LazySerializable)_serializable;
-
-				return lazySerializable.getData();
-			}
-
-			Serializer serializer = new Serializer();
-
-			serializer.writeObject(_serializable);
-
-			ByteBuffer byteBuffer = serializer.toByteBuffer();
-
-			return byteBuffer.array();
-		}
-
-		private volatile Serializable _serializable;
-
-	}
-
-	private static class SerializableHttpSessionWrapper
-		extends HttpSessionWrapper {
-
-		@Override
-		public Object getAttribute(String name) {
-			Object value = super.getAttribute(name);
-
-			if (value instanceof LazySerializableObjectWrapper) {
-				LazySerializableObjectWrapper lazySerializableObjectWrapper =
-					(LazySerializableObjectWrapper)value;
-
-				return lazySerializableObjectWrapper.getSerializable();
-			}
-
-			return value;
-		}
-
-		@Override
-		public void setAttribute(String name, Object value) {
-			if (!(value instanceof Serializable)) {
-				super.setAttribute(name, value);
-
-				return;
-			}
-
-			Class<?> clazz = value.getClass();
-
-			ClassLoader classLoader = clazz.getClassLoader();
-
-			if ((classLoader != null) &&
-				!PortalClassLoaderUtil.isPortalClassLoader(classLoader)) {
-
-				value = new LazySerializableObjectWrapper((Serializable)value);
-			}
-
-			super.setAttribute(name, value);
-		}
-
-		private SerializableHttpSessionWrapper(HttpSession session) {
-			super(session);
-		}
-
-	}
 
 }

--- a/portal-impl/test/unit/com/liferay/portlet/internal/PortletSessionImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/internal/PortletSessionImplTest.java
@@ -14,50 +14,26 @@
 
 package com.liferay.portlet.internal;
 
-import com.liferay.petra.lang.ClassLoaderPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
-import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.portlet.LiferayPortletSession;
-import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
-import com.liferay.portal.kernel.test.rule.NewEnv;
-import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ProxyUtil;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LogEntry;
-import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.AdviseWith;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
-import com.liferay.portal.util.PropsUtil;
 
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
-
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 
 import java.util.Enumeration;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.logging.Level;
 
 import javax.portlet.PortletContext;
 import javax.portlet.PortletSession;
 
 import javax.servlet.http.HttpSession;
 
-import org.aspectj.lang.annotation.Around;
-import org.aspectj.lang.annotation.Aspect;
-
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -67,7 +43,6 @@ import org.springframework.mock.web.MockHttpSession;
 /**
  * @author Shuyang Zhou
  */
-@NewEnv(type = NewEnv.Type.CLASSLOADER)
 public class PortletSessionImplTest {
 
 	@ClassRule
@@ -76,22 +51,8 @@ public class PortletSessionImplTest {
 		new AggregateTestRule(
 			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
 
-	@Before
-	public void setUp() throws ClassNotFoundException {
-		ClassLoader classLoader = PortletSessionImpl.class.getClassLoader();
-
-		_lazySerializableClass = classLoader.loadClass(
-			PortletSessionImpl.class.getName() + "$LazySerializable");
-
-		_lazySerializableObjectWrapperClass = classLoader.loadClass(
-			PortletSessionImpl.class.getName() +
-				"$LazySerializableObjectWrapper");
-	}
-
 	@Test
 	public void testConstructor() {
-		PropsUtil.set(PropsKeys.PORTLET_SESSION_REPLICATE_ENABLED, "false");
-
 		PortletSessionImpl portletSessionImpl = _getPortletSessionImpl();
 
 		Assert.assertSame(_mockHttpSession, portletSessionImpl.session);
@@ -107,8 +68,6 @@ public class PortletSessionImplTest {
 
 	@Test
 	public void testDirectDelegateMethods() {
-		PropsUtil.set(PropsKeys.PORTLET_SESSION_REPLICATE_ENABLED, "false");
-
 		PortletSessionImpl portletSessionImpl = _getPortletSessionImpl();
 
 		Assert.assertEquals(
@@ -149,8 +108,6 @@ public class PortletSessionImplTest {
 
 	@Test
 	public void testGetAttribute() {
-		PropsUtil.set(PropsKeys.PORTLET_SESSION_REPLICATE_ENABLED, "false");
-
 		PortletSessionImpl portletSessionImpl = _getPortletSessionImpl();
 
 		try {
@@ -201,8 +158,6 @@ public class PortletSessionImplTest {
 
 	@Test
 	public void testGetAttributeMap() {
-		PropsUtil.set(PropsKeys.PORTLET_SESSION_REPLICATE_ENABLED, "false");
-
 		PortletSessionImpl portletSessionImpl = _getPortletSessionImpl();
 
 		String scopePrefix = portletSessionImpl.scopePrefix;
@@ -233,8 +188,6 @@ public class PortletSessionImplTest {
 
 	@Test
 	public void testGetAttributeNames() {
-		PropsUtil.set(PropsKeys.PORTLET_SESSION_REPLICATE_ENABLED, "false");
-
 		PortletSessionImpl portletSessionImpl = _getPortletSessionImpl();
 
 		String scopePrefix = portletSessionImpl.scopePrefix;
@@ -292,99 +245,7 @@ public class PortletSessionImplTest {
 	}
 
 	@Test
-	public void testLazySerializableObjectWrapper() throws Exception {
-		Constructor<?> constructor =
-			_lazySerializableObjectWrapperClass.getDeclaredConstructor(
-				Serializable.class);
-
-		constructor.setAccessible(true);
-
-		TestSerializable testSerializable = new TestSerializable(
-			"testSerializableName");
-
-		Object lazySerializableObjectWrapperObject = constructor.newInstance(
-			testSerializable);
-
-		Assert.assertSame(
-			testSerializable,
-			ReflectionTestUtil.invoke(
-				lazySerializableObjectWrapperObject, "getSerializable",
-				new Class<?>[0]));
-
-		Assert.assertNotSame(
-			testSerializable,
-			ReflectionTestUtil.invoke(
-				_getDeserializedObject(lazySerializableObjectWrapperObject),
-				"getSerializable", new Class<?>[0]));
-
-		Assert.assertEquals(
-			testSerializable,
-			(TestSerializable)ReflectionTestUtil.invoke(
-				_getDeserializedObject(lazySerializableObjectWrapperObject),
-				"getSerializable", new Class<?>[0]));
-
-		Assert.assertEquals(
-			testSerializable,
-			(TestSerializable)ReflectionTestUtil.invoke(
-				_getDeserializedObject(
-					_getDeserializedObject(
-						lazySerializableObjectWrapperObject)),
-				"getSerializable", new Class<?>[0]));
-
-		// Test with broken classloader
-
-		ClassLoaderPool.unregister(ClassLoaderPool.class.getClassLoader());
-
-		Thread currentThread = Thread.currentThread();
-
-		ClassLoader contextClassLoader = currentThread.getContextClassLoader();
-
-		ClassNotFoundException classNotFoundException =
-			new ClassNotFoundException();
-
-		currentThread.setContextClassLoader(
-			new ClassLoader() {
-
-				@Override
-				public Class<?> loadClass(String name)
-					throws ClassNotFoundException {
-
-					if (name.equals(TestSerializable.class.getName())) {
-						throw classNotFoundException;
-					}
-
-					return super.loadClass(name);
-				}
-
-			});
-
-		try (LogCapture logCapture = LoggerTestUtil.configureJDKLogger(
-				_lazySerializableClass.getName(), Level.ALL)) {
-
-			List<LogEntry> logEntries = logCapture.getLogEntries();
-
-			Assert.assertNull(
-				ReflectionTestUtil.invoke(
-					_getDeserializedObject(lazySerializableObjectWrapperObject),
-					"getSerializable", new Class<?>[0]));
-
-			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
-
-			LogEntry logEntry = logEntries.get(0);
-
-			Assert.assertEquals(
-				"Unable to deserialize object", logEntry.getMessage());
-			Assert.assertSame(classNotFoundException, logEntry.getThrowable());
-		}
-		finally {
-			currentThread.setContextClassLoader(contextClassLoader);
-		}
-	}
-
-	@Test
 	public void testRemoveAttribute() {
-		PropsUtil.set(PropsKeys.PORTLET_SESSION_REPLICATE_ENABLED, "false");
-
 		PortletSessionImpl portletSessionImpl = _getPortletSessionImpl();
 
 		String scopePrefix = portletSessionImpl.scopePrefix;
@@ -427,97 +288,8 @@ public class PortletSessionImplTest {
 		Assert.assertFalse(enumeration.hasMoreElements());
 	}
 
-	@AdviseWith(adviceClasses = PortalClassLoaderUtilAdvice.class)
-	@Test
-	public void testSerializableHttpSessionWrapper() {
-		PropsUtil.set(PropsKeys.PORTLET_SESSION_REPLICATE_ENABLED, "true");
-
-		// Constructor
-
-		PortletSessionImpl portletSessionImpl = new PortletSessionImpl(
-			_mockHttpSession, _portletContext, _PORTLET_NAME, _PLID);
-
-		String scopePrefix = portletSessionImpl.scopePrefix;
-
-		Assert.assertTrue(
-			portletSessionImpl.session instanceof HttpSessionWrapper);
-
-		HttpSessionWrapper httpSessionWrapper =
-			(HttpSessionWrapper)portletSessionImpl.session;
-
-		Assert.assertSame(
-			_mockHttpSession, httpSessionWrapper.getWrappedSession());
-
-		// Set http session when session is not SerializableHttpSessionWrapper
-
-		portletSessionImpl.setHttpSession(_mockHttpSession);
-
-		Assert.assertNotSame(_mockHttpSession, portletSessionImpl.session);
-		Assert.assertTrue(
-			portletSessionImpl.session instanceof HttpSessionWrapper);
-
-		// Set http session when session is SerializableHttpSessionWrapper
-
-		portletSessionImpl.setHttpSession(httpSessionWrapper);
-
-		Assert.assertSame(httpSessionWrapper, portletSessionImpl.session);
-
-		// Set/get attribute when value class is loaded by the bootstrap class
-		// loader
-
-		String key = "key";
-		String value = "value";
-
-		portletSessionImpl.setAttribute(key, value);
-
-		Assert.assertSame(value, portletSessionImpl.getAttribute(key));
-		Assert.assertSame(
-			value, _mockHttpSession.getAttribute(scopePrefix.concat(key)));
-
-		// Set/get attribute when value class is not loaded by the portal class
-		// loader
-
-		TestSerializable testSerializable = new TestSerializable("name");
-
-		PortalClassLoaderUtilAdvice.setPortalClassLoader(false);
-
-		portletSessionImpl.setAttribute(key, testSerializable);
-
-		Assert.assertSame(
-			testSerializable, portletSessionImpl.getAttribute(key));
-		Assert.assertTrue(
-			_lazySerializableObjectWrapperClass.isInstance(
-				_mockHttpSession.getAttribute(scopePrefix.concat(key))));
-
-		// Set/get non-serializable attribute when value class is not loaded by
-		// PortalClassLoader
-
-		Object objectValue = new Object();
-
-		portletSessionImpl.setAttribute(key, objectValue);
-
-		Assert.assertSame(objectValue, portletSessionImpl.getAttribute(key));
-		Assert.assertSame(
-			objectValue,
-			_mockHttpSession.getAttribute(scopePrefix.concat(key)));
-
-		// Set/get attribute when value class is loaded by PortalClassLoader
-
-		PortalClassLoaderUtilAdvice.setPortalClassLoader(true);
-
-		portletSessionImpl.setAttribute(key, testSerializable);
-
-		Assert.assertSame(
-			testSerializable, portletSessionImpl.getAttribute(key));
-		Assert.assertSame(
-			testSerializable,
-			_mockHttpSession.getAttribute(scopePrefix.concat(key)));
-	}
-
 	@Test
 	public void testSetAttribute() {
-		PropsUtil.set(PropsKeys.PORTLET_SESSION_REPLICATE_ENABLED, "false");
-
 		PortletSessionImpl portletSessionImpl = _getPortletSessionImpl();
 
 		String scopePrefix = portletSessionImpl.scopePrefix;
@@ -545,48 +317,6 @@ public class PortletSessionImplTest {
 			key8, value8, PortletSession.APPLICATION_SCOPE);
 
 		Assert.assertSame(value8, _mockHttpSession.getAttribute(key8));
-	}
-
-	@Aspect
-	public static class PortalClassLoaderUtilAdvice {
-
-		public static void setPortalClassLoader(boolean portalClassLoader) {
-			_portalClassLoader = portalClassLoader;
-		}
-
-		@Around(
-			"execution(public static boolean com.liferay.portal.kernel.util." +
-				"PortalClassLoaderUtil.isPortalClassLoader(ClassLoader)) && " +
-					"args(classLoader)"
-		)
-		public boolean isPortalClassLoader(ClassLoader classLoader) {
-			return _portalClassLoader;
-		}
-
-		private static boolean _portalClassLoader;
-
-	}
-
-	private Object _getDeserializedObject(Object object) throws Exception {
-		try (UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
-				new UnsyncByteArrayOutputStream()) {
-
-			try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(
-					unsyncByteArrayOutputStream)) {
-
-				objectOutputStream.writeObject(object);
-			}
-
-			try (UnsyncByteArrayInputStream unsyncByteArrayInputStream =
-					new UnsyncByteArrayInputStream(
-						unsyncByteArrayOutputStream.unsafeGetByteArray(), 0,
-						unsyncByteArrayOutputStream.size());
-				ObjectInputStream objectInputStream = new ObjectInputStream(
-					unsyncByteArrayInputStream)) {
-
-				return objectInputStream.readObject();
-			}
-		}
 	}
 
 	private PortletSessionImpl _getPortletSessionImpl() {
@@ -636,47 +366,11 @@ public class PortletSessionImplTest {
 
 			});
 
-	private Class<?> _lazySerializableClass;
-	private Class<?> _lazySerializableObjectWrapperClass;
 	private final MockHttpSession _mockHttpSession = new MockHttpSession();
 	private final Object _value1 = new Object();
 	private final Object _value2 = new Object();
 	private final Object _value3 = new Object();
 	private final Object _value4 = new Object();
 	private final Object _value5 = new Object();
-
-	private static class TestSerializable implements Serializable {
-
-		@Override
-		public boolean equals(Object object) {
-			if (this == object) {
-				return true;
-			}
-
-			if (!(object instanceof TestSerializable)) {
-				return false;
-			}
-
-			TestSerializable testSerializable = (TestSerializable)object;
-
-			return Objects.equals(_name, testSerializable._name);
-		}
-
-		public String getName() {
-			return _name;
-		}
-
-		@Override
-		public int hashCode() {
-			return _name.hashCode();
-		}
-
-		private TestSerializable(String name) {
-			_name = name;
-		}
-
-		private final String _name;
-
-	}
 
 }


### PR DESCRIPTION
- LPS-135570 Add filter/wrapper to serialize session attributes to bytes so that app server classloader can do replication without knowing the actual classes of attributes
- LPS-135570 Make sure the session replicate wrapper is the lowest level
- LPS-135570 Don't wrap if session from the actual request is null
- LPS-135570 Use ASMWrapperUtil to wrap the request since HttpServletRequestWrapper may be unwrapped by portal code
- LPS-135570 Apply filter; here the filter will be the first in the filter chain, and will not be registered at all if session replication support is not enabled.
- LPS-135570 SF, short prefix to make it easy to read when debugging
- LPS-135570 Implement HttpSession#getAttributeNames, strip serialized attribute prefix from saved names
- LPS-135570 Implement HttpSession#removeAttribute; it's hard to check whether the attribute is serialized, just try to remove both names
- LPS-135570 For Java 11+: some JDK classes are now loaded by the new PlatformClassLoader
- LPS-133557 SF, simplify checking logic at runtime
- LPS-133557 Make it also catch the runtime exceptions thrown by objectInputStream.readObject().
- LPS-133557 Add unit test
- LPS-135570 Remove old logic that is no longer needed
- LPS-135570 Fix test, remove unused test logic as it had been removed in target class
- LPS-135570 Use cache replication for session attributes that needs to be replicated
