### PR TITLE
LPS 142278 11 25

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1188,7 +1188,6 @@ information.
 				<sysproperty file="woven-classes" key="junit.aspectj.dump" />
 				<sysproperty key="junit.code.coverage" value="${junit.code.coverage}" />
 				<sysproperty if:true="${jvm.debug}" key="jvm.debug" value="true" />
-				<sysproperty key="liferay.lib.portal.dir" value="${app.server.tomcat.lib.portal.dir}" />
 				<sysproperty key="liferay.temp.dir" value="${app.server.tomcat.temp.dir}" />
 				<sysproperty if:true="${aspectj.weaver.enabled}" key="org.aspectj.weaver.loadtime.configuration" value="${aspectj.configuration}" />
 				<sysproperty key="whip.agent" value="${whip.agent}" />

--- a/build-common.xml
+++ b/build-common.xml
@@ -1901,7 +1901,6 @@ rerun your task.
 						test.type="@{test.type}"
 					>
 						<misc>
-							<jvmarg value="-Dliferay.lib.portal.dir=${project.dir}/lib/portal" />
 							<jvmarg value="-Dtest.class.group.index=${test.class.group.index}" />
 							<jvmarg value="-Dtest.class.groups=${TEST_CLASS_GROUPS}" />
 						</misc>

--- a/build-dist.xml
+++ b/build-dist.xml
@@ -151,7 +151,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.jboss.deploy.dir}" />
 			<param name="deployer.app.server.type" value="jboss" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.jboss.portal.dir}/WEB-INF/lib" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="${app.server.jboss.shielded-container-lib.portal.dir}" />
 		</antcall>
 	</target>
 
@@ -273,7 +273,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.tcserver.deploy.dir}" />
 			<param name="deployer.app.server.type" value="tomcat" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.tcserver.lib.portal.dir}" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="${app.server.tcserver.shielded-container-lib.portal.dir}" />
 		</antcall>
 	</target>
 
@@ -294,7 +294,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/webapps" />
 			<param name="deployer.app.server.type" value="tomcat" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/webapps/ROOT/WEB-INF/lib" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="${app.server.tomcat.shielded-container-lib.portal.dir}" />
 		</antcall>
 	</target>
 
@@ -326,7 +326,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.weblogic.deploy.dir}" />
 			<param name="deployer.app.server.type" value="weblogic" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.weblogic.lib.portal.dir}" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="${app.server.weblogic.shielded-container-lib.portal.dir}" />
 		</antcall>
 	</target>
 
@@ -346,7 +346,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.websphere.deploy.dir}" />
 			<param name="deployer.app.server.type" value="websphere" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.websphere.portal.dir}/WEB-INF/lib" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="app.server.websphere.shielded-container-lib.portal.dir" />
 		</antcall>
 	</target>
 
@@ -366,7 +366,7 @@
 		<antcall target="deploy-plugins">
 			<param name="deployer.dest.dir" value="${app.server.parent.dir}/wildfly-${app.server.wildfly.version}/standalone/deployments" />
 			<param name="deployer.app.server.type" value="wildfly" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.parent.dir}/wildfly-${app.server.wildfly.version}/standalone/deployments/ROOT.war/WEB-INF/lib" />
+			<param name="deployer.app.server.shielded-container-lib.portal.dir" value="${app.server.wildfly.shielded-container-lib.portal.dir}" />
 		</antcall>
 	</target>
 
@@ -388,7 +388,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />
@@ -416,7 +416,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />
@@ -444,7 +444,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />
@@ -468,7 +468,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />
@@ -503,7 +503,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />
@@ -533,7 +533,7 @@
 			<!-- Required Arguments -->
 
 			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dliferay.lib.portal.dir=${deployer.app.server.lib.portal.dir}" />
+			<jvmarg value="-Dliferay.shielded.container.lib.portal.dir=${deployer.app.server.shielded-container-lib.portal.dir}" />
 			<jvmarg value="-Ddeployer.base.dir=${lp.plugins.dir}/dist" />
 			<jvmarg value="-Ddeployer.dest.dir=${deployer.dest.dir}" />
 			<jvmarg value="-Ddeployer.app.server.type=${deployer.app.server.type}" />

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalDirTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalDirTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Dante Wang
+ */
+@RunWith(Arquillian.class)
+public class PortalDirTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testPortalDir() {
+		File portalWebInfDir = new File(
+			PropsValues.LIFERAY_WEB_PORTAL_DIR, "WEB-INF");
+
+		Assert.assertTrue(
+			"LIFERAY_WEB_PORTAL_DIR should be parent dir for \"WEB-INF\": " +
+				PropsValues.LIFERAY_WEB_PORTAL_DIR,
+			portalWebInfDir.isDirectory());
+
+		Assert.assertTrue(
+			"LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR should point to " +
+				"\"WEB-INF/shielded-container-lib/\": " +
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
+			PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR.endsWith(
+				"WEB-INF/shielded-container-lib/"));
+
+		Assert.assertEquals(
+			StringPool.BLANK, PropsValues.LIFERAY_LIB_GLOBAL_DIR);
+
+		Assert.assertEquals(
+			StringPool.BLANK, PropsValues.LIFERAY_LIB_PORTAL_DIR);
+	}
+
+}

