### PR TITLE
LPS 143660

### DIFF
--- a/modules/apps/document-library/document-library-asset-auto-tagger-tensorflow/src/main/java/com/liferay/document/library/asset/auto/tagger/tensorflow/internal/configuration/TensorFlowImageAssetAutoTagProviderDownloadConfiguration.java
+++ b/modules/apps/document-library/document-library-asset-auto-tagger-tensorflow/src/main/java/com/liferay/document/library/asset/auto/tagger/tensorflow/internal/configuration/TensorFlowImageAssetAutoTagProviderDownloadConfiguration.java
@@ -34,9 +34,19 @@ public interface TensorFlowImageAssetAutoTagProviderDownloadConfiguration {
 	public String modelDownloadURL();
 
 	@Meta.AD(
+		deflt = "e3b84c7e240ce8025b30d868f5e840b4bba9761d", required = false
+	)
+	public String modelDownloadSHA1();
+
+	@Meta.AD(
 		deflt = "https://repository-cdn.liferay.com/nexus/service/local/repositories/public/content/org/tensorflow/libtensorflow_jni/1.15.0/libtensorflow_jni-1.15.0.jar",
 		required = false
 	)
 	public String nativeLibraryDownloadURL();
+
+	@Meta.AD(
+		deflt = "e749c7ce289ad236914657a11b3c198f35ae5f41", required = false
+	)
+	public String nativeLibraryDownloadSHA1();
 
 }

--- a/modules/apps/document-library/document-library-asset-auto-tagger-tensorflow/src/main/java/com/liferay/document/library/asset/auto/tagger/tensorflow/internal/upgrade/v0_0_2/TensorFlowModelUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-asset-auto-tagger-tensorflow/src/main/java/com/liferay/document/library/asset/auto/tagger/tensorflow/internal/upgrade/v0_0_2/TensorFlowModelUpgradeProcess.java
@@ -90,21 +90,27 @@ public class TensorFlowModelUpgradeProcess extends UpgradeProcess {
 					_downloadFile(
 						"org.tensorflow.models.inception-5h.jar",
 						tensorFlowImageAssetAutoTagProviderDownloadConfiguration.
-							modelDownloadURL());
+							modelDownloadURL(),
+						tensorFlowImageAssetAutoTagProviderDownloadConfiguration.
+							modelDownloadSHA1());
 					_downloadFile(
 						"libtensorflow_jni-1.15.0.jar",
 						tensorFlowImageAssetAutoTagProviderDownloadConfiguration.
-							nativeLibraryDownloadURL());
+							nativeLibraryDownloadURL(),
+						tensorFlowImageAssetAutoTagProviderDownloadConfiguration.
+							nativeLibraryDownloadSHA1());
 
 					return;
 				}
 			});
 	}
 
