### PR TITLE
[Bug fix] LPS-137608 FreeMarker

### DIFF
--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapper.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapper.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.spring.aop.AopInvocationHandler;
 import com.liferay.portal.util.PortalImpl;
+import com.liferay.portal.util.PropsValues;
 
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.ext.beans.StringModel;
@@ -320,7 +321,8 @@ public class RestrictedLiferayObjectWrapper extends LiferayObjectWrapper {
 		TransactionConfig.Builder builder = new TransactionConfig.Builder();
 
 		builder.setPropagation(Propagation.REQUIRES_NEW);
-		builder.setStrictReadOnly(true);
+		builder.setStrictReadOnly(
+			PropsValues.FREEMARKER_TEMPLATE_TRANSACTION_STRICTREADONLY);
 		builder.setRollbackForClasses(Exception.class);
 
 		_transactionConfig = builder.build();

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapper.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapper.java
@@ -322,7 +322,7 @@ public class RestrictedLiferayObjectWrapper extends LiferayObjectWrapper {
 
 		builder.setPropagation(Propagation.REQUIRES_NEW);
 		builder.setStrictReadOnly(
-			PropsValues.FREEMARKER_TEMPLATE_TRANSACTION_STRICTREADONLY);
+			PropsValues.TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY);
 		builder.setRollbackForClasses(Exception.class);
 
 		_transactionConfig = builder.build();

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
@@ -495,6 +495,11 @@ public class RestrictedLiferayObjectWrapperTest
 		}
 
 		@Override
+		public TestBaseModel cloneWithOriginalValues() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
 		public int compareTo(TestBaseModel testBaseModel) {
 			return 0;
 		}

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
@@ -575,7 +575,7 @@ public class RestrictedLiferayObjectWrapperTest
 		try {
 			liferayFreeMarkerStringModel.get(key);
 
-			Assert.assertNull("Should throw TemplateModelException for " + key);
+			Assert.fail("Should throw TemplateModelException for " + key);
 		}
 		catch (TemplateModelException templateModelException) {
 			Assert.assertSame(

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.template.freemarker.internal;
 
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.impl.BaseModelImpl;
@@ -45,9 +46,6 @@ import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 
 import java.io.Serializable;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 import java.util.Collections;
 import java.util.List;
@@ -355,34 +353,24 @@ public class RestrictedLiferayObjectWrapperTest
 
 		// Local service object with proxy
 
-		StringModel stringModel = StringModel.class.cast(
+		StringModel testLocalServiceStringModel = StringModel.class.cast(
 			objectWrapper.wrap(
 				_createAopProxy(
 					new TestLocalServiceImpl("TestLocalServiceObject"))));
 
-		Object wrappedObject = stringModel.getWrappedObject();
-
-		Method localServiceAddMethod = ReflectionTestUtil.getMethod(
-			wrappedObject.getClass(), "add");
-
 		assertTemplateModel(
-			"TestLocalServiceObject",
-			object -> localServiceAddMethod.invoke(object), wrappedObject);
+			"TestLocalServiceObject", TestLocalService::add,
+			(TestLocalService)testLocalServiceStringModel.getWrappedObject());
 
 		// Service object with proxy
 
-		stringModel = StringModel.class.cast(
+		StringModel testServiceStringModel = StringModel.class.cast(
 			objectWrapper.wrap(
 				_createAopProxy(new TestServiceImpl("TestServiceObject"))));
 
-		wrappedObject = stringModel.getWrappedObject();
-
-		Method serviceAddMethod = ReflectionTestUtil.getMethod(
-			wrappedObject.getClass(), "add");
-
 		assertTemplateModel(
-			"TestServiceObject", object -> serviceAddMethod.invoke(object),
-			wrappedObject);
+			"TestServiceObject", TestService::add,
+			(TestService)testServiceStringModel.getWrappedObject());
 	}
 
 	@NewEnv(type = NewEnv.Type.CLASSLOADER)
@@ -405,29 +393,24 @@ public class RestrictedLiferayObjectWrapperTest
 
 		// Local service object with proxy
 
-		StringModel stringModel = StringModel.class.cast(
+		StringModel testLocalServiceStringModel = StringModel.class.cast(
 			objectWrapper.wrap(
 				_createAopProxy(
 					new TestLocalServiceImpl("TestLocalServiceObject"))));
 
-		Object wrappedObject = stringModel.getWrappedObject();
-
 		_assertException(
-			ReflectionTestUtil.getMethod(wrappedObject.getClass(), "add"),
-			stringModel.getWrappedObject());
+			TestLocalService::add,
+			(TestLocalService)testLocalServiceStringModel.getWrappedObject());
 
 		// Service object with proxy
 
-		stringModel = StringModel.class.cast(
+		StringModel testServiceStringModel = StringModel.class.cast(
 			objectWrapper.wrap(
-				_createAopProxy(
-					new TestLocalServiceImpl("TestServiceObject"))));
-
-		wrappedObject = stringModel.getWrappedObject();
+				_createAopProxy(new TestServiceImpl("TestServiceObject"))));
 
 		_assertException(
-			ReflectionTestUtil.getMethod(wrappedObject.getClass(), "add"),
-			stringModel.getWrappedObject());
+			TestService::add,
+			(TestService)testServiceStringModel.getWrappedObject());
 	}
 
 	public class TestLiferayMethodObject {
@@ -550,24 +533,22 @@ public class RestrictedLiferayObjectWrapperTest
 		}
 	}
 
