### PR TITLE
compileOnly commons io

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/build.gradle
@@ -3,7 +3,7 @@ dependencies {
 	compileInclude group: "com.netflix.archaius", name: "archaius-core", version: "0.4.1"
 	compileInclude group: "com.netflix.hystrix", name: "hystrix-core", version: "1.5.11"
 	compileInclude group: "commons-configuration", name: "commons-configuration", version: "1.8"
-	compileInclude group: "commons-io", name: "commons-io", version: "2.8.0"
+	compileOnly group: "commons-io", name: "commons-io", version: "2.8.0"
 	compileInclude group: "io.reactivex", name: "rxjava", version: "1.2.0"
 	compileInclude group: "net.minidev", name: "accessors-smart", version: "2.4.2"
 	compileInclude group: "net.minidev", name: "json-smart", version: "2.4.2"

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	compileInclude group: "com.liferay", name: "org.apache.logging.log4j", version: "2.15.0.LIFERAY-PATCHED-1"
 	compileInclude group: "com.liferay", name: "org.apache.logging.log4j.core", version: "2.15.0.LIFERAY-PATCHED-1"
 	compileInclude group: "commons-codec", name: "commons-codec", version: "1.11"
-	compileInclude group: "commons-io", name: "commons-io", version: "2.8.0"
+	compileOnly group: "commons-io", name: "commons-io", version: "2.8.0"
 	compileInclude group: "commons-lang", name: "commons-lang", version: "2.6"
 	compileInclude group: "commons-logging", name: "commons-logging", version: "1.2"
 	compileInclude group: "joda-time", name: "joda-time", version: "2.10.10"


### PR DESCRIPTION
- LPS-X Change to compileOnly for commons-io; leaving the one in sass-compiler-jsass alone because it's a tool and its compileIncludes are expanded.
- LPS-X Also change other commons dependencies in these files
- LPS-X Auto SF