-	private void _downloadFile(String fileName, String url) throws Exception {
+	private void _downloadFile(String fileName, String url, String sha1)
+		throws Exception {
+
 		File tempFile = FileUtil.createTempFile();
 
-		JarUtil.downloadAndInstallJar(new URL(url), tempFile.toPath());
+		JarUtil.downloadAndInstallJar(new URL(url), tempFile.toPath(), sha1);
 
 		_store.addFile(
 			0, CompanyConstants.SYSTEM,

--- a/modules/apps/document-library/document-library-asset-auto-tagger-tensorflow/src/main/java/com/liferay/document/library/asset/auto/tagger/tensorflow/internal/util/TensorFlowDownloadUtil.java
+++ b/modules/apps/document-library/document-library-asset-auto-tagger-tensorflow/src/main/java/com/liferay/document/library/asset/auto/tagger/tensorflow/internal/util/TensorFlowDownloadUtil.java
@@ -56,12 +56,16 @@ public class TensorFlowDownloadUtil {
 			_downloadFile(
 				_getModelFileName(),
 				tensorFlowImageAssetAutoTagProviderDownloadConfiguration.
-					modelDownloadURL());
+					modelDownloadURL(),
+				tensorFlowImageAssetAutoTagProviderDownloadConfiguration.
+					modelDownloadSHA1());
 
 			_downloadFile(
 				_getNativeLibraryFileName(),
 				tensorFlowImageAssetAutoTagProviderDownloadConfiguration.
-					nativeLibraryDownloadURL());
+					nativeLibraryDownloadURL(),
+				tensorFlowImageAssetAutoTagProviderDownloadConfiguration.
+					nativeLibraryDownloadSHA1());
 		}
 		catch (Exception exception) {
 			_downloadFailed = true;
@@ -106,12 +110,12 @@ public class TensorFlowDownloadUtil {
 		return _downloadFailed;
 	}
 
-	private static void _downloadFile(String fileName, String url)
+	private static void _downloadFile(String fileName, String url, String sha1)
 		throws Exception {
 
 		File tempFile = FileUtil.createTempFile();
 
-		JarUtil.downloadAndInstallJar(new URL(url), tempFile.toPath());
+		JarUtil.downloadAndInstallJar(new URL(url), tempFile.toPath(), sha1);
 
 		DLStoreUtil.addFile(
 			DLStoreRequest.builder(

--- a/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.jndi.JNDIUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.JavaDetector;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -41,6 +42,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.spring.hibernate.DialectDetector;
+import com.liferay.portal.util.DigesterImpl;
 import com.liferay.portal.util.JarUtil;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
@@ -620,6 +622,10 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 			}
 
 			try {
+				DigesterUtil digesterUtil = new DigesterUtil();
+
+				digesterUtil.setDigester(new DigesterImpl());
+
 				JarUtil.downloadAndInstallJar(
 					new URL(url),
 					Paths.get(PropsValues.LIFERAY_LIB_PORTAL_DIR, name),

--- a/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
@@ -600,8 +600,12 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 				PropsKeys.SETUP_DATABASE_JAR_URL, new Filter(driverClassName));
 			String name = PropsUtil.get(
 				PropsKeys.SETUP_DATABASE_JAR_NAME, new Filter(driverClassName));
+			String sha1Checksum = PropsUtil.get(
+				PropsKeys.SETUP_DATABASE_JAR_SHA1, new Filter(driverClassName));
 
-			if (Validator.isNull(url) || Validator.isNull(name)) {
+			if (Validator.isNull(url) || Validator.isNull(name) ||
+				Validator.isNull(sha1Checksum)) {
+
 				throw classNotFoundException;
 			}
 
@@ -619,7 +623,7 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 				JarUtil.downloadAndInstallJar(
 					new URL(url),
 					Paths.get(PropsValues.LIFERAY_LIB_PORTAL_DIR, name),
-					(URLClassLoader)classLoader);
+					(URLClassLoader)classLoader, sha1Checksum);
 			}
 			catch (Exception exception) {
 				_log.error(

--- a/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
@@ -600,11 +600,11 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 				PropsKeys.SETUP_DATABASE_JAR_URL, new Filter(driverClassName));
 			String name = PropsUtil.get(
 				PropsKeys.SETUP_DATABASE_JAR_NAME, new Filter(driverClassName));
-			String sha1Checksum = PropsUtil.get(
+			String sha1 = PropsUtil.get(
 				PropsKeys.SETUP_DATABASE_JAR_SHA1, new Filter(driverClassName));
 
 			if (Validator.isNull(url) || Validator.isNull(name) ||
-				Validator.isNull(sha1Checksum)) {
+				Validator.isNull(sha1)) {
 
 				throw classNotFoundException;
 			}
@@ -623,7 +623,7 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 				JarUtil.downloadAndInstallJar(
 					new URL(url),
 					Paths.get(PropsValues.LIFERAY_LIB_PORTAL_DIR, name),
-					(URLClassLoader)classLoader, sha1Checksum);
+					(URLClassLoader)classLoader, sha1);
 			}
 			catch (Exception exception) {
 				_log.error(

--- a/portal-impl/src/com/liferay/portal/util/JarUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/JarUtil.java
@@ -18,6 +18,8 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Digester;
+import com.liferay.portal.kernel.util.DigesterUtil;
 
 import java.io.File;
 import java.io.InputStream;
@@ -32,12 +34,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
+import java.util.Objects;
+
 /**
  * @author Shuyang Zhou
  */
 public class JarUtil {
 
-	public static void downloadAndInstallJar(URL url, Path path)
+	public static void downloadAndInstallJar(URL url, Path path, String sha1)
 		throws Exception {
 
 		if (_log.isInfoEnabled()) {
@@ -48,16 +52,28 @@ public class JarUtil {
 			Files.copy(inputStream, path, StandardCopyOption.REPLACE_EXISTING);
 		}
 
+		try (InputStream inputStream = Files.newInputStream(path)) {
+			String digest = DigesterUtil.digestHex(Digester.SHA_1, inputStream);
+
+			if (!Objects.equals(sha1, digest)) {
+				throw new Exception(
+					StringBundler.concat(
+						"Failed to download ", url, " to ", path, " due to ",
+						"integrity check failure: expected ", sha1, " actual ",
+						digest));
+			}
+		}
+
 		if (_log.isInfoEnabled()) {
 			_log.info(StringBundler.concat("Downloaded ", url, " to ", path));
 		}
 	}
 
 	public static void downloadAndInstallJar(
-			URL url, Path path, URLClassLoader urlClassLoader)
+			URL url, Path path, URLClassLoader urlClassLoader, String sha1)
 		throws Exception {
 
-		downloadAndInstallJar(url, path);
+		downloadAndInstallJar(url, path, sha1);
 
 		URI uri = path.toUri();
 
@@ -78,7 +94,7 @@ public class JarUtil {
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #downloadAndInstallJar(URL, Path)}
+	 *             #downloadAndInstallJar(URL, Path, String)}
 	 */
 	@Deprecated
 	public static Path downloadAndInstallJar(
@@ -89,14 +105,14 @@ public class JarUtil {
 
 		Path path = file.toPath();
 
-		downloadAndInstallJar(url, path);
+		downloadAndInstallJar(url, path, null);
 
 		return path;
 	}
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #downloadAndInstallJar(URL, Path, URLClassLoader)}
+	 *             #downloadAndInstallJar(URL, Path, URLClassLoader, String)}
 	 */
 	@Deprecated
 	public static void downloadAndInstallJar(
@@ -107,7 +123,7 @@ public class JarUtil {
 
 		Path path = file.toPath();
 
-		downloadAndInstallJar(url, path, urlClassLoader);
+		downloadAndInstallJar(url, path, urlClassLoader, null);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(JarUtil.class);

--- a/portal-impl/src/com/liferay/portal/util/JarUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/JarUtil.java
@@ -92,40 +92,6 @@ public class JarUtil {
 		}
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #downloadAndInstallJar(URL, Path, String)}
-	 */
-	@Deprecated
-	public static Path downloadAndInstallJar(
-			URL url, String libPath, String name)
-		throws Exception {
-
-		File file = new File(libPath, name);
-
-		Path path = file.toPath();
-
-		downloadAndInstallJar(url, path, null);
-
-		return path;
-	}
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #downloadAndInstallJar(URL, Path, URLClassLoader, String)}
-	 */
-	@Deprecated
-	public static void downloadAndInstallJar(
-			URL url, String libPath, String name, URLClassLoader urlClassLoader)
-		throws Exception {
-
-		File file = new File(libPath, name);
-
-		Path path = file.toPath();
-
-		downloadAndInstallJar(url, path, urlClassLoader, null);
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(JarUtil.class);
 
 	private static final Method _addURLMethod;

--- a/portal-impl/src/com/liferay/portal/util/JarUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/JarUtil.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Digester;
 import com.liferay.portal.kernel.util.DigesterUtil;
 
-import java.io.File;
 import java.io.InputStream;
 
 import java.lang.reflect.Method;

--- a/portal-impl/src/com/liferay/portal/xuggler/XugglerImpl.java
+++ b/portal-impl/src/com/liferay/portal/xuggler/XugglerImpl.java
@@ -47,7 +47,7 @@ public class XugglerImpl implements Xuggler {
 		try {
 			JarUtil.downloadAndInstallJar(
 				new URL(PropsValues.XUGGLER_JAR_URL + name),
-				Paths.get(PropsValues.LIFERAY_LIB_PORTAL_DIR, name));
+				Paths.get(PropsValues.LIFERAY_LIB_PORTAL_DIR, name), null);
 
 			_nativeLibraryCopied = true;
 		}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5945,7 +5945,7 @@
     #
     setup.database.jar.name[com.mysql.cj.jdbc.Driver]=mysql.jar
     setup.database.jar.url[com.mysql.cj.jdbc.Driver]=https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
-    setup.database.jar.checksum[com.mysql.cj.jdbc.Driver]=53fd3a0887667aae7e40a3439fff2d03d93ec4c2
+    setup.database.jar.sha1[com.mysql.cj.jdbc.Driver]=53fd3a0887667aae7e40a3439fff2d03d93ec4c2
 
     #
     # Env: LIFERAY_SETUP_PERIOD_DATABASE_PERIOD_URL_OPENBRACKET_DB_NUMBER2__CLOSEBRACKET_

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5939,11 +5939,13 @@
     setup.database.driverClassName[sybase]=com.sybase.jdbc4.jdbc.SybDriver
 
     #
+    # Env: LIFERAY_SETUP_PERIOD_DATABASE_PERIOD_JAR_PERIOD_CHECKSUM_OPENBRACKET_COM_PERIOD_MYSQL_PERIOD_CJ_PERIOD_JDBC_PERIOD__UPPERCASED_RIVER_CLOSEBRACKET_
     # Env: LIFERAY_SETUP_PERIOD_DATABASE_PERIOD_JAR_PERIOD_NAME_OPENBRACKET_COM_PERIOD_MYSQL_PERIOD_CJ_PERIOD_JDBC_PERIOD__UPPERCASED_RIVER_CLOSEBRACKET_
     # Env: LIFERAY_SETUP_PERIOD_DATABASE_PERIOD_JAR_PERIOD_URL_OPENBRACKET_COM_PERIOD_MYSQL_PERIOD_CJ_PERIOD_JDBC_PERIOD__UPPERCASED_RIVER_CLOSEBRACKET_
     #
     setup.database.jar.name[com.mysql.cj.jdbc.Driver]=mysql.jar
     setup.database.jar.url[com.mysql.cj.jdbc.Driver]=https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
+    setup.database.jar.checksum[com.mysql.cj.jdbc.Driver]=53fd3a0887667aae7e40a3439fff2d03d93ec4c2
 
     #
     # Env: LIFERAY_SETUP_PERIOD_DATABASE_PERIOD_URL_OPENBRACKET_DB_NUMBER2__CLOSEBRACKET_

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2997,6 +2997,9 @@ public interface PropsKeys {
 	public static final String SETUP_DATABASE_JAR_NAME =
 		"setup.database.jar.name";
 
+	public static final String SETUP_DATABASE_JAR_SHA1 =
+		"setup.database.jar.sha1";
+
 	public static final String SETUP_DATABASE_JAR_URL =
 		"setup.database.jar.url";
 


### PR DESCRIPTION
- LPS-143660 Make JarUtil require SHA1 checksum for the file it downloads, and check the checksum after downloading
- LPS-143660 Remove methods deprecated for 7.3.x
- LPS-143660 Apply to mysql.jar downloading
- LPS-143660 Apply to tensorflow jar downloading
- LPS-143660 TEMP: apply to Xuggler downloading
- LPS-143660 SF
- LPS-143660 Typo
- LPS-143660 Naming
- LPS-143660 Fix NPE: DataSourceFactoryImpl is executed before Spring context startup, so at the moment the wiring is not available
