### PR TITLE
[Bug Fix] LPS-88060

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/embedded/test/EmbeddedPortletWhenEmbeddingPortletUsingTemplateProcessorTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/embedded/test/EmbeddedPortletWhenEmbeddingPortletUsingTemplateProcessorTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.osgi.web.portlet.container.embedded.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.layoutconfiguration.util.velocity.TemplateProcessor;
+import com.liferay.portal.osgi.web.portlet.container.test.BasePortletContainerTestCase;
+import com.liferay.portal.osgi.web.portlet.container.test.util.PortletContainerTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Hai Yu
+ */
+@RunWith(Arquillian.class)
+public class EmbeddedPortletWhenEmbeddingPortletUsingTemplateProcessorTest
+	extends BasePortletContainerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testShouldCreatePortletEmbeddedPortletPreferences()
+		throws Exception {
+
+		setUpPortlet(
+			testPortlet, new HashMapDictionary<>(), TEST_PORTLET_ID, false);
+
+		HttpServletRequest httpServletRequest =
+			PortletContainerTestUtil.getHttpServletRequest(group, layout);
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		themeDisplay.setLayoutTypePortlet(
+			(LayoutTypePortlet)layout.getLayoutType());
+
+		Assert.assertFalse(
+			"layout.isPortletEmbedded() should return false",
+			layout.isPortletEmbedded(TEST_PORTLET_ID, layout.getGroupId()));
+
+		TemplateProcessor templateProcessor = new TemplateProcessor(
+			httpServletRequest, new MockHttpServletResponse(), TEST_PORTLET_ID);
+
+		templateProcessor.processPortlet(TEST_PORTLET_ID);
+
+		Assert.assertTrue(
+			"layout.isPortletEmbedded() should return true",
+			layout.isPortletEmbedded(TEST_PORTLET_ID, layout.getGroupId()));
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/TemplateProcessor.java
+++ b/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/TemplateProcessor.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.layoutconfiguration.util.PortletRenderer;
@@ -217,7 +218,10 @@ public class TemplateProcessor implements ColumnProcessor {
 				}
 
 				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-					layout, portletId, defaultPreferences);
+					layout.getCompanyId(), layout.getGroupId(),
+					PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+					PortletKeys.PREFS_PLID_SHARED, portletId,
+					defaultPreferences);
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/TemplateProcessor.java
+++ b/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/TemplateProcessor.java
@@ -24,12 +24,10 @@ import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletContainerUtil;
 import com.liferay.portal.kernel.portlet.PortletJSONUtil;
-import com.liferay.portal.kernel.portlet.PortletLayoutListener;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletProvider;
 import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.BufferCacheServletResponse;
 import com.liferay.portal.kernel.settings.ModifiableSettings;
 import com.liferay.portal.kernel.settings.PortletInstanceSettingsLocator;
@@ -39,7 +37,6 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.layoutconfiguration.util.PortletRenderer;
@@ -219,32 +216,8 @@ public class TemplateProcessor implements ColumnProcessor {
 					defaultPreferences = sb.toString();
 				}
 
-				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-					layout.getCompanyId(), layout.getGroupId(),
-					PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
-					PortletKeys.PREFS_PLID_SHARED, portletId,
-					defaultPreferences);
-
-				long count =
-					PortletPreferencesLocalServiceUtil.
-						getPortletPreferencesCount(
-							PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
-							themeDisplay.getPlid(), portletId);
-
-				if (count < 1) {
-					PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-						layout, portletId, defaultPreferences);
-					PortletPreferencesFactoryUtil.getPortletSetup(
-						_httpServletRequest, portletId, defaultPreferences);
-
-					PortletLayoutListener portletLayoutListener =
-						portlet.getPortletLayoutListenerInstance();
-
-					if (portletLayoutListener != null) {
-						portletLayoutListener.onAddToLayout(
-							portletId, themeDisplay.getPlid());
-					}
-				}
+				PortletPreferencesFactoryUtil.getLayoutPortletAndPortletSetup(
+					_httpServletRequest, portlet, defaultPreferences);
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/TemplateProcessor.java
+++ b/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/TemplateProcessor.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.layoutconfiguration.util.PortletRenderer;
@@ -218,9 +217,7 @@ public class TemplateProcessor implements ColumnProcessor {
 				}
 
 				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-					layout.getCompanyId(), layout.getGroupId(),
