### PR TITLE
LPS 141792

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
@@ -127,7 +127,7 @@ public class PortalClassPathUtil {
 		sb.append(
 			_buildClassPath(
 				classLoader,
-				"com.liferay.portal.internal.servlet.MainServlet"));
+				"com.liferay.shielded.container.ShieldedContainerInitializer"));
 
 		if (servletContext != null) {
 			sb.append(File.pathSeparator);

--- a/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
@@ -20,7 +20,6 @@ import com.liferay.petra.process.ProcessLog;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -118,8 +117,7 @@ public class PortalClassPathUtil {
 		sb.append(File.pathSeparator);
 
 		String portalGlobalClassPath = _buildClassPath(
-			classLoader, CentralizedThreadLocal.class.getName(),
-			PortalException.class.getName());
+			classLoader, CentralizedThreadLocal.class.getName());
 
 		sb.append(portalGlobalClassPath);
 

--- a/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
@@ -109,17 +109,13 @@ public class PortalClassPathUtil {
 
 		StringBundler sb = new StringBundler(8);
 
-		String appServerGlobalClassPath = _buildClassPath(
-			classLoader, ServletException.class.getName());
-
-		sb.append(appServerGlobalClassPath);
+		sb.append(
+			_buildClassPath(classLoader, ServletException.class.getName()));
 
 		sb.append(File.pathSeparator);
-
-		String portalGlobalClassPath = _buildClassPath(
-			classLoader, CentralizedThreadLocal.class.getName());
-
-		sb.append(portalGlobalClassPath);
+		sb.append(
+			_buildClassPath(
+				classLoader, CentralizedThreadLocal.class.getName()));
 
 		String globalClassPath = sb.toString();
 


### PR DESCRIPTION
- LPS-141792 Simplify, petra and portal-kernel jars are in the same directory now, only need one of them to build the class path
- LPS-141792 Replace class name. The previous name causes duplicate items of jars in shielded-container-lib to appear in the class path, while the jars in WEB-INF/lib are missing.
- LPS-141792 SF, inline