--- a/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/tasks/DirectDeployTask.java
+++ b/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/tasks/DirectDeployTask.java
@@ -57,9 +57,10 @@ public class DirectDeployTask extends BasePortalToolsTask {
 	public List<String> getArgs() {
 		List<String> args = new ArrayList<>(3);
 
-		File appServerLibPortalDir = _getAppServerLibPortalDir();
+		File appServerShieldedContainerLibPortalDir =
+			_getAppServerShieldedContainerLibPortalDir();
 
-		String path = appServerLibPortalDir.getAbsolutePath();
+		String path = appServerShieldedContainerLibPortalDir.getAbsolutePath();
 
 		args.add(path + "/util-bridges.jar");
 		args.add(path + "/util-java.jar");
@@ -86,9 +87,14 @@ public class DirectDeployTask extends BasePortalToolsTask {
 		jvmArgs.add(
 			"-Dexternal-properties=com/liferay/portal/tools/dependencies" +
 				"/portal-tools.properties");
+
+		String appServerShieldedContainerLibPortalDir =
+			FileUtil.getAbsolutePath(
+				_getAppServerShieldedContainerLibPortalDir());
+
 		jvmArgs.add(
-			"-Dliferay.lib.portal.dir=" +
-				FileUtil.getAbsolutePath(_getAppServerLibPortalDir()));
+			"-Dliferay.shielded.container.lib.portal.dir=" +
+				appServerShieldedContainerLibPortalDir);
 
 		String webAppType = getWebAppType();
 
@@ -213,8 +219,9 @@ public class DirectDeployTask extends BasePortalToolsTask {
 		return "Deployer";
 	}
 
-	private File _getAppServerLibPortalDir() {
-		return new File(getAppServerPortalDir(), "WEB-INF/lib");
+	private File _getAppServerShieldedContainerLibPortalDir() {
+		return new File(
+			getAppServerPortalDir(), "WEB-INF/shielded-container-lib");
 	}
 
 	private Object _appServerDeployDir;

--- a/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
@@ -618,14 +618,17 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 			try {
 				JarUtil.downloadAndInstallJar(
 					new URL(url),
-					Paths.get(PropsValues.LIFERAY_LIB_PORTAL_DIR, name),
+					Paths.get(
+						PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
+						name),
 					(URLClassLoader)classLoader);
 			}
 			catch (Exception exception) {
 				_log.error(
 					StringBundler.concat(
 						"Unable to download and install ", name, " to ",
-						PropsValues.LIFERAY_LIB_PORTAL_DIR, " from ", url),
+						PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
+						" from ", url),
 					exception);
 
 				throw classNotFoundException;

--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -18,7 +18,6 @@ import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.petra.lang.ClassLoaderPool;
 import com.liferay.petra.log4j.Log4JUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
-import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.bean.BeanLocatorImpl;
@@ -48,10 +47,7 @@ import com.liferay.portal.kernel.util.ClearTimerThreadUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PortalLifecycleUtil;
-import com.liferay.portal.kernel.util.PropsKeys;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.module.framework.ModuleFrameworkUtil;
 import com.liferay.portal.spring.aop.DynamicProxyCreator;
 import com.liferay.portal.spring.compat.CompatBeanDefinitionRegistryPostProcessor;
@@ -202,16 +198,6 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 		FieldInterceptionHelperUtil.initialize();
 
 		ServletContext servletContext = servletContextEvent.getServletContext();
-
-		String portalLibDir = servletContext.getRealPath("/WEB-INF/lib");
-
-		portalLibDir = StringUtil.replace(
-			portalLibDir, CharPool.BACK_SLASH, CharPool.FORWARD_SLASH);
-
-		if (Validator.isNotNull(portalLibDir)) {
-			SystemProperties.set(
-				PropsKeys.LIFERAY_LIB_PORTAL_DIR, portalLibDir);
-		}
 
 		PortalClassPathUtil.initializeClassPaths(servletContext);
 

--- a/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
+++ b/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -350,7 +349,9 @@ public class BaseDeployer implements AutoDeployer, Deployer {
 			}
 
 			try {
-				String portalJarPath = PortalUtil.getPortalLibDir() + portalJar;
+				String portalJarPath =
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR +
+						portalJar;
 
 				FileUtil.copyFile(
 					portalJarPath, srcFile + "/WEB-INF/lib/" + portalJar, true);
@@ -396,7 +397,8 @@ public class BaseDeployer implements AutoDeployer, Deployer {
 
 			if (ArrayUtil.isEmpty(commonsLoggingJars)) {
 				String portalJarPath =
-					PortalUtil.getPortalLibDir() + "commons-logging.jar";
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR +
+						"commons-logging.jar";
 
 				FileUtil.copyFile(
 					portalJarPath, srcFile + "/WEB-INF/lib/commons-logging.jar",
@@ -412,20 +414,24 @@ public class BaseDeployer implements AutoDeployer, Deployer {
 
 			if (ArrayUtil.isEmpty(log4jJars)) {
 				String portalJarPath =
-					PortalUtil.getPortalLibDir() + "log4j-api.jar";
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR +
+						"log4j-api.jar";
 
 				FileUtil.copyFile(
 					portalJarPath, srcFile + "/WEB-INF/lib/log4j-api.jar",
 					true);
 
 				portalJarPath =
-					PortalUtil.getPortalLibDir() + "log4j-1.2-api.jar";
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR +
+						"log4j-1.2-api.jar";
 
 				FileUtil.copyFile(
 					portalJarPath, srcFile + "/WEB-INF/lib/log4j-1.2-api.jar",
 					true);
 
-				portalJarPath = PortalUtil.getPortalLibDir() + "log4j-core.jar";
+				portalJarPath =
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR +
+						"log4j-core.jar";
 
 				FileUtil.copyFile(
 					portalJarPath, srcFile + "/WEB-INF/lib/log4j-core.jar",

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4061,6 +4061,10 @@ public class PortalImpl implements Portal {
 			new PortalInetSocketAddressEventListener[0]);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	@Override
 	public String getPortalLibDir() {
 		return PropsValues.LIFERAY_LIB_PORTAL_DIR;

--- a/portal-impl/src/com/liferay/portal/util/PropsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsUtil.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.util;
 
-import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.ConfigurationFactoryImpl;
@@ -369,53 +368,40 @@ public class PropsUtil {
 
 		// Global lib directory
 
-		String globalLibDir = _getLibDir(CentralizedThreadLocal.class);
-
-		if (_log.isInfoEnabled()) {
-			_log.info("Global lib directory " + globalLibDir);
-		}
-
-		SystemProperties.set(PropsKeys.LIFERAY_LIB_GLOBAL_DIR, globalLibDir);
+		SystemProperties.set(
+			PropsKeys.LIFERAY_LIB_GLOBAL_DIR, StringPool.BLANK);
 
 		// Portal lib directory
 
-		ClassLoader classLoader = PropsUtil.class.getClassLoader();
-
-		String portalLibDir = WebDirDetector.getLibDir(classLoader);
-
-		String portalLibDirProperty = System.getProperty(
-			PropsKeys.LIFERAY_LIB_PORTAL_DIR);
-
-		if (portalLibDirProperty != null) {
-			if (!portalLibDirProperty.endsWith(StringPool.SLASH)) {
-				portalLibDirProperty += StringPool.SLASH;
-			}
-
-			portalLibDir = portalLibDirProperty;
-		}
-
-		if (_log.isInfoEnabled()) {
-			_log.info("Portal lib directory " + portalLibDir);
-		}
-
-		SystemProperties.set(PropsKeys.LIFERAY_LIB_PORTAL_DIR, portalLibDir);
+		SystemProperties.set(
+			PropsKeys.LIFERAY_LIB_PORTAL_DIR, StringPool.BLANK);
 
 		// Portal shielded container lib directory
+
+		String portalShieldedContainerLibDir = _getLibDir(PropsUtil.class);
 
 		String portalShieldedContainerLibDirProperty = System.getProperty(
 			PropsKeys.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR);
 
-		if (portalShieldedContainerLibDirProperty == null) {
-			portalShieldedContainerLibDirProperty = portalLibDir;
+		if (portalShieldedContainerLibDirProperty != null) {
+			if (!portalShieldedContainerLibDirProperty.endsWith(
+					StringPool.SLASH)) {
+
+				portalShieldedContainerLibDirProperty += StringPool.SLASH;
+			}
+
+			portalShieldedContainerLibDir =
+				portalShieldedContainerLibDirProperty;
 		}
 
 		SystemProperties.set(
 			PropsKeys.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
-			portalShieldedContainerLibDirProperty);
+			portalShieldedContainerLibDir);
 
 		// Portal web directory
 
-		String portalWebDir = WebDirDetector.getRootDir(portalLibDir);
+		String portalWebDir = WebDirDetector.getRootDir(
+			portalShieldedContainerLibDir);
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("Portal web directory " + portalWebDir);

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1532,6 +1532,10 @@ public class PropsValues {
 	public static final String LIFERAY_LIB_GLOBAL_SHARED_DIR = PropsUtil.get(
 		PropsKeys.LIFERAY_LIB_GLOBAL_SHARED_DIR);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String LIFERAY_LIB_PORTAL_DIR = PropsUtil.get(
 		PropsKeys.LIFERAY_LIB_PORTAL_DIR);
 

--- a/portal-impl/src/com/liferay/portal/xuggler/XugglerImpl.java
+++ b/portal-impl/src/com/liferay/portal/xuggler/XugglerImpl.java
@@ -47,7 +47,9 @@ public class XugglerImpl implements Xuggler {
 		try {
 			JarUtil.downloadAndInstallJar(
 				new URL(PropsValues.XUGGLER_JAR_URL + name),
-				Paths.get(PropsValues.LIFERAY_LIB_PORTAL_DIR, name));
+				Paths.get(
+					PropsValues.LIFERAY_SHIELDED_CONTAINER_LIB_PORTAL_DIR,
+					name));
 
 			_nativeLibraryCopied = true;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/WebDirDetector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/WebDirDetector.java
@@ -56,8 +56,8 @@ public class WebDirDetector {
 		String rootDir = StringUtil.replace(
 			libDir, CharPool.BACK_SLASH, CharPool.FORWARD_SLASH);
 
-		if (rootDir.endsWith("/WEB-INF/lib/")) {
-			rootDir = rootDir.substring(0, rootDir.length() - 12);
+		if (rootDir.endsWith("/WEB-INF/shielded-container-lib/")) {
+			rootDir = rootDir.substring(0, rootDir.length() - 32);
 		}
 
 		return rootDir;

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/WebDirDetector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/WebDirDetector.java
@@ -23,6 +23,10 @@ import com.liferay.portal.kernel.util.StringUtil;
  */
 public class WebDirDetector {
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static String getLibDir(ClassLoader classLoader) {
 		String libDir = ClassUtil.getParentPath(
 			classLoader, "com.liferay.util.bean.PortletBeanLocatorUtil");
@@ -48,6 +52,10 @@ public class WebDirDetector {
 		return libDir;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static String getRootDir(ClassLoader classLoader) {
 		return getRootDir(getLibDir(classLoader));
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -873,6 +873,10 @@ public interface Portal {
 	public PortalInetSocketAddressEventListener[]
 		getPortalInetSocketAddressEventListeners();
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public String getPortalLibDir();
 
 	public InetAddress getPortalLocalInetAddress(boolean secure);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1317,6 +1317,10 @@ public class PortalUtil {
 		return _portal.getPortalInetSocketAddressEventListeners();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static String getPortalLibDir() {
 		return _portal.getPortalLibDir();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1792,6 +1792,10 @@ public interface PropsKeys {
 	public static final String LIFERAY_LIB_GLOBAL_SHARED_DIR =
 		"liferay.lib.global.shared.dir";
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String LIFERAY_LIB_PORTAL_DIR =
 		"liferay.lib.portal.dir";
 


### PR DESCRIPTION
- LPS-142278 Should download into shielded container lib dir
- LPS-142278 Should copy portal jars from shielded container lib dir in BaseDeployer
- LPS-142278 Apply to calls to *Deployers in build-dist.xml
- LPS-142278 Remove old logic that sets LIFERAY_LIB_PORTAL_DIR by servlet context; shielded container dir is already set this way. Also, this was added by LPS-52665 to resolve JRuby issue when deploying portal using unexploded war - JRuby is no longer used and our customer facing documents never mention using unexploded war now.
- LPS-142278 Remove sysproperty for portal lib dir, this was added by LPS-65693 (a161a2a957de85c3eb6591d7921ca082a628a9a4) for integration tests in core, but these tests have been moved to modules.
- LPS-142278 Remove this, as long as no unit test fails we don't replace it with shielded container lib dir
- LPS-142278 Replace portal lib dir with shielded container lib dir in DirectDeployTask
- LPS-142278 Deprecate LIFERAY_LIB_PORTAL_DIR
- LPS-142278 Remove initialization logic for deprecated properties; this will also fix LPS-142277
- LPS-142278 Also deprecate these unused methods
- LPS-142278 Add integration test