-	private void _assertException(Method method, Object object)
-		throws Exception {
+	private <T, R> void _assertException(
+		UnsafeFunction<T, R, Exception> unsafeFunction, T wrappedObject) {
 
 		try {
-			method.invoke(object);
+			unsafeFunction.apply(wrappedObject);
 
-			Assert.fail("Should throw InvocationTargetException");
+			Assert.fail("Should throw IllegalStateException");
 		}
-		catch (InvocationTargetException invocationTargetException) {
-			Throwable throwable = invocationTargetException.getCause();
-
+		catch (Exception exception) {
 			Assert.assertTrue(
-				throwable.toString(),
-				throwable instanceof IllegalStateException);
+				exception.toString(),
+				exception instanceof IllegalStateException);
 
 			Assert.assertEquals(
 				"Strict read only transaction is not writable",
-				throwable.getMessage());
+				exception.getMessage());
 		}
 	}
 

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
@@ -354,23 +354,23 @@ public class RestrictedLiferayObjectWrapperTest
 		// Local service object with proxy
 
 		StringModel testLocalServiceStringModel = StringModel.class.cast(
-			objectWrapper.wrap(
-				_createAopProxy(
-					new TestLocalServiceImpl("TestLocalServiceObject"))));
+			objectWrapper.wrap(_createAopProxy(new TestLocalServiceImpl(""))));
 
 		assertTemplateModel(
-			"TestLocalServiceObject", TestLocalService::add,
-			(TestLocalService)testLocalServiceStringModel.getWrappedObject());
+			"TestLocalServiceObject",
+			((TestLocalService)testLocalServiceStringModel.getWrappedObject())::
+				add,
+			"TestLocalServiceObject");
 
 		// Service object with proxy
 
 		StringModel testServiceStringModel = StringModel.class.cast(
-			objectWrapper.wrap(
-				_createAopProxy(new TestServiceImpl("TestServiceObject"))));
+			objectWrapper.wrap(_createAopProxy(new TestServiceImpl(""))));
 
 		assertTemplateModel(
-			"TestServiceObject", TestService::add,
-			(TestService)testServiceStringModel.getWrappedObject());
+			"TestServiceObject",
+			((TestService)testServiceStringModel.getWrappedObject())::add,
+			"TestServiceObject");
 	}
 
 	@NewEnv(type = NewEnv.Type.CLASSLOADER)