-					PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
-					portletId, defaultPreferences);
+					layout, portletId, defaultPreferences);
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/TemplateProcessor.java
+++ b/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/TemplateProcessor.java
@@ -24,10 +24,12 @@ import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletContainerUtil;
 import com.liferay.portal.kernel.portlet.PortletJSONUtil;
+import com.liferay.portal.kernel.portlet.PortletLayoutListener;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletProvider;
 import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.BufferCacheServletResponse;
 import com.liferay.portal.kernel.settings.ModifiableSettings;
 import com.liferay.portal.kernel.settings.PortletInstanceSettingsLocator;
@@ -222,6 +224,27 @@ public class TemplateProcessor implements ColumnProcessor {
 					PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
 					PortletKeys.PREFS_PLID_SHARED, portletId,
 					defaultPreferences);
+
+				long count =
+					PortletPreferencesLocalServiceUtil.
+						getPortletPreferencesCount(
+							PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+							themeDisplay.getPlid(), portletId);
+
+				if (count < 1) {
+					PortletPreferencesFactoryUtil.getLayoutPortletSetup(
+						layout, portletId, defaultPreferences);
+					PortletPreferencesFactoryUtil.getPortletSetup(
+						_httpServletRequest, portletId, defaultPreferences);
+
+					PortletLayoutListener portletLayoutListener =
+						portlet.getPortletLayoutListenerInstance();
+
+					if (portletLayoutListener != null) {
+						portletLayoutListener.onAddToLayout(
+							portletId, themeDisplay.getPlid());
+					}
+				}
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayPortletMode;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
+import com.liferay.portal.kernel.portlet.PortletLayoutListener;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
 import com.liferay.portal.kernel.portlet.constants.PortletPreferencesFactoryConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -270,6 +271,54 @@ public class PortletPreferencesFactoryImpl
 
 		return getExistingPortletSetup(
 			themeDisplay.getLayout(), portletResource);
+	}
+
+	@Override
+	public boolean getLayoutPortletAndPortletSetup(
+			HttpServletRequest httpServletRequest, Portlet portlet,
+			String defaultPreferences)
+		throws Exception {
+
+		boolean writeObject = false;
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Layout layout = themeDisplay.getLayout();
+
+		String portletId = portlet.getPortletId();
+
+		if (!layout.isPortletEmbedded(portletId, layout.getGroupId())) {
+			getLayoutPortletSetup(
+				layout.getCompanyId(), layout.getGroupId(),
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+				PortletKeys.PREFS_PLID_SHARED, portletId, defaultPreferences);
+
+			writeObject = true;
+		}
+
+		long count =
+			PortletPreferencesLocalServiceUtil.getPortletPreferencesCount(
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
+				portletId);
+
+		if (count < 1) {
+			getLayoutPortletSetup(layout, portletId, defaultPreferences);
+			getPortletSetup(httpServletRequest, portletId, defaultPreferences);
+
+			PortletLayoutListener portletLayoutListener =
+				portlet.getPortletLayoutListenerInstance();
+
+			if (portletLayoutListener != null) {
+				portletLayoutListener.onAddToLayout(
+					portletId, layout.getPlid());
+			}
+
+			writeObject = true;
+		}
+
+		return writeObject;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletPreferencesFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletPreferencesFactory.java
@@ -57,6 +57,11 @@ public interface PortletPreferencesFactory {
 			PortletRequest portletRequest)
 		throws PortalException;
 
+	public boolean getLayoutPortletAndPortletSetup(
+			HttpServletRequest httpServletRequest, Portlet portlet,
+			String defaultPreferences)
+		throws Exception;
+
 	public PortletPreferences getLayoutPortletSetup(
 		Layout layout, String portletId);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletPreferencesFactoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletPreferencesFactoryUtil.java
@@ -76,6 +76,15 @@ public class PortletPreferencesFactoryUtil {
 			portletRequest);
 	}
 
