### PR TITLE
LPS 141792 11 3

### DIFF
--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalClassPathUtilTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalClassPathUtilTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.process.ProcessConfig;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringUtil;
+import com.liferay.portal.kernel.util.ServerDetector;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PortalClassPathUtil;
+
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Dante Wang
+ */
+@RunWith(Arquillian.class)
+public class PortalClassPathUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetPortalProcessConfig() {
+		ProcessConfig processConfig =
+			PortalClassPathUtil.getPortalProcessConfig();
+
+		// bootstrap class path
+
+		List<String> boostrapClassPathEntries = StringUtil.split(
+			processConfig.getBootstrapClassPath(), File.pathSeparatorChar);
+
+		List<String> nonpetraEntries = new ArrayList<>();
+
+		for (String bootstrapClassPathEntry : boostrapClassPathEntries) {
+			if (!bootstrapClassPathEntry.contains("petra")) {
+				nonpetraEntries.add(bootstrapClassPathEntry);
+			}
+		}
+
+		Assert.assertTrue(
+			"Portal process config bootstrap class path should only contain " +
+				"petra jars, but non petra jars found: " + nonpetraEntries,
+			nonpetraEntries.isEmpty());
+
+		// runtime class path
+
+		List<String> runtimeClassPathEntries = StringUtil.split(
+			processConfig.getRuntimeClassPath(), File.pathSeparatorChar);
+
+		Set<String> runtimeClassPathEntrySet = new HashSet<>();
+
+		List<String> duplicateEntries = new ArrayList<>();
+
+		List<String> webInfLibEntries = new ArrayList<>();
+
+		for (String runtimeClassPathEntry : runtimeClassPathEntries) {
+			if (!runtimeClassPathEntrySet.add(runtimeClassPathEntry)) {
+				duplicateEntries.add(runtimeClassPathEntry);
+			}
+
+			if (runtimeClassPathEntry.contains("WEB-INF/lib")) {
+				webInfLibEntries.add(runtimeClassPathEntry);
+			}
+		}
+
+		Assert.assertTrue(
+			"Portal process config runtime class path should not contain " +
+				"duplicate entries: " + duplicateEntries,
+			duplicateEntries.isEmpty());
+
+		int expectedWebInfLibEntryCount = 2;
+
+		if (ServerDetector.isTomcat()) {
+			expectedWebInfLibEntryCount = 3;
+		}
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Portal process config runtime class path should contain ",
+				expectedWebInfLibEntryCount, "WEB-INF/lib entries: ",
+				webInfLibEntries),
+			expectedWebInfLibEntryCount, webInfLibEntries.size());
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
@@ -127,7 +127,7 @@ public class PortalClassPathUtil {
 		sb.append(
 			_buildClassPath(
 				classLoader,
-				"com.liferay.portal.internal.servlet.MainServlet"));
+				"com.liferay.shielded.container.ShieldedContainerInitializer"));
 
 		if (servletContext != null) {
 			sb.append(File.pathSeparator);

--- a/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
@@ -20,7 +20,6 @@ import com.liferay.petra.process.ProcessLog;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -118,8 +117,7 @@ public class PortalClassPathUtil {
 		sb.append(File.pathSeparator);
 
 		String portalGlobalClassPath = _buildClassPath(
-			classLoader, CentralizedThreadLocal.class.getName(),
-			PortalException.class.getName());
+			classLoader, CentralizedThreadLocal.class.getName());
 
 		sb.append(portalGlobalClassPath);
 

--- a/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
@@ -109,17 +109,13 @@ public class PortalClassPathUtil {
 
 		StringBundler sb = new StringBundler(8);
 
-		String appServerGlobalClassPath = _buildClassPath(
-			classLoader, ServletException.class.getName());
-
-		sb.append(appServerGlobalClassPath);
+		sb.append(
+			_buildClassPath(classLoader, ServletException.class.getName()));
 
 		sb.append(File.pathSeparator);
-
-		String portalGlobalClassPath = _buildClassPath(
-			classLoader, CentralizedThreadLocal.class.getName());
-
-		sb.append(portalGlobalClassPath);
+		sb.append(
+			_buildClassPath(
+				classLoader, CentralizedThreadLocal.class.getName()));
 
 		String globalClassPath = sb.toString();
 

--- a/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
@@ -117,7 +117,7 @@ public class PortalClassPathUtil {
 			_buildClassPath(
 				classLoader, CentralizedThreadLocal.class.getName()));
 
-		String globalClassPath = sb.toString();
+		String bootstrapClassPath = sb.toString();
 
 		sb.append(File.pathSeparator);
 		sb.append(
@@ -136,7 +136,7 @@ public class PortalClassPathUtil {
 		ProcessConfig.Builder builder = new ProcessConfig.Builder();
 
 		builder.setArguments(_processArgs);
-		builder.setBootstrapClassPath(globalClassPath);
+		builder.setBootstrapClassPath(bootstrapClassPath);
 		builder.setReactClassLoader(classLoader);
 		builder.setRuntimeClassPath(portalClassPath);
 

--- a/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
@@ -127,6 +127,8 @@ public class PortalClassPathUtil {
 
 		String bootstrapClassPath = sb.toString();
 
+		sb.setIndex(0);
+
 		sb.append(
 			_buildClassPath(
 				classLoader, ServletException.class.getName(),

--- a/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalClassPathUtil.java
@@ -107,22 +107,30 @@ public class PortalClassPathUtil {
 			classLoader = currentThread.getContextClassLoader();
 		}
 
-		StringBundler sb = new StringBundler(8);
+		File[] files = _listClassPathFiles(
+			classLoader, CentralizedThreadLocal.class.getName());
 
-		sb.append(
-			_buildClassPath(classLoader, ServletException.class.getName()));
+		StringBundler sb = new StringBundler((files.length * 2) + 4);
 
-		sb.append(File.pathSeparator);
-		sb.append(
-			_buildClassPath(
-				classLoader, CentralizedThreadLocal.class.getName()));
+		for (File file : files) {
+			String absolutePath = file.getAbsolutePath();
+
+			if (absolutePath.contains("petra")) {
+				sb.append(absolutePath);
+				sb.append(File.pathSeparator);
+			}
+		}
+
+		if (sb.index() > 0) {
+			sb.setIndex(sb.index() - 1);
+		}
 
 		String bootstrapClassPath = sb.toString();
 
-		sb.append(File.pathSeparator);
 		sb.append(
 			_buildClassPath(
-				classLoader,
+				classLoader, ServletException.class.getName(),
+				CentralizedThreadLocal.class.getName(),
 				"com.liferay.shielded.container.ShieldedContainerInitializer"));
 
 		if (servletContext != null) {


### PR DESCRIPTION
- LPS-141792 Simplify, petra and portal-kernel jars are in the same directory now, only need one of them to build the class path
- LPS-141792 Replace class name. The previous name causes duplicate items of jars in shielded-container-lib to appear in the class path, while the jars in WEB-INF/lib are missing.
- LPS-141792 SF, inline
- LPS-141792 SF, rename
- LPS-141792 Only contains petra jars for bootstrap class path, others should be the runtime class path
- LPS-141792 Add integration test
- LPS-141792 Fix duplicate entry