@@ -394,23 +394,21 @@ public class RestrictedLiferayObjectWrapperTest
 		// Local service object with proxy
 
 		StringModel testLocalServiceStringModel = StringModel.class.cast(
-			objectWrapper.wrap(
-				_createAopProxy(
-					new TestLocalServiceImpl("TestLocalServiceObject"))));
+			objectWrapper.wrap(_createAopProxy(new TestLocalServiceImpl(""))));
 
 		_assertException(
-			TestLocalService::add,
-			(TestLocalService)testLocalServiceStringModel.getWrappedObject());
+			((TestLocalService)testLocalServiceStringModel.getWrappedObject())::
+				add,
+			"TestLocalServiceObject");
 
 		// Service object with proxy
 
 		StringModel testServiceStringModel = StringModel.class.cast(
-			objectWrapper.wrap(
-				_createAopProxy(new TestServiceImpl("TestServiceObject"))));
+			objectWrapper.wrap(_createAopProxy(new TestServiceImpl(""))));
 
 		_assertException(
-			TestService::add,
-			(TestService)testServiceStringModel.getWrappedObject());
+			((TestService)testServiceStringModel.getWrappedObject())::add,
+			"TestServiceObject");
 	}
 
 	public class TestLiferayMethodObject {
@@ -673,8 +671,10 @@ public class RestrictedLiferayObjectWrapperTest
 	private static class TestLocalServiceImpl implements TestLocalService {
 
 		@Override
-		public String add() {
-			return _name;
+		public String add(String value) {
+			_value = value;
+
+			return _value;
 		}
 
 		@Override
@@ -687,14 +687,17 @@ public class RestrictedLiferayObjectWrapperTest
 		}
 
 		private final String _name;
+		private String _value;
 
 	}
 
 	private static class TestServiceImpl implements TestService {
 
 		@Override
-		public String add() {
-			return _name;
+		public String add(String value) {
+			_value = value;
+
+			return _value;
 		}
 
 		@Override
@@ -707,6 +710,7 @@ public class RestrictedLiferayObjectWrapperTest
 		}
 
 		private final String _name;
+		private String _value;
 
 	}
 
@@ -735,13 +739,13 @@ public class RestrictedLiferayObjectWrapperTest
 
 	private interface TestLocalService extends BaseLocalService {
 
-		public String add();
+		public String add(String value);
 
 	}
 
 	private interface TestService extends BaseService {
 
-		public String add();
+		public String add(String value);
 
 	}
 

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
@@ -59,7 +59,7 @@ import java.util.logging.Level;
 import org.hamcrest.CoreMatchers;
 
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -76,13 +76,13 @@ public class RestrictedLiferayObjectWrapperTest
 		new AggregateTestRule(
 			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
 
-	@Before
-	public void setUp() {
+	@BeforeClass
+	public static void setUpClass() {
 		TransactionInvokerUtil transactionInvokerUtil =
 			new TransactionInvokerUtil();
 
 		transactionInvokerUtil.setTransactionInvoker(
-			new TestTransactionInvoker());
+			new TestTransactionInvoker(false));
 	}
 
 	@Test
@@ -340,57 +340,49 @@ public class RestrictedLiferayObjectWrapperTest
 	public void testWrapWithServiceProxyAndTransactionStrictReadOnlyForFalse()
 		throws Exception {
 
-		_transactionWriteOperation = true;
+		TransactionInvokerUtil transactionInvokerUtil =
+			new TransactionInvokerUtil();
 
-		boolean strictReadOnly =
-			PropsValues.TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY;
+		transactionInvokerUtil.setTransactionInvoker(
+			new TestTransactionInvoker(true));
 
-		_setPortalProperty(
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class,
 			"TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY", false);
 
 		ObjectWrapper objectWrapper = new RestrictedLiferayObjectWrapper(
 			null, null, null);
 
-		try {
+		// Local service object with proxy
 
-			// Local service object with proxy
+		StringModel stringModel = StringModel.class.cast(
+			objectWrapper.wrap(
+				_createAopProxy(
+					new TestLocalServiceImpl("TestLocalServiceObject"))));
 
-			StringModel stringModel = StringModel.class.cast(
-				objectWrapper.wrap(
-					_createAopProxy(
-						new TestLocalServiceImpl("TestLocalServiceObject"))));
+		Object wrappedObject = stringModel.getWrappedObject();
 
-			Object wrappedObject = stringModel.getWrappedObject();
+		Method localServiceAddMethod = ReflectionTestUtil.getMethod(
+			wrappedObject.getClass(), "add");
 
-			Method localServiceAddMethod = ReflectionTestUtil.getMethod(
-				wrappedObject.getClass(), "add");
+		assertTemplateModel(
+			"TestLocalServiceObject",
+			object -> localServiceAddMethod.invoke(object), wrappedObject);
 
-			assertTemplateModel(
-				"TestLocalServiceObject",
-				object -> localServiceAddMethod.invoke(object), wrappedObject);
+		// Service object with proxy
 
-			// Service object with proxy
+		stringModel = StringModel.class.cast(
+			objectWrapper.wrap(
+				_createAopProxy(new TestServiceImpl("TestServiceObject"))));
 
-			stringModel = StringModel.class.cast(
-				objectWrapper.wrap(
-					_createAopProxy(new TestServiceImpl("TestServiceObject"))));
+		wrappedObject = stringModel.getWrappedObject();
 
-			wrappedObject = stringModel.getWrappedObject();
+		Method serviceAddMethod = ReflectionTestUtil.getMethod(
+			wrappedObject.getClass(), "add");
 
-			Method serviceAddMethod = ReflectionTestUtil.getMethod(
-				wrappedObject.getClass(), "add");
-
-			assertTemplateModel(
-				"TestServiceObject", object -> serviceAddMethod.invoke(object),
-				wrappedObject);
-		}
-		finally {
-			_transactionWriteOperation = false;
-
-			_setPortalProperty(
-				"TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY",
-				strictReadOnly);
-		}
+		assertTemplateModel(
+			"TestServiceObject", object -> serviceAddMethod.invoke(object),
+			wrappedObject);
 	}
 
 	@NewEnv(type = NewEnv.Type.CLASSLOADER)
@@ -398,52 +390,44 @@ public class RestrictedLiferayObjectWrapperTest
 	public void testWrapWithServiceProxyAndTransactionStrictReadOnlyForTrue()
 		throws Exception {
 
-		_transactionWriteOperation = true;
+		TransactionInvokerUtil transactionInvokerUtil =
+			new TransactionInvokerUtil();
 
-		boolean strictReadOnly =
-			PropsValues.TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY;
+		transactionInvokerUtil.setTransactionInvoker(
+			new TestTransactionInvoker(true));
 
-		_setPortalProperty(
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class,
 			"TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY", true);
 
 		ObjectWrapper objectWrapper = new RestrictedLiferayObjectWrapper(
 			null, null, null);
 
-		try {
+		// Local service object with proxy
 
-			// Local service object with proxy
+		StringModel stringModel = StringModel.class.cast(
+			objectWrapper.wrap(
+				_createAopProxy(
+					new TestLocalServiceImpl("TestLocalServiceObject"))));
 
-			StringModel stringModel = StringModel.class.cast(
-				objectWrapper.wrap(
-					_createAopProxy(
-						new TestLocalServiceImpl("TestLocalServiceObject"))));
+		Object wrappedObject = stringModel.getWrappedObject();
 
-			Object wrappedObject = stringModel.getWrappedObject();
+		_assertException(
+			ReflectionTestUtil.getMethod(wrappedObject.getClass(), "add"),
+			stringModel.getWrappedObject());
 
-			_assertException(
-				ReflectionTestUtil.getMethod(wrappedObject.getClass(), "add"),
-				stringModel.getWrappedObject());
+		// Service object with proxy
 
-			// Service object with proxy
+		stringModel = StringModel.class.cast(
+			objectWrapper.wrap(
+				_createAopProxy(
+					new TestLocalServiceImpl("TestServiceObject"))));
 
-			stringModel = StringModel.class.cast(
-				objectWrapper.wrap(
-					_createAopProxy(
-						new TestLocalServiceImpl("TestServiceObject"))));
+		wrappedObject = stringModel.getWrappedObject();
 
-			wrappedObject = stringModel.getWrappedObject();
-
-			_assertException(
-				ReflectionTestUtil.getMethod(wrappedObject.getClass(), "add"),
-				stringModel.getWrappedObject());
-		}
-		finally {
-			_transactionWriteOperation = false;
-
-			_setPortalProperty(
-				"TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY",
-				strictReadOnly);
-		}
+		_assertException(
+			ReflectionTestUtil.getMethod(wrappedObject.getClass(), "add"),
+			stringModel.getWrappedObject());
 	}
 
 	public class TestLiferayMethodObject {
@@ -604,11 +588,6 @@ public class RestrictedLiferayObjectWrapperTest
 			new Class<?>[] {Class.class}, targetClass);
 	}
 
-	private void _setPortalProperty(String propertyName, Object value) {
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, propertyName, value);
-	}
-
 	private void _testRestrictedMethodNames(
 		LiferayFreeMarkerStringModel liferayFreeMarkerStringModel, String key) {
 
@@ -629,8 +608,6 @@ public class RestrictedLiferayObjectWrapperTest
 				templateModelException.getMessage());
 		}
 	}
