### PR TITLE
LPS 124315 POC

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -39,6 +40,7 @@ import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.webserver.WebServerServlet;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -48,6 +50,7 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 /**
  * <p>
@@ -267,6 +270,23 @@ public class VirtualHostFilter extends BasePortalFilter {
 		long companyId = PortalInstances.getCompanyId(httpServletRequest);
 
 		try {
+			HttpSession session = httpServletRequest.getSession();
+
+			if (session.getAttribute(WebKeys.LOCALE) == null) {
+				String defaultLanguageId =
+					(String)httpServletRequest.getAttribute(
+						WebKeys.VIRTUAL_HOST_DEFAULT_LANGUAGE_ID);
+
+				if (Validator.isNotNull(defaultLanguageId)) {
+					Locale locale = LocaleUtil.fromLanguageId(
+						defaultLanguageId, true, false);
+
+					if (locale != null) {
+						session.setAttribute(WebKeys.LOCALE, locale);
+					}
+				}
+			}
+
 			Map<String, String[]> parameterMap =
 				httpServletRequest.getParameterMap();
 

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -481,7 +481,7 @@ public class PortalInstances {
 					}
 
 					httpServletRequest.setAttribute(
-						WebKeys.I18N_LANGUAGE_ID, languageId);
+						WebKeys.VIRTUAL_HOST_DEFAULT_LANGUAGE_ID, languageId);
 				}
 			}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -793,6 +793,9 @@ public interface WebKeys {
 
 	public static final String USERS_NOTIFIED = "USERS_NOTIFIED";
 
+	public static final String VIRTUAL_HOST_DEFAULT_LANGUAGE_ID =
+		"VIRTUAL_HOST_DEFAULT_LANGUAGE_ID";
+
 	public static final String VIRTUAL_HOST_LAYOUT_SET =
 		"VIRTUAL_HOST_LAYOUT_SET";
 


### PR DESCRIPTION
- LPS-X Store the virtual host default languageId instead of directly assigning it as the i18n languageId
- LPS-X Set the default virtual host languageId as the locale if available and the locale has not been assigned yet
