### PR TITLE
LPS LPS 142278 portal lib

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1188,7 +1188,6 @@ information.
 				<sysproperty file="woven-classes" key="junit.aspectj.dump" />
 				<sysproperty key="junit.code.coverage" value="${junit.code.coverage}" />
 				<sysproperty if:true="${jvm.debug}" key="jvm.debug" value="true" />
-				<sysproperty key="liferay.lib.portal.dir" value="${app.server.tomcat.lib.portal.dir}" />
 				<sysproperty key="liferay.temp.dir" value="${app.server.tomcat.temp.dir}" />
 				<sysproperty if:true="${aspectj.weaver.enabled}" key="org.aspectj.weaver.loadtime.configuration" value="${aspectj.configuration}" />
 				<sysproperty key="whip.agent" value="${whip.agent}" />

--- a/build-common.xml
+++ b/build-common.xml
@@ -1901,7 +1901,6 @@ rerun your task.
 						test.type="@{test.type}"
 					>
 						<misc>
-							<jvmarg value="-Dliferay.lib.portal.dir=${project.dir}/lib/portal" />
 							<jvmarg value="-Dtest.class.group.index=${test.class.group.index}" />
 							<jvmarg value="-Dtest.class.groups=${TEST_CLASS_GROUPS}" />
 						</misc>

--- a/build-dist.xml
+++ b/build-dist.xml
@@ -151,7 +151,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.jboss.deploy.dir}" />
 			<param name="deployer.app.server.type" value="jboss" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.jboss.portal.dir}/WEB-INF/lib" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="${app.server.jboss.shielded-container-lib.portal.dir}" />
 		</antcall>
 	</target>
 
@@ -273,7 +273,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.tcserver.deploy.dir}" />
 			<param name="deployer.app.server.type" value="tomcat" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.tcserver.lib.portal.dir}" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="${app.server.tcserver.shielded-container-lib.portal.dir}" />
 		</antcall>
 	</target>
 
@@ -294,7 +294,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/webapps" />
 			<param name="deployer.app.server.type" value="tomcat" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/webapps/ROOT/WEB-INF/lib" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="${app.server.tomcat.shielded-container-lib.portal.dir}" />
 		</antcall>
 	</target>
 
@@ -326,7 +326,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.weblogic.deploy.dir}" />
 			<param name="deployer.app.server.type" value="weblogic" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.weblogic.lib.portal.dir}" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="${app.server.weblogic.shielded-container-lib.portal.dir}" />
 		</antcall>
 	</target>
 
@@ -346,7 +346,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.websphere.deploy.dir}" />
 			<param name="deployer.app.server.type" value="websphere" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.websphere.portal.dir}/WEB-INF/lib" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="app.server.websphere.shielded-container-lib.portal.dir" />
 		</antcall>
 	</target>
 
@@ -366,7 +366,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.parent.dir}/wildfly-${app.server.wildfly.version}/standalone/deployments" />
 			<param name="deployer.app.server.type" value="wildfly" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.parent.dir}/wildfly-${app.server.wildfly.version}/standalone/deployments/ROOT.war/WEB-INF/lib" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="${app.server.wildfly.shielded-container-lib.portal.dir}" />
 		</antcall>
 	</target>
 
@@ -388,7 +388,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />
@@ -416,7 +416,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />
@@ -444,7 +444,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />
@@ -468,7 +468,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />
@@ -503,7 +503,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />
@@ -533,7 +533,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />

--- a/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
@@ -618,14 +618,17 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 			try {
 				JarUtil.downloadAndInstallJar(
 					new URL(url),
-					Paths.get(PropsValues.LIFERAY_LIB_PORTAL_DIR, name),
+					Paths.get(
+						PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
+						name),
 					(URLClassLoader)classLoader);
 			}
 			catch (Exception exception) {
 				_log.error(
 					StringBundler.concat(
 						"Unable to download and install ", name, " to ",
-						PropsValues.LIFERAY_LIB_PORTAL_DIR, " from ", url),
+						PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
+						" from ", url),
 					exception);
 
 				throw classNotFoundException;

--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -18,7 +18,6 @@ import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.petra.lang.ClassLoaderPool;
 import com.liferay.petra.log4j.Log4JUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
-import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.bean.BeanLocatorImpl;
@@ -48,10 +47,7 @@ import com.liferay.portal.kernel.util.ClearTimerThreadUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PortalLifecycleUtil;
-import com.liferay.portal.kernel.util.PropsKeys;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.module.framework.ModuleFrameworkUtil;
 import com.liferay.portal.spring.aop.DynamicProxyCreator;
 import com.liferay.portal.spring.compat.CompatBeanDefinitionRegistryPostProcessor;
@@ -202,16 +198,6 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 		FieldInterceptionHelperUtil.initialize();
 
 		ServletContext servletContext = servletContextEvent.getServletContext();
-
-		String portalLibDir = servletContext.getRealPath("/WEB-INF/lib");
-
-		portalLibDir = StringUtil.replace(
-			portalLibDir, CharPool.BACK_SLASH, CharPool.FORWARD_SLASH);
-
-		if (Validator.isNotNull(portalLibDir)) {
-			SystemProperties.set(
-				PropsKeys.LIFERAY_LIB_PORTAL_DIR, portalLibDir);
-		}
 
 		PortalClassPathUtil.initializeClassPaths(servletContext);
 