-
-	private static boolean _transactionWriteOperation;
 
 	private static class TestBaseModel extends BaseModelImpl<TestBaseModel> {
 
@@ -754,20 +731,24 @@ public class RestrictedLiferayObjectWrapperTest
 
 	private static class TestTransactionInvoker implements TransactionInvoker {
 
+		public TestTransactionInvoker(boolean modification) {
+			_modification = modification;
+		}
+
 		@Override
 		public <T> T invoke(
 				TransactionConfig transactionConfig, Callable<T> callable)
 			throws Throwable {
 
-			if (transactionConfig.isStrictReadOnly() &&
-				_transactionWriteOperation) {
-
+			if (transactionConfig.isStrictReadOnly() && _modification) {
 				throw new IllegalStateException(
 					"Strict read only transaction is not writable");
 			}
 
 			return callable.call();
 		}
+
+		private final boolean _modification;
 
 	}
 

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.BaseService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.test.rule.NewEnv;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvoker;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
@@ -32,6 +33,7 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.PropsValues;
 
 import freemarker.ext.beans.InvalidPropertyException;
 import freemarker.ext.beans.SimpleMethodModel;
@@ -44,6 +46,9 @@ import freemarker.template.TemplateModelException;
 
 import java.io.Serializable;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +59,7 @@ import java.util.logging.Level;
 import org.hamcrest.CoreMatchers;
 
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -71,8 +76,8 @@ public class RestrictedLiferayObjectWrapperTest
 		new AggregateTestRule(
 			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
 
-	@BeforeClass
-	public static void setUpClass() {
+	@Before
+	public void setUp() {
 		TransactionInvokerUtil transactionInvokerUtil =
 			new TransactionInvokerUtil();
 
@@ -330,6 +335,117 @@ public class RestrictedLiferayObjectWrapperTest
 				}));
 	}
 
+	@NewEnv(type = NewEnv.Type.CLASSLOADER)
+	@Test
+	public void testWrapWithServiceProxyAndTransactionStrictReadOnlyForFalse()
+		throws Exception {
+
+		_transactionWriteOperation = true;
+
+		boolean strictReadOnly =
+			PropsValues.TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY;
+
+		_setPortalProperty(
+			"TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY", false);
+
+		ObjectWrapper objectWrapper = new RestrictedLiferayObjectWrapper(
+			null, null, null);
+
+		try {
+
+			// Local service object with proxy
+
+			StringModel stringModel = StringModel.class.cast(
+				objectWrapper.wrap(
+					_createAopProxy(
+						new TestLocalServiceImpl("TestLocalServiceObject"))));
+
+			Object wrappedObject = stringModel.getWrappedObject();
+
+			Method localServiceAddMethod = ReflectionTestUtil.getMethod(
+				wrappedObject.getClass(), "add");
+
+			assertTemplateModel(
+				"TestLocalServiceObject",
+				object -> localServiceAddMethod.invoke(object), wrappedObject);
+
+			// Service object with proxy
+
+			stringModel = StringModel.class.cast(
+				objectWrapper.wrap(
+					_createAopProxy(new TestServiceImpl("TestServiceObject"))));
+
+			wrappedObject = stringModel.getWrappedObject();
+
+			Method serviceAddMethod = ReflectionTestUtil.getMethod(
+				wrappedObject.getClass(), "add");
+
+			assertTemplateModel(
+				"TestServiceObject", object -> serviceAddMethod.invoke(object),
+				wrappedObject);
+		}
+		finally {
+			_transactionWriteOperation = false;
+
+			_setPortalProperty(
+				"TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY",
+				strictReadOnly);
+		}
+	}
+
+	@NewEnv(type = NewEnv.Type.CLASSLOADER)
+	@Test
+	public void testWrapWithServiceProxyAndTransactionStrictReadOnlyForTrue()
+		throws Exception {
+
+		_transactionWriteOperation = true;
+
+		boolean strictReadOnly =
+			PropsValues.TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY;
+
+		_setPortalProperty(
+			"TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY", true);
+
+		ObjectWrapper objectWrapper = new RestrictedLiferayObjectWrapper(
+			null, null, null);
+
+		try {
+
+			// Local service object with proxy
+
+			StringModel stringModel = StringModel.class.cast(
+				objectWrapper.wrap(
+					_createAopProxy(
+						new TestLocalServiceImpl("TestLocalServiceObject"))));
+
+			Object wrappedObject = stringModel.getWrappedObject();
+
+			_assertException(
+				ReflectionTestUtil.getMethod(wrappedObject.getClass(), "add"),
+				stringModel.getWrappedObject());
+
+			// Service object with proxy
+
+			stringModel = StringModel.class.cast(
+				objectWrapper.wrap(
+					_createAopProxy(
+						new TestLocalServiceImpl("TestServiceObject"))));
+
+			wrappedObject = stringModel.getWrappedObject();
+
+			_assertException(
+				ReflectionTestUtil.getMethod(wrappedObject.getClass(), "add"),
+				stringModel.getWrappedObject());
+		}
+		finally {
+			_transactionWriteOperation = false;
+
+			_setPortalProperty(
+				"TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY",
+				strictReadOnly);
+		}
+	}
+
 	public class TestLiferayMethodObject {
 
 		public String generate(String postfix) {
@@ -366,7 +482,7 @@ public class RestrictedLiferayObjectWrapperTest
 			"TestLocalServiceObject", stringModel -> stringModel.getAsString(),
 			StringModel.class.cast(
 				objectWrapper.wrap(
-					new TestLocalService("TestLocalServiceObject"))));
+					new TestLocalServiceImpl("TestLocalServiceObject"))));
 
 		// Local service object with proxy
 
