### PR TITLE
LPS 142794 12 28

### DIFF
--- a/modules/apps/archived/xsl-content-web/src/main/java/com/liferay/xsl/content/web/internal/util/XSLContentUtil.java
+++ b/modules/apps/archived/xsl-content-web/src/main/java/com/liferay/xsl/content/web/internal/util/XSLContentUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.xsl.content.web.internal.util;
 
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.portal.kernel.security.xml.SecureXMLFactoryProviderUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -107,7 +108,7 @@ public class XSLContentUtil {
 		throws Exception {
 
 		TransformerFactory transformerFactory =
-			TransformerFactory.newInstance();
+			SecureXMLFactoryProviderUtil.newTransformerFactory();
 
 		transformerFactory.setFeature(
 			XMLConstants.FEATURE_SECURE_PROCESSING,

--- a/modules/apps/portal-remote/portal-remote-soap-extender-test/src/testIntegration/java/com/liferay/portal/remote/soap/extender/test/SampleHandler.java
+++ b/modules/apps/portal-remote/portal-remote-soap-extender-test/src/testIntegration/java/com/liferay/portal/remote/soap/extender/test/SampleHandler.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.remote.soap.extender.test;
 
+import com.liferay.portal.kernel.security.xml.SecureXMLFactoryProviderUtil;
+
 import java.net.URL;
 
 import javax.xml.transform.Transformer;
@@ -32,7 +34,8 @@ import javax.xml.ws.handler.MessageContext;
 public class SampleHandler implements LogicalHandler<LogicalMessageContext> {
 
 	public SampleHandler() {
-		_transformerFactory = TransformerFactory.newInstance();
+		_transformerFactory =
+			SecureXMLFactoryProviderUtil.newTransformerFactory();
 
 		_url = SampleHandler.class.getResource("dependencies/template.xsl");
 	}

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.template.xsl.internal;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.template.StringTemplateResource;
@@ -63,6 +64,11 @@ public class XSLTemplate extends BaseTemplate {
 
 		_transformerFactory = TransformerFactory.newInstance(
 			_TRANSFORMER_FACTORY_CLASS_NAME, _TRANSFORMER_FACTORY_CLASS_LOADER);
+
+		_transformerFactory.setAttribute(
+			XMLConstants.ACCESS_EXTERNAL_DTD, StringPool.BLANK);
+		_transformerFactory.setAttribute(
+			XMLConstants.ACCESS_EXTERNAL_STYLESHEET, StringPool.BLANK);
 
 		try {
 			_transformerFactory.setFeature(

--- a/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/src/main/java/com/liferay/sharepoint/soap/repository/connector/schema/XMLUtil.java
+++ b/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/src/main/java/com/liferay/sharepoint/soap/repository/connector/schema/XMLUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.sharepoint.soap.repository.connector.schema;
 
+import com.liferay.portal.kernel.security.xml.SecureXMLFactoryProviderUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.StringWriter;
@@ -77,7 +78,7 @@ public final class XMLUtil {
 
 	public static String toString(org.w3c.dom.Node node) {
 		TransformerFactory transformerFactory =
-			TransformerFactory.newInstance();
+			SecureXMLFactoryProviderUtil.newTransformerFactory();
 
 		Transformer transformer = null;
 

--- a/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/src/test/java/com/liferay/sharepoint/soap/repository/connector/SharepointConnectionTest.java
+++ b/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/src/test/java/com/liferay/sharepoint/soap/repository/connector/SharepointConnectionTest.java
@@ -16,7 +16,9 @@ package com.liferay.sharepoint.soap.repository.connector;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.security.xml.SecureXMLFactoryProviderUtil;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.security.xml.SecureXMLFactoryProviderImpl;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.sharepoint.soap.repository.connector.internal.util.test.SharepointConnectionTestUtil;
 import com.liferay.sharepoint.soap.repository.connector.schema.query.Query;
@@ -55,6 +57,12 @@ public class SharepointConnectionTest {
 
 	@BeforeClass
 	public static void setUpClass() {
+		SecureXMLFactoryProviderUtil secureXMLFactoryProviderUtil =
+			new SecureXMLFactoryProviderUtil();
+
+		secureXMLFactoryProviderUtil.setSecureXMLFactoryProvider(
+			new SecureXMLFactoryProviderImpl());
+
 		_sharepointConnection = SharepointConnectionFactory.getInstance(
 			_SERVER_VERSION, _SERVER_PROTOCOL,
 			SharepointConnectionTestUtil.getSharepointVMHostname(),

--- a/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/internal/util/XMLUtil.java
+++ b/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/internal/util/XMLUtil.java
@@ -18,6 +18,7 @@ import com.liferay.gradle.util.Validator;
 
 import java.io.File;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
@@ -105,6 +106,10 @@ public class XMLUtil {
 	public static void write(Document document, File file) throws Exception {
 		TransformerFactory transformerFactory =
 			TransformerFactory.newInstance();
+
+		transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		transformerFactory.setAttribute(
+			XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
 
 		Transformer transformer = transformerFactory.newTransformer();
 

--- a/modules/sdk/gradle-plugins-maven-plugin-builder/src/main/java/com/liferay/gradle/plugins/maven/plugin/builder/internal/util/XMLUtil.java
+++ b/modules/sdk/gradle-plugins-maven-plugin-builder/src/main/java/com/liferay/gradle/plugins/maven/plugin/builder/internal/util/XMLUtil.java
@@ -18,6 +18,7 @@ import com.liferay.gradle.util.Validator;
 
 import java.io.File;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
@@ -58,6 +59,10 @@ public class XMLUtil {
 	public static void write(Document document, File file) throws Exception {
 		TransformerFactory transformerFactory =
 			TransformerFactory.newInstance();
+
+		transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		transformerFactory.setAttribute(
+			XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
 
 		Transformer transformer = transformerFactory.newTransformer();
 

--- a/modules/sdk/project-templates/project-templates/src/test/java/com/liferay/project/templates/BaseProjectTemplatesTestCase.java
+++ b/modules/sdk/project-templates/project-templates/src/test/java/com/liferay/project/templates/BaseProjectTemplatesTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.project.templates;
 import aQute.bnd.main.bnd;
 
 import com.liferay.maven.executor.MavenExecutor;
+import com.liferay.petra.string.StringPool;
 import com.liferay.project.templates.extensions.ProjectTemplatesArgs;
 import com.liferay.project.templates.extensions.util.FileUtil;
 import com.liferay.project.templates.extensions.util.ProjectTemplatesUtil;
@@ -64,6 +65,7 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
@@ -803,6 +805,11 @@ public interface BaseProjectTemplatesTestCase {
 
 		TransformerFactory transformerFactory =
 			TransformerFactory.newInstance();
+
+		transformerFactory.setAttribute(
+			XMLConstants.ACCESS_EXTERNAL_DTD, StringPool.BLANK);
+		transformerFactory.setAttribute(
+			XMLConstants.ACCESS_EXTERNAL_STYLESHEET, StringPool.BLANK);
 
 		Transformer transformer = transformerFactory.newTransformer();
 

--- a/modules/sdk/project-templates/project-templates/src/test/java/com/liferay/project/templates/util/XMLTestUtil.java
+++ b/modules/sdk/project-templates/project-templates/src/test/java/com/liferay/project/templates/util/XMLTestUtil.java
@@ -14,6 +14,8 @@
 
 package com.liferay.project.templates.util;
 
+import com.liferay.petra.string.StringPool;
+
 import java.io.StringWriter;
 
 import java.nio.file.Path;
@@ -21,6 +23,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
@@ -148,6 +151,11 @@ public class XMLTestUtil {
 	static {
 		TransformerFactory transformerFactory =
 			TransformerFactory.newInstance();
+
+		transformerFactory.setAttribute(
+			XMLConstants.ACCESS_EXTERNAL_DTD, StringPool.BLANK);
+		transformerFactory.setAttribute(
+			XMLConstants.ACCESS_EXTERNAL_STYLESHEET, StringPool.BLANK);
 
 		try {
 			_transformer = transformerFactory.newTransformer();

--- a/portal-impl/src/com/liferay/portal/diff/DiffHtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/diff/DiffHtmlImpl.java
@@ -17,6 +17,7 @@ package com.liferay.portal.diff;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.diff.DiffHtml;
+import com.liferay.portal.kernel.security.xml.SecureXMLFactoryProviderUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -24,7 +25,6 @@ import java.io.Reader;
 
 import java.util.Locale;
 
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamResult;
@@ -82,7 +82,8 @@ public class DiffHtmlImpl implements DiffHtml {
 
 		try {
 			SAXTransformerFactory saxTransformerFactory =
-				(SAXTransformerFactory)TransformerFactory.newInstance();
+				(SAXTransformerFactory)
+					SecureXMLFactoryProviderUtil.newTransformerFactory();
 
 			TransformerHandler tranformHandler =
 				saxTransformerFactory.newTransformerHandler();

--- a/portal-impl/src/com/liferay/portal/security/xml/SecureXMLFactoryProviderImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/xml/SecureXMLFactoryProviderImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.security.xml;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -23,6 +24,7 @@ import com.liferay.portal.util.PropsValues;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.transform.TransformerFactory;
 
 import org.apache.xerces.parsers.SAXParser;
 
@@ -79,6 +81,31 @@ public class SecureXMLFactoryProviderImpl implements SecureXMLFactoryProvider {
 		}
 
 		return documentBuilderFactory;
+	}
+
+	@Override
+	public TransformerFactory newTransformerFactory() {
+		TransformerFactory transformerFactory =
+			TransformerFactory.newInstance();
+
+		if (!PropsValues.XML_SECURITY_ENABLED) {
+			return transformerFactory;
+		}
+
+		try {
+			transformerFactory.setAttribute(
+				XMLConstants.ACCESS_EXTERNAL_DTD, StringPool.BLANK);
+			transformerFactory.setAttribute(
+				XMLConstants.ACCESS_EXTERNAL_STYLESHEET, StringPool.BLANK);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to initialize safe transformer factory to protect " +
+					"from XXE attacks",
+				exception);
+		}
+
+		return transformerFactory;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/tools/SPDXBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/SPDXBuilder.java
@@ -17,11 +17,13 @@ package com.liferay.portal.tools;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.xml.Dom4jUtil;
+import com.liferay.portal.kernel.security.xml.SecureXMLFactoryProvider;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CSVUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.xml.SecureXMLFactoryProviderImpl;
 import com.liferay.portal.xml.SAXReaderFactory;
 
 import java.io.BufferedReader;
@@ -124,8 +126,11 @@ public class SPDXBuilder {
 				new File(spdxFile.getParentFile(), "versions-spdx.csv"),
 				_toCSV(document));
 
+			SecureXMLFactoryProvider secureXMLFactoryProvider =
+				new SecureXMLFactoryProviderImpl();
+
 			TransformerFactory transformerFactory =
-				TransformerFactory.newInstance();
+				secureXMLFactoryProvider.newTransformerFactory();
 
 			Transformer transformer = transformerFactory.newTransformer(
 				new StreamSource(

--- a/portal-impl/src/com/liferay/portal/tools/XSLTBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/XSLTBuilder.java
@@ -19,8 +19,10 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.petra.xml.Dom4jUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.xml.SecureXMLFactoryProvider;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.security.xml.SecureXMLFactoryProviderImpl;
 import com.liferay.portal.xml.SAXReaderFactory;
 
 import java.io.BufferedReader;
@@ -97,8 +99,11 @@ public class XSLTBuilder {
 					completeContent.getBytes(StandardCharsets.UTF_8));
 			}
 
+			SecureXMLFactoryProvider secureXMLFactoryProvider =
+				new SecureXMLFactoryProviderImpl();
+
 			TransformerFactory transformerFactory =
-				TransformerFactory.newInstance();
+				secureXMLFactoryProvider.newTransformerFactory();
 
 			Transformer transformer = transformerFactory.newTransformer(
 				new StreamSource(xsl));

--- a/portal-impl/src/com/liferay/portlet/internal/PortletResponseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletResponseImpl.java
@@ -615,7 +615,7 @@ public abstract class PortletResponseImpl implements LiferayPortletResponse {
 				Writer writer = new UnsyncStringWriter();
 
 				TransformerFactory transformerFactory =
-					TransformerFactory.newInstance();
+					SecureXMLFactoryProviderUtil.newTransformerFactory();
 
 				Transformer transformer = transformerFactory.newTransformer();
 

--- a/portal-impl/src/system.properties
+++ b/portal-impl/src/system.properties
@@ -219,6 +219,19 @@
 
     javax.xml.bind.JAXBContextFactory=com.sun.xml.bind.v2.ContextFactory
 
+
+##
+## Java API for XML Processing
+##
+
+    #
+    # Set the JAXP transformer factory to avoid using the one detected by
+    # context. This forces Java to use the implementation provided by JDK.
+    # Set this property to a blank value to use the auto-detected JAXP
+    # transformer factory.
+    #
+    javax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
+
 ##
 ## JRuby
 ##

--- a/portal-impl/test/unit/com/liferay/portal/diff/DiffHtmlTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/diff/DiffHtmlTest.java
@@ -15,12 +15,15 @@
 package com.liferay.portal.diff;
 
 import com.liferay.portal.kernel.diff.DiffHtml;
+import com.liferay.portal.kernel.security.xml.SecureXMLFactoryProviderUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.security.xml.SecureXMLFactoryProviderImpl;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.StringReader;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +37,15 @@ public class DiffHtmlTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		SecureXMLFactoryProviderUtil secureXMLFactoryProviderUtil =
+			new SecureXMLFactoryProviderUtil();
+
+		secureXMLFactoryProviderUtil.setSecureXMLFactoryProvider(
+			new SecureXMLFactoryProviderImpl());
+	}
 
 	@Test
 	public void testDiffMustNotHaveXMLDeclaration() throws Exception {

--- a/portal-impl/test/unit/com/liferay/portal/security/xml/SecureXMLFactoryProviderImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/xml/SecureXMLFactoryProviderImplTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
 
@@ -30,6 +31,10 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -121,6 +126,50 @@ public class SecureXMLFactoryProviderImplTest {
 			ConnectException.class,
 			"Parameter Entities XXE attack using PUBLIC entity does not work.",
 			SAXParseException.class,
+			"Vulnerable to Parameter Entities XXE attack using PUBLIC entity.");
+	}
+
+	@Test
+	public void testNewTransformerFactory() throws Throwable {
+		XMLSecurityTest transformerFactoryTest = new XMLSecurityTest() {
+
+			@Override
+			public void run(String xml) throws Exception {
+				TransformerFactory transformerFactory =
+					_secureXMLFactoryProviderImpl.newTransformerFactory();
+
+				Transformer transformer = transformerFactory.newTransformer();
+
+				transformer.transform(
+					new StreamSource(new ByteArrayInputStream(xml.getBytes())),
+					new StreamResult(new ByteArrayOutputStream()));
+			}
+
+		};
+
+		runXMLSecurityTest(
+			transformerFactoryTest, _xxeGeneralEntitiesXML1,
+			ConnectException.class,
+			"General Entities XXE attack using SYSTEM entity does not work.",
+			IllegalArgumentException.class,
+			"Vulnerable to General Entities XXE attack using SYSTEM entity.");
+		runXMLSecurityTest(
+			transformerFactoryTest, _xxeGeneralEntitiesXML2,
+			ConnectException.class,
+			"General Entities XXE attack using PUBLIC entity does not work.",
+			IllegalArgumentException.class,
+			"Vulnerable to General Entities XXE attack using PUBLIC entity.");
+		runXMLSecurityTest(
+			transformerFactoryTest, _xxeParameterEntitiesXML1,
+			ConnectException.class,
+			"Parameter Entities XXE using SYSTEM entity does not work.",
+			IllegalArgumentException.class,
+			"Vulnerable to Parameter Entities XXE using SYSTEM entity.");
+		runXMLSecurityTest(
+			transformerFactoryTest, _xxeParameterEntitiesXML2,
+			ConnectException.class,
+			"Parameter Entities XXE attack using PUBLIC entity does not work.",
+			IllegalArgumentException.class,
 			"Vulnerable to Parameter Entities XXE attack using PUBLIC entity.");
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/security/xml/SecureXMLFactoryProviderImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/xml/SecureXMLFactoryProviderImplTest.java
@@ -151,25 +151,25 @@ public class SecureXMLFactoryProviderImplTest {
 			transformerFactoryTest, _xxeGeneralEntitiesXML1,
 			ConnectException.class,
 			"General Entities XXE attack using SYSTEM entity does not work.",
-			IllegalArgumentException.class,
+			SAXParseException.class,
 			"Vulnerable to General Entities XXE attack using SYSTEM entity.");
 		runXMLSecurityTest(
 			transformerFactoryTest, _xxeGeneralEntitiesXML2,
 			ConnectException.class,
 			"General Entities XXE attack using PUBLIC entity does not work.",
-			IllegalArgumentException.class,
+			SAXParseException.class,
 			"Vulnerable to General Entities XXE attack using PUBLIC entity.");
 		runXMLSecurityTest(
 			transformerFactoryTest, _xxeParameterEntitiesXML1,
 			ConnectException.class,
 			"Parameter Entities XXE using SYSTEM entity does not work.",
-			IllegalArgumentException.class,
+			SAXParseException.class,
 			"Vulnerable to Parameter Entities XXE using SYSTEM entity.");
 		runXMLSecurityTest(
 			transformerFactoryTest, _xxeParameterEntitiesXML2,
 			ConnectException.class,
 			"Parameter Entities XXE attack using PUBLIC entity does not work.",
-			IllegalArgumentException.class,
+			SAXParseException.class,
 			"Vulnerable to Parameter Entities XXE attack using PUBLIC entity.");
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/xml/SecureXMLFactoryProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/xml/SecureXMLFactoryProvider.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.security.xml;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.transform.TransformerFactory;
 
 import org.xml.sax.XMLReader;
 
@@ -25,6 +26,8 @@ import org.xml.sax.XMLReader;
 public interface SecureXMLFactoryProvider {
 
 	public DocumentBuilderFactory newDocumentBuilderFactory();
+
+	public TransformerFactory newTransformerFactory();
 
 	public XMLInputFactory newXMLInputFactory();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/xml/SecureXMLFactoryProviderUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/xml/SecureXMLFactoryProviderUtil.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.security.xml;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.transform.TransformerFactory;
 
 import org.xml.sax.XMLReader;
 
@@ -30,6 +31,10 @@ public class SecureXMLFactoryProviderUtil {
 
 	public static DocumentBuilderFactory newDocumentBuilderFactory() {
 		return _secureXMLFactoryProvider.newDocumentBuilderFactory();
+	}
+
+	public static TransformerFactory newTransformerFactory() {
+		return _secureXMLFactoryProvider.newTransformerFactory();
 	}
 
 	public static XMLInputFactory newXMLInputFactory() {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/xml/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/xml/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0


### PR DESCRIPTION
- LPS-142794 Add new method to provide secure TransformerFactory
- LPS-142794 Add XXE test coverage for the new method
- LPS-142794 Apply to PortletResponseImpl
- LPS-142794 Apply to DiffHtmlImpl
- LPS-142794 Apply to XMLUtil in sharepoint-soap-repository
- LPS-142794 Apply to SampleHandler
- LPS-142794 Apply to XSLContentUtil
- LPS-142794 Apply to SPDXBuilder and XSLTBuilder (this fixes LPS-142695)
- LPS-142794 Directly set attributes in XSLTemplate, as it's the only usage of TransformerFactory.newInstance(String, ClassLoader)
- LPS-142794 Directly set attributes in project-templates test classes
- LPS-142794 Directly set attributes in gradle plugin classes
- LPS-142794 Fix test
- LPS-142794 Enforce JDK version
- LPS-142794 SemVer