+	public static boolean getLayoutPortletAndPortletSetup(
+			HttpServletRequest httpServletRequest, Portlet portlet,
+			String defaultPreferences)
+		throws Exception {
+
+		return _portletPreferencesFactory.getLayoutPortletAndPortletSetup(
+			httpServletRequest, portlet, defaultPreferences);
+	}
+
 	public static PortletPreferences getLayoutPortletSetup(
 		Layout layout, String portletId) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 13.1.0
+version 13.2.0

--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.model.PortletWrapper;
 import com.liferay.portal.kernel.portlet.PortletContainerUtil;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletJSONUtil;
-import com.liferay.portal.kernel.portlet.PortletLayoutListener;
 import com.liferay.portal.kernel.portlet.PortletParameterUtil;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletProvider;
@@ -37,13 +36,11 @@ import com.liferay.portal.kernel.portlet.RestrictPortletServletRequest;
 import com.liferay.portal.kernel.portlet.constants.PortletPreferencesFactoryConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.DirectTag;
@@ -290,8 +287,6 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 				}
 			}
 
-			Layout layout = themeDisplay.getLayout();
-
 			httpServletRequest.setAttribute(
 				WebKeys.SETTINGS_SCOPE, settingsScope);
 
@@ -300,42 +295,10 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 			boolean writeObject = false;
 
 			if (persistSettings) {
-				if (!layout.isPortletEmbedded(
-						portlet.getPortletId(), layout.getGroupId())) {
-
-					PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-						themeDisplay.getCompanyId(),
-						themeDisplay.getScopeGroupId(),
-						PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
-						PortletKeys.PREFS_PLID_SHARED, portletInstanceKey,
-						defaultPreferences);
-
-					writeObject = true;
-				}
-
-				long count =
-					PortletPreferencesLocalServiceUtil.
-						getPortletPreferencesCount(
-							PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
-							themeDisplay.getPlid(), portletInstanceKey);
-
-				if (count < 1) {
-					PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-						layout, portletInstanceKey, defaultPreferences);
-					PortletPreferencesFactoryUtil.getPortletSetup(
-						httpServletRequest, portletInstanceKey,
-						defaultPreferences);
-
-					PortletLayoutListener portletLayoutListener =
-						portlet.getPortletLayoutListenerInstance();
-
-					if (portletLayoutListener != null) {
-						portletLayoutListener.onAddToLayout(
-							portletInstanceKey, themeDisplay.getPlid());
-					}
-
-					writeObject = true;
-				}
+				writeObject =
+					PortletPreferencesFactoryUtil.
+						getLayoutPortletAndPortletSetup(
+							httpServletRequest, portlet, defaultPreferences);
 			}
 
 			if (writeObject) {

--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -299,20 +299,20 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 
 			boolean writeObject = false;
 
-			if (persistSettings &&
-				!layout.isPortletEmbedded(
-					portlet.getPortletId(), layout.getGroupId())) {
-
-				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-					themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId(),
-					PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
-					PortletKeys.PREFS_PLID_SHARED, portletInstanceKey,
-					defaultPreferences);
-
-				writeObject = true;
-			}
-
 			if (persistSettings) {
+				if (!layout.isPortletEmbedded(
+						portlet.getPortletId(), layout.getGroupId())) {
+
+					PortletPreferencesFactoryUtil.getLayoutPortletSetup(
+						themeDisplay.getCompanyId(),
+						themeDisplay.getScopeGroupId(),
+						PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+						PortletKeys.PREFS_PLID_SHARED, portletInstanceKey,
+						defaultPreferences);
+
+					writeObject = true;
+				}
+
 				long count =
 					PortletPreferencesLocalServiceUtil.
 						getPortletPreferencesCount(


### PR DESCRIPTION
@dantewang, I want to firstly send it to you to review because I am not sure if this extraction is good. The previous requirement is from https://github.com/liferay-core-infra/liferay-portal/pull/255

At this pr, I extract the whole code fragment to the new method. For the invoking from TemplateProcessor#processPortlet class, it will run twice layout.isPortletEmbedded(portletId, layout.getGroupId()). I think this may be acceptable. Because after 7.0, we recommend using <liferay-portlet:runtime /> tag to embed portlets. 

I feel the new method naming seems a little strange. Maybe the method’s name is not good. I focus on the method's returned boolean type. Mostly method names called is*(), contains(), *enabled(), these methods return boolean. I feel the method naming is a little unmatched with the return type.