@@ -375,14 +491,14 @@ public class RestrictedLiferayObjectWrapperTest
 			StringModel.class.cast(
 				objectWrapper.wrap(
 					_createAopProxy(
-						new TestLocalService("TestLocalServiceObject1")))));
+						new TestLocalServiceImpl("TestLocalServiceObject1")))));
 
 		assertTemplateModel(
 			"TestLocalServiceObject2", stringModel -> stringModel.getAsString(),
 			StringModel.class.cast(
 				objectWrapper.wrap(
 					_createAopProxy(
-						new TestLocalService("TestLocalServiceObject2")))));
+						new TestLocalServiceImpl("TestLocalServiceObject2")))));
 
 		// Service object
 
@@ -390,7 +506,8 @@ public class RestrictedLiferayObjectWrapperTest
 			"TestServiceObject", stringModel -> stringModel.getAsString(),
 			StringModel.class.cast(
 				objectWrapper.wrap(
-					_createAopProxy(new TestService("TestServiceObject")))));
+					_createAopProxy(
+						new TestServiceImpl("TestServiceObject")))));
 
 		// System company ID
 
@@ -449,6 +566,27 @@ public class RestrictedLiferayObjectWrapperTest
 		}
 	}
 
+	private void _assertException(Method method, Object object)
+		throws Exception {
+
+		try {
+			method.invoke(object);
+
+			Assert.fail("Should throw InvocationTargetException");
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			Throwable throwable = invocationTargetException.getCause();
+
+			Assert.assertTrue(
+				throwable.toString(),
+				throwable instanceof IllegalStateException);
+
+			Assert.assertEquals(
+				"Strict read only transaction is not writable",
+				throwable.getMessage());
+		}
+	}
+
 	private Object _createAopProxy(Object target) {
 		Class<?> clazz = target.getClass();
 
@@ -464,6 +602,11 @@ public class RestrictedLiferayObjectWrapperTest
 		return ReflectionTestUtil.invoke(
 			restrictedLiferayObjectWrapper, "_isRestricted",
 			new Class<?>[] {Class.class}, targetClass);
+	}
+
+	private void _setPortalProperty(String propertyName, Object value) {
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, propertyName, value);
 	}
 
 	private void _testRestrictedMethodNames(
@@ -486,6 +629,8 @@ public class RestrictedLiferayObjectWrapperTest
 				templateModelException.getMessage());
 		}
 	}
