### PR TITLE
[Bug Fix] LPS-107347

### DIFF
--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 18.0.3
+Bundle-Version: 18.1.0
 Export-Package:\
 	com.liferay.portal.asm,\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -407,12 +407,29 @@ public class MainServlet extends HttpServlet {
 			}
 		}
 
-		if (StartupHelperUtil.isDBNew() &&
-			PropsValues.SETUP_WIZARD_ADD_SAMPLE_DATA) {
-
+		if (StartupHelperUtil.isDBNew()) {
 			try {
-				SetupWizardSampleDataUtil.addSampleData(
-					PortalInstances.getDefaultCompanyId());
+				if (PropsValues.SETUP_WIZARD_ADD_SAMPLE_DATA) {
+					SetupWizardSampleDataUtil.addSampleData(
+						PortalInstances.getDefaultCompanyId());
+				}
+
+				if (PropsValues.
+						SETUP_WIZARD_DEFAULT_ADMIN_PASSWORD_RESET_ENABLED) {
+
+					Company company = CompanyLocalServiceUtil.getCompanyByWebId(
+						PropsValues.COMPANY_DEFAULT_WEB_ID);
+
+					User adminUser =
+						UserLocalServiceUtil.fetchUserByEmailAddress(
+							company.getCompanyId(),
+							PropsValues.DEFAULT_ADMIN_EMAIL_ADDRESS_PREFIX +
+								"@" + company.getMx());
+
+					adminUser.setPasswordReset(true);
+
+					UserLocalServiceUtil.updateUser(adminUser);
+				}
 			}
 			catch (Exception exception) {
 				_log.error(exception, exception);

--- a/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
+++ b/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
@@ -195,7 +195,8 @@ public class SetupWizardUtil {
 		_updateCompany(httpServletRequest, unicodeProperties);
 
 		_updateAdminUser(
-			httpServletRequest, httpServletResponse, unicodeProperties);
+			httpServletRequest, httpServletResponse, unicodeProperties,
+			databaseConfigurationUnchanged);
 
 		_updateCompanyWebId(httpServletRequest, unicodeProperties);
 
@@ -329,7 +330,8 @@ public class SetupWizardUtil {
 	private static void _updateAdminUser(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse,
-			UnicodeProperties unicodeProperties)
+			UnicodeProperties unicodeProperties,
+			boolean databaseConfigurationUnchanged)
 		throws Exception {
 
 		ThemeDisplay themeDisplay =
@@ -363,6 +365,12 @@ public class SetupWizardUtil {
 
 		if ((passwordPolicy != null) && passwordPolicy.isChangeable()) {
 			passwordReset = true;
+
+			if (!databaseConfigurationUnchanged) {
+				unicodeProperties.put(
+					PropsKeys.SETUP_WIZARD_DEFAULT_ADMIN_PASSWORD_RESET_ENABLED,
+					Boolean.TRUE.toString());
+			}
 		}
 
 		User user = SetupWizardSampleDataUtil.updateAdminUser(

--- a/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
+++ b/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
@@ -178,10 +178,12 @@ public class SetupWizardUtil {
 			PropsKeys.LIFERAY_HOME,
 			SystemProperties.get(PropsKeys.LIFERAY_HOME));
 
-		boolean databaseConfigured = _isDatabaseConfigured(unicodeProperties);
+		boolean databaseConfigurationUnchanged =
+			_isDatabaseConfigurationUnchanged(unicodeProperties);
 
 		_processDatabaseProperties(
-			httpServletRequest, unicodeProperties, databaseConfigured);
+			httpServletRequest, unicodeProperties,
+			databaseConfigurationUnchanged);
 
 		_processOtherProperties(httpServletRequest, unicodeProperties);
 
@@ -229,7 +231,7 @@ public class SetupWizardUtil {
 			unicodeProperties.toString(), _NULL_HOLDER);
 	}
 
-	private static boolean _isDatabaseConfigured(
+	private static boolean _isDatabaseConfigurationUnchanged(
 		UnicodeProperties unicodeProperties) {
 
 		String defaultDriverClassName = unicodeProperties.get(
@@ -254,13 +256,14 @@ public class SetupWizardUtil {
 
 	private static void _processDatabaseProperties(
 			HttpServletRequest httpServletRequest,
-			UnicodeProperties unicodeProperties, boolean databaseConfigured)
+			UnicodeProperties unicodeProperties,
+			boolean databaseConfigurationUnchanged)
 		throws Exception {
 
 		boolean defaultDatabase = ParamUtil.getBoolean(
 			httpServletRequest, "defaultDatabase", true);
 
-		if (defaultDatabase || databaseConfigured) {
+		if (defaultDatabase || databaseConfigurationUnchanged) {
 			unicodeProperties.remove(PropsKeys.JDBC_DEFAULT_URL);
 			unicodeProperties.remove(PropsKeys.JDBC_DEFAULT_DRIVER_CLASS_NAME);
 			unicodeProperties.remove(PropsKeys.JDBC_DEFAULT_USERNAME);

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2682,6 +2682,13 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.SETUP_WIZARD_ADD_SAMPLE_DATA));
 
+	public static final boolean
+		SETUP_WIZARD_DEFAULT_ADMIN_PASSWORD_RESET_ENABLED =
+			GetterUtil.getBoolean(
+				PropsUtil.get(
+					PropsKeys.
+						SETUP_WIZARD_DEFAULT_ADMIN_PASSWORD_RESET_ENABLED));
+
 	public static boolean SETUP_WIZARD_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.SETUP_WIZARD_ENABLED));
 

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 15.0.0
+version 15.1.0

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5973,6 +5973,15 @@
     setup.wizard.add.sample.data=false
 
     #
+    # Set this property to true to enable the default admin password reset in
+    # the new database on startup. This will happen even if the Setup Wizard is
+    # disabled.
+    #
+    # Env: LIFERAY_SETUP_PERIOD_WIZARD_PERIOD_DEFAULT_PERIOD_ADMIN_PERIOD_PASSWORD_PERIOD_RESET_PERIOD_ENABLED
+    #
+    setup.wizard.default.admin.password.reset.enabled=false
+
+    #
     # Set this property to true if the Setup Wizard should be displayed the
     # first time the portal is started.
     #

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -3011,6 +3011,10 @@ public interface PropsKeys {
 	public static final String SETUP_WIZARD_ADD_SAMPLE_DATA =
 		"setup.wizard.add.sample.data";
 
+	public static final String
+		SETUP_WIZARD_DEFAULT_ADMIN_PASSWORD_RESET_ENABLED =
+			"setup.wizard.default.admin.password.reset.enabled";
+
 	public static final String SETUP_WIZARD_ENABLED = "setup.wizard.enabled";
 
 	public static final String SHAREPOINT_STORAGE_CLASS =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 20.0.0
+version 20.1.0


### PR DESCRIPTION
@dantewang,  the pr is based on https://github.com/yuhai/liferay-portal/pull/277. When setup wizard, we have exported the below properties. These properties will take the changed values to the new database on startup. Please refer to the [code1 ](https://github.com/yuhai/liferay-portal/blob/LPS-107347-pr3/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java#L1870)and [code2](https://github.com/yuhai/liferay-portal/blob/LPS-107347-pr3/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java#L2014-L2023)
```
company.default.locale
default.admin.email.address.prefix
company.default.web.id
default.admin.first.name
default.admin.last.name
```
I removed one condition and only use the below code as emailAddress is enough in MainServlet. Because when init company, we use the [code3 ](https://github.com/yuhai/liferay-portal/blob/LPS-107347-pr3/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java#L2014-L2015) to add the default admin user.
```
PropsValues.DEFAULT_ADMIN_EMAIL_ADDRESS_PREFIX +"@" + company.getMx()
```