### PR TITLE
LPS 142277 11 16

### DIFF
--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalDirTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalDirTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Dante Wang
+ */
+@RunWith(Arquillian.class)
+public class PortalDirTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testPortalDir() {
+		File portalWebInfDir = new File(
+			PropsValues.LIFERAY_WEB_PORTAL_DIR, "WEB-INF");
+
+		Assert.assertTrue(
+			"LIFERAY_WEB_PORTAL_DIR should contain \"WEB-INF\", but the " +
+				"actual dir does not: " + PropsValues.LIFERAY_WEB_PORTAL_DIR,
+			portalWebInfDir.isDirectory());
+
+		Assert.assertTrue(
+			"LIFERAY_LIB_PORTAL_DIR should point to \"WEB-INF/lib\": " +
+				PropsValues.LIFERAY_LIB_PORTAL_DIR,
+			PropsValues.LIFERAY_LIB_PORTAL_DIR.endsWith("WEB-INF/lib"));
+
+		Assert.assertTrue(
+			"LIFERAY_LIB_PORTAL_DIR should point to \"WEB-INF/shielded-" +
+				"container-lib\": " +
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
+			PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR.endsWith(
+				"WEB-INF/shielded-container-lib"));
+	}
+
+}

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalDirTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalDirTest.java
@@ -50,14 +50,14 @@ public class PortalDirTest {
 		Assert.assertTrue(
 			"LIFERAY_LIB_PORTAL_DIR should point to \"WEB-INF/lib\": " +
 				PropsValues.LIFERAY_LIB_PORTAL_DIR,
-			PropsValues.LIFERAY_LIB_PORTAL_DIR.endsWith("WEB-INF/lib"));
+			PropsValues.LIFERAY_LIB_PORTAL_DIR.endsWith("WEB-INF/lib/"));
 
 		Assert.assertTrue(
 			"LIFERAY_LIB_PORTAL_DIR should point to \"WEB-INF/shielded-" +
 				"container-lib\": " +
 					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
 			PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR.endsWith(
-				"WEB-INF/shielded-container-lib"));
+				"WEB-INF/shielded-container-lib/"));
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
@@ -618,14 +618,17 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 			try {
 				JarUtil.downloadAndInstallJar(
 					new URL(url),
-					Paths.get(PropsValues.LIFERAY_LIB_PORTAL_DIR, name),
+					Paths.get(
+						PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
+						name),
 					(URLClassLoader)classLoader);
 			}
 			catch (Exception exception) {
 				_log.error(
 					StringBundler.concat(
 						"Unable to download and install ", name, " to ",
-						PropsValues.LIFERAY_LIB_PORTAL_DIR, " from ", url),
+						PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
+						" from ", url),
 					exception);
 
 				throw classNotFoundException;

--- a/portal-impl/src/com/liferay/portal/util/PropsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsUtil.java
@@ -402,16 +402,25 @@ public class PropsUtil {
 
 		// Portal shielded container lib directory
 
+		String portalShieldedContainerLibDir = _getLibDir(PropsUtil.class);
+
 		String portalShieldedContainerLibDirProperty = System.getProperty(
 			PropsKeys.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR);
 
-		if (portalShieldedContainerLibDirProperty == null) {
-			portalShieldedContainerLibDirProperty = _getLibDir(PropsUtil.class);
+		if (portalShieldedContainerLibDirProperty != null) {
+			if (!portalShieldedContainerLibDirProperty.endsWith(
+					StringPool.SLASH)) {
+
+				portalShieldedContainerLibDirProperty += StringPool.SLASH;
+			}
+
+			portalShieldedContainerLibDir =
+				portalShieldedContainerLibDirProperty;
 		}
 
 		SystemProperties.set(
 			PropsKeys.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
-			portalShieldedContainerLibDirProperty);
+			portalShieldedContainerLibDir);
 
 		// Portal web directory
 

--- a/portal-impl/src/com/liferay/portal/util/PropsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsUtil.java
@@ -406,7 +406,7 @@ public class PropsUtil {
 			PropsKeys.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR);
 
 		if (portalShieldedContainerLibDirProperty == null) {
-			portalShieldedContainerLibDirProperty = portalLibDir;
+			portalShieldedContainerLibDirProperty = _getLibDir(PropsUtil.class);
 		}
 
 		SystemProperties.set(

--- a/portal-impl/src/com/liferay/portal/xuggler/XugglerImpl.java
+++ b/portal-impl/src/com/liferay/portal/xuggler/XugglerImpl.java
@@ -47,7 +47,9 @@ public class XugglerImpl implements Xuggler {
 		try {
 			JarUtil.downloadAndInstallJar(
 				new URL(PropsValues.XUGGLER_JAR_URL + name),
-				Paths.get(PropsValues.LIFERAY_LIB_PORTAL_DIR, name));
+				Paths.get(
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
+					name));
 
 			_nativeLibraryCopied = true;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/WebDirDetector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/WebDirDetector.java
@@ -25,8 +25,7 @@ public class WebDirDetector {
 
 	public static String getLibDir(ClassLoader classLoader) {
 		String libDir = ClassUtil.getParentPath(
-			classLoader,
-			"com.liferay.shielded.container.ShieldedContainerInitializer");
+			classLoader, "com.liferay.util.bean.PortletBeanLocatorUtil");
 
 		if (libDir.endsWith("/WEB-INF/classes/")) {
 			return libDir.substring(0, libDir.length() - 8) + "lib/";

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/WebDirDetector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/WebDirDetector.java
@@ -25,7 +25,8 @@ public class WebDirDetector {
 
 	public static String getLibDir(ClassLoader classLoader) {
 		String libDir = ClassUtil.getParentPath(
-			classLoader, "com.liferay.util.bean.PortletBeanLocatorUtil");
+			classLoader,
+			"com.liferay.shielded.container.ShieldedContainerInitializer");
 
 		if (libDir.endsWith("/WEB-INF/classes/")) {
 			return libDir.substring(0, libDir.length() - 8) + "lib/";

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/WebDirDetector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/WebDirDetector.java
@@ -31,7 +31,7 @@ public class WebDirDetector {
 			return libDir.substring(0, libDir.length() - 8) + "lib/";
 		}
 
-		int pos = libDir.indexOf("/WEB-INF/lib/");
+		int pos = libDir.indexOf("/WEB-INF/shielded-container-lib/");
 
 		if (pos != -1) {
 			return libDir.substring(0, pos) + "/WEB-INF/lib/";


### PR DESCRIPTION
- LPS-142277 Add integration test to expose the issue
- LPS-142277 Use correct class name
- LPS-142277 Now portal lib dir points to WEB-INF/lib, do not fallback shielded container lib dir to portal lib dir
- LPS-142277 Use similar logic of portal lib dir for shielded container lib dir
- LPS-142277 Fix the test
- LPS-142277 Download and install jar to shielded container lib dir
- Revert "LPS-142277 Use correct class name"
- LPS-142277 Check for /WEB-INF/shielded-container-lib instead