--- a/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
+++ b/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ServerDetector;
@@ -352,7 +351,9 @@ public class BaseDeployer implements AutoDeployer, Deployer {
 			}
 
 			try {
-				String portalJarPath = PortalUtil.getPortalLibDir() + portalJar;
+				String portalJarPath =
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR +
+						portalJar;
 
 				FileUtil.copyFile(
 					portalJarPath, srcFile + "/WEB-INF/lib/" + portalJar, true);
@@ -398,7 +399,8 @@ public class BaseDeployer implements AutoDeployer, Deployer {
 
 			if (ArrayUtil.isEmpty(commonsLoggingJars)) {
 				String portalJarPath =
-					PortalUtil.getPortalLibDir() + "commons-logging.jar";
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR +
+						"commons-logging.jar";
 
 				FileUtil.copyFile(
 					portalJarPath, srcFile + "/WEB-INF/lib/commons-logging.jar",
@@ -414,20 +416,24 @@ public class BaseDeployer implements AutoDeployer, Deployer {
 
 			if (ArrayUtil.isEmpty(log4jJars)) {
 				String portalJarPath =
-					PortalUtil.getPortalLibDir() + "log4j-api.jar";
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR +
+						"log4j-api.jar";
 
 				FileUtil.copyFile(
 					portalJarPath, srcFile + "/WEB-INF/lib/log4j-api.jar",
 					true);
 
 				portalJarPath =
-					PortalUtil.getPortalLibDir() + "log4j-1.2-api.jar";
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR +
+						"log4j-1.2-api.jar";
 
 				FileUtil.copyFile(
 					portalJarPath, srcFile + "/WEB-INF/lib/log4j-1.2-api.jar",
 					true);
 
-				portalJarPath = PortalUtil.getPortalLibDir() + "log4j-core.jar";
+				portalJarPath =
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR +
+						"log4j-core.jar";
 
 				FileUtil.copyFile(
 					portalJarPath, srcFile + "/WEB-INF/lib/log4j-core.jar",

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4057,6 +4057,10 @@ public class PortalImpl implements Portal {
 			new PortalInetSocketAddressEventListener[0]);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	@Override
 	public String getPortalLibDir() {
 		return PropsValues.LIFERAY_LIB_PORTAL_DIR;

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1538,6 +1538,10 @@ public class PropsValues {
 	public static final String LIFERAY_LIB_GLOBAL_SHARED_DIR = PropsUtil.get(
 		PropsKeys.LIFERAY_LIB_GLOBAL_SHARED_DIR);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String LIFERAY_LIB_PORTAL_DIR = PropsUtil.get(
 		PropsKeys.LIFERAY_LIB_PORTAL_DIR);
 

--- a/portal-impl/src/com/liferay/portal/xuggler/XugglerImpl.java
+++ b/portal-impl/src/com/liferay/portal/xuggler/XugglerImpl.java
@@ -47,7 +47,9 @@ public class XugglerImpl implements Xuggler {
 		try {
 			JarUtil.downloadAndInstallJar(
 				new URL(PropsValues.XUGGLER_JAR_URL + name),
-				Paths.get(PropsValues.LIFERAY_LIB_PORTAL_DIR, name));
+				Paths.get(
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
+					name));
 
 			_nativeLibraryCopied = true;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -869,6 +869,10 @@ public interface Portal {
 	public PortalInetSocketAddressEventListener[]
 		getPortalInetSocketAddressEventListeners();
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public String getPortalLibDir();
 
 	public InetAddress getPortalLocalInetAddress(boolean secure);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1313,6 +1313,10 @@ public class PortalUtil {
 		return _portal.getPortalInetSocketAddressEventListeners();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static String getPortalLibDir() {
 		return _portal.getPortalLibDir();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1795,6 +1795,10 @@ public interface PropsKeys {
 	public static final String LIFERAY_LIB_GLOBAL_SHARED_DIR =
 		"liferay.lib.global.shared.dir";
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String LIFERAY_LIB_PORTAL_DIR =
 		"liferay.lib.portal.dir";
 


### PR DESCRIPTION
- LPS-142278 Should download into shielded container lib dir
- LPS-142278 Should copy portal jars from shielded container lib dir in BaseDeployer
- LPS-142278 Apply to calls to *Deployers in build-dist.xml
- LPS-142278 Remove old logic that sets LIFERAY_LIB_PORTAL_DIR by servlet context; shielded container dir is already set this way. Also, this was added by LPS-52665 to resolve JRuby issue when deploying portal using unexploded war - JRuby is no longer used and our customer facing documents never mention using unexploded war now.
- LPS-142278 Remove sysproperty for portal lib dir, this was added by LPS-65693 (a161a2a957de85c3eb6591d7921ca082a628a9a4) for integration tests in core, but these tests have been moved to modules.
- LPS-142278 Can we also remove this one?
- LPS-142278 Deprecate portal lib dir
