### PR TITLE
LPS-X Use the connection that came from an initialized DataSource obj…

### DIFF
--- a/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java
@@ -274,7 +274,7 @@ public class DBPartitionUtil {
 				connection.setCatalog(
 					_getSchemaName(CompanyThreadLocal.getCompanyId()));
 
-				return _wrapStatement(super.createStatement());
+				return _wrapStatement(super.createStatement(), connection);
 			}
 
 			@Override
@@ -286,7 +286,8 @@ public class DBPartitionUtil {
 					_getSchemaName(CompanyThreadLocal.getCompanyId()));
 
 				return _wrapStatement(
-					super.createStatement(resultSetType, resultSetConcurrency));
+					super.createStatement(resultSetType, resultSetConcurrency),
+					connection);
 			}
 
 			@Override
@@ -301,7 +302,8 @@ public class DBPartitionUtil {
 				return _wrapStatement(
 					super.createStatement(
 						resultSetType, resultSetConcurrency,
-						resultSetHoldability));
+						resultSetHoldability),
+					connection);
 			}
 
 			@Override
@@ -461,8 +463,10 @@ public class DBPartitionUtil {
 		return false;
 	}
 
-	private static boolean _isSkip(String tableName) throws SQLException {
-		try (Connection connection = DataAccess.getConnection()) {
+	private static boolean _isSkip(String tableName, Connection connection)
+		throws SQLException {
+
+		try {
 			DBInspector dbInspector = new DBInspector(connection);
 
 			if (_isControlTable(dbInspector, tableName) &&
@@ -536,7 +540,9 @@ public class DBPartitionUtil {
 		statement.executeUpdate(_getCreateViewSQL(companyId, tableName));
 	}
 
-	private static Statement _wrapStatement(Statement statement) {
+	private static Statement _wrapStatement(
+		Statement statement, Connection connection) {
+
 		return new StatementWrapper(statement) {
 
 			@Override
@@ -546,13 +552,13 @@ public class DBPartitionUtil {
 				String[] query = sql.split(StringPool.SPACE);
 
 				if ((StringUtil.startsWith(lowerCaseSQL, "alter table") &&
-					 _isSkip(query[2])) ||
+					 _isSkip(query[2], connection)) ||
 					((StringUtil.startsWith(lowerCaseSQL, "create index") ||
 					  StringUtil.startsWith(lowerCaseSQL, "drop index")) &&
-					 _isSkip(query[4])) ||
+					 _isSkip(query[4], connection)) ||
 					(StringUtil.startsWith(
 						lowerCaseSQL, "create unique index") &&
-					 _isSkip(query[5]))) {
+					 _isSkip(query[5], connection))) {
 
 					return 0;
 				}


### PR DESCRIPTION
Hi @dantewang 

After this commit https://github.com/liferay/liferay-portal/commit/58242445718710847aa18d5363856946d71ef5d8 of [LPS-103534](https://issues.liferay.com/browse/LPS-103534), The `DBInitUtil.init()` will be invoked before starting modules which will set the DataSource in `InfrastructureUtil`,  when enabling the DB partition, the method https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java#L465 will be invoked during `DBInitUtil.init()`, so the DBPartitionUtil method got a null dataSource object when trying to use InfrastructureUtil.getDataSource()  the dataSource object in InfrastructureUtil will be initialized later during the module start process see https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java#L254

I fix the issue by using the connection that came from an initialized DataSource object instead of using DataAccess.getConnection() to get the connection since it will try to get an uninitialized DataSource object by InfrastructureUtil.getDataSource().

I did not change these invoke orders in the `PortalContextLoaderListener`, since I think the DB side should be ready before the starting module process.

https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java#L252
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java#L254

/cc @tinatian

Regards
Lily