+
+	private static boolean _transactionWriteOperation;
 
 	private static class TestBaseModel extends BaseModelImpl<TestBaseModel> {
 
@@ -567,14 +712,19 @@ public class RestrictedLiferayObjectWrapperTest
 
 	}
 
-	private static class TestLocalService implements BaseLocalService {
+	private static class TestLocalServiceImpl implements TestLocalService {
+
+		@Override
+		public String add() {
+			return _name;
+		}
 
 		@Override
 		public String toString() {
 			return _name;
 		}
 
-		private TestLocalService(String name) {
+		private TestLocalServiceImpl(String name) {
 			_name = name;
 		}
 
@@ -582,14 +732,19 @@ public class RestrictedLiferayObjectWrapperTest
 
 	}
 
-	private static class TestService implements BaseService {
+	private static class TestServiceImpl implements TestService {
+
+		@Override
+		public String add() {
+			return _name;
+		}
 
 		@Override
 		public String toString() {
 			return _name;
 		}
 
-		private TestService(String name) {
+		private TestServiceImpl(String name) {
 			_name = name;
 		}
 
@@ -604,12 +759,27 @@ public class RestrictedLiferayObjectWrapperTest
 				TransactionConfig transactionConfig, Callable<T> callable)
 			throws Throwable {
 
-			if (transactionConfig.isStrictReadOnly()) {
-				return callable.call();
+			if (transactionConfig.isStrictReadOnly() &&
+				_transactionWriteOperation) {
+
+				throw new IllegalStateException(
+					"Strict read only transaction is not writable");
 			}
 
-			return null;
+			return callable.call();
 		}
+
+	}
+
+	private interface TestLocalService extends BaseLocalService {
+
+		public String add();
+
+	}
+
+	private interface TestService extends BaseService {
+
+		public String add();
 
 	}
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1148,6 +1148,11 @@ public class PropsValues {
 					PropsKeys.
 						FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS));
 
+	public static final boolean FREEMARKER_TEMPLATE_TRANSACTION_STRICTREADONLY =
+		GetterUtil.getBoolean(
+			PropsUtil.get(
+				PropsKeys.FREEMARKER_TEMPLATE_TRANSACTION_STRICTREADONLY));
+
 	public static final String[] GLOBAL_SHUTDOWN_EVENTS = PropsUtil.getArray(
 		PropsKeys.GLOBAL_SHUTDOWN_EVENTS);
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1148,11 +1148,6 @@ public class PropsValues {
 					PropsKeys.
 						FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS));
 
-	public static final boolean FREEMARKER_TEMPLATE_TRANSACTION_STRICTREADONLY =
-		GetterUtil.getBoolean(
-			PropsUtil.get(
-				PropsKeys.FREEMARKER_TEMPLATE_TRANSACTION_STRICTREADONLY));
-
 	public static final String[] GLOBAL_SHUTDOWN_EVENTS = PropsUtil.getArray(
 		PropsKeys.GLOBAL_SHUTDOWN_EVENTS);
 
@@ -2898,6 +2893,13 @@ public class PropsValues {
 
 	public static String[] STRIP_MIME_TYPES = PropsUtil.getArray(
 		PropsKeys.STRIP_MIME_TYPES);
+
+	public static final boolean
+		TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY =
+			GetterUtil.getBoolean(
+				PropsUtil.get(
+					PropsKeys.
+						TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY));
 
 	public static final boolean TEMPLATE_ENGINE_SERVICE_LOCATOR_RESTRICT =
 		GetterUtil.getBoolean(

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6774,6 +6774,18 @@
     etag.response.size.max=1048576
 
 ##
+## FreeMarker Template Transaction
+##
+
+    #
+    # Set this to true to limit only allow to read from database in freemarker
+    # template. Otherwise allow to crud from databse.
+    #
+    # Env: LIFERAY_FREEMARKER_PERIOD_TEMPLATE_PERIOD_TRANSACTION_PERIOD_STRICTREADONLY
+    #
+    freemarker.template.transaction.strictreadonly=true
+
+##
 ## GZip
 ##
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9523,8 +9523,8 @@
 ##
 
     #
-    # Set this to true to limit only allow to read from database in freemarker
-    # template. Otherwise allow to crud from databse.
+    # Set this to true to restrict database modifications from API calls in
+    # FreeMarker templates. Otherwise CRUD are allowed.
     #
     # Env: LIFERAY_TEMPLATE_PERIOD_ENGINE_PERIOD_FREEMARKER_PERIOD_TRANSACTION_PERIOD_READ_PERIOD_ONLY
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6774,18 +6774,6 @@
     etag.response.size.max=1048576
 
 ##
-## FreeMarker Template Transaction
-##
-
-    #
-    # Set this to true to limit only allow to read from database in freemarker
-    # template. Otherwise allow to crud from databse.
-    #
-    # Env: LIFERAY_FREEMARKER_PERIOD_TEMPLATE_PERIOD_TRANSACTION_PERIOD_STRICTREADONLY
-    #
-    freemarker.template.transaction.strictreadonly=true
-
-##
 ## GZip
 ##
 
@@ -9533,6 +9521,14 @@
 ##
 ## Template Engine
 ##
+
+    #
+    # Set this to true to limit only allow to read from database in freemarker
+    # template. Otherwise allow to crud from databse.
+    #
+    # Env: LIFERAY_TEMPLATE_PERIOD_ENGINE_PERIOD_FREEMARKER_PERIOD_TRANSACTION_PERIOD_READ_PERIOD_ONLY
+    #
+    template.engine.freemarker.transaction.read.only=true
 
     #
     # Set this to true if you want to only allow service builder generated

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1292,6 +1292,9 @@ public interface PropsKeys {
 	public static final String FINALIZE_MANAGER_THREAD_ENABLED =
 		"finalize.manager.thread.enabled";
 
+	public static final String FREEMARKER_TEMPLATE_TRANSACTION_STRICTREADONLY =
+		"freemarker.template.transaction.strictreadonly";
+
 	public static final String FULL_PAGE_DISPLAYABLE = "full.page.displayable";
 
 	public static final String GLOBAL_SHUTDOWN_EVENTS =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1292,9 +1292,6 @@ public interface PropsKeys {
 	public static final String FINALIZE_MANAGER_THREAD_ENABLED =
 		"finalize.manager.thread.enabled";
 
-	public static final String FREEMARKER_TEMPLATE_TRANSACTION_STRICTREADONLY =
-		"freemarker.template.transaction.strictreadonly";
-
 	public static final String FULL_PAGE_DISPLAYABLE = "full.page.displayable";
 
 	public static final String GLOBAL_SHUTDOWN_EVENTS =
@@ -3273,6 +3270,10 @@ public interface PropsKeys {
 
 	public static final String TABLE_MAPPER_CACHELESS_MAPPING_TABLE_NAMES =
 		"table.mapper.cacheless.mapping.table.names";
+
+	public static final String
+		TEMPLATE_ENGINE_FREEMARKER_TRANSACTION_READ_ONLY =
+			"template.engine.freemarker.transaction.read.only";
 
 	public static final String TEMPLATE_ENGINE_SERVICE_LOCATOR_RESTRICT =
 		"template.engine.service.locator.restrict";


### PR DESCRIPTION
@dantewang, the pr is based on the [requirement](https://github.com/tinatian/liferay-portal/pull/2379#issuecomment-916451133). I merged "rename the property to "template.engine.freemarker.transaction.read.only"" to the previous commits. And add the last commit to make the method name and behavior consistent.