### PR TITLE
LPS X CleanUpLog4J

### DIFF
--- a/modules/apps/portal/portal-output-stream-container/build.gradle
+++ b/modules/apps/portal/portal-output-stream-container/build.gradle
@@ -1,6 +1,4 @@
 dependencies {
-	compileOnly group: "com.liferay", name: "org.apache.logging.log4j", version: "2.17.1.LIFERAY-PATCHED-1"
-	compileOnly group: "com.liferay", name: "org.apache.logging.log4j.core", version: "2.17.1.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"

--- a/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/OutputStreamContainerFactoryTrackerImpl.java
+++ b/modules/apps/portal/portal-output-stream-container/src/main/java/com/liferay/portal/output/stream/container/internal/OutputStreamContainerFactoryTrackerImpl.java
@@ -18,8 +18,10 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.log.LogListener;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.output.stream.container.OutputStreamContainer;
 import com.liferay.portal.output.stream.container.OutputStreamContainerFactory;
 import com.liferay.portal.output.stream.container.OutputStreamContainerFactoryTracker;
@@ -36,11 +38,6 @@ import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.Set;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.WriterAppender;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -168,21 +165,10 @@ public class OutputStreamContainerFactoryTrackerImpl
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		PatternLayout.Builder build = PatternLayout.newBuilder();
-
-		build.withPattern("%level - %m%n");
-
-		PatternLayout patternLayout = build.build();
-
-		_writerAppender = WriterAppender.createAppender(
-			patternLayout, null, new ThreadLocalWriter(), "WriterAppender",
-			false, false);
-
-		_writerAppender.start();
-
-		Logger rootLogger = (Logger)LogManager.getRootLogger();
-
-		rootLogger.addAppender(_writerAppender);
+		_serviceRegistrations.add(
+			bundleContext.registerService(
+				LogListener.class,
+				new WriterLogListener(new ThreadLocalWriter()), null));
 
 		Dictionary<String, Object> dictionary =
 			HashMapDictionaryBuilder.<String, Object>put(
@@ -231,12 +217,6 @@ public class OutputStreamContainerFactoryTrackerImpl
 		}
 
 		_serviceRegistrations.clear();
-
-		Logger rootLogger = (Logger)LogManager.getRootLogger();
-
-		if (rootLogger != null) {
-			rootLogger.removeAppender(_writerAppender);
-		}
 	}
 
 	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED, unbind = "-")
@@ -259,7 +239,6 @@ public class OutputStreamContainerFactoryTrackerImpl
 
 	private final List<ServiceRegistration<?>> _serviceRegistrations =
 		new ArrayList<>();
-	private WriterAppender _writerAppender;
 	private final ThreadLocal<Writer> _writerThreadLocal = new ThreadLocal<>();
 
 	private class ThreadLocalWriter extends Writer {
@@ -292,6 +271,35 @@ public class OutputStreamContainerFactoryTrackerImpl
 				writer.write(chars, offset, length);
 			}
 		}
+
+	}
+
+	private class WriterLogListener implements LogListener {
+
+		public WriterLogListener(Writer writer) {
+			_writer = writer;
+		}
+
+		@Override
+		public void onLogged(
+			String level, String loggerName, String formattedMessage) {
+
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(level);
+			sb.append(" - ");
+			sb.append(formattedMessage);
+			sb.append(System.lineSeparator());
+
+			try {
+				_writer.write(sb.toString());
+			}
+			catch (IOException ioException) {
+				_log.error(ioException);
+			}
+		}
+
+		private final Writer _writer;
 
 	}
 

--- a/modules/apps/portal/portal-upgrade-impl/build.gradle
+++ b/modules/apps/portal/portal-upgrade-impl/build.gradle
@@ -4,8 +4,6 @@ dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay", name: "org.apache.felix.configadmin", version: "1.9.8.LIFERAY-PATCHED-6"
 	compileOnly group: "com.liferay", name: "org.apache.felix.gogo.runtime", version: "1.1.2.LIFERAY-PATCHED-1"
-	compileOnly group: "com.liferay", name: "org.apache.logging.log4j", version: "2.17.1.LIFERAY-PATCHED-1"
-	compileOnly group: "com.liferay", name: "org.apache.logging.log4j.core", version: "2.17.1.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "commons-io", name: "commons-io", version: "2.8.0"

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogAppender.java
@@ -14,23 +14,14 @@
 
 package com.liferay.portal.upgrade.internal.apache.logging.log4j.core;
 
+import com.liferay.portal.kernel.log.LogListener;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.upgrade.internal.release.osgi.commands.ReleaseManagerOSGiCommands;
 import com.liferay.portal.upgrade.internal.report.UpgradeReport;
 
-import java.io.Serializable;
-
 import java.util.Objects;
 
 import org.apache.felix.cm.PersistenceManager;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.ErrorHandler;
-import org.apache.logging.log4j.core.Layout;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.message.Message;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -40,64 +31,10 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
  * @author Sam Ziemer
  */
 @Component(
-	immediate = true, property = "appender.name=UpgradeReportLogAppender",
-	service = Appender.class
+	immediate = true, property = "log.listener.name=UpgradeReportLogListener",
+	service = LogListener.class
 )
-public class UpgradeReportLogAppender implements Appender {
-
-	@Override
-	public void append(LogEvent logEvent) {
-		Message message = logEvent.getMessage();
-
-		if (logEvent.getLevel() == Level.ERROR) {
-			_upgradeReport.addErrorMessage(
-				logEvent.getLoggerName(), message.getFormattedMessage());
-		}
-		else if (logEvent.getLevel() == Level.INFO) {
-			String formattedMessage = message.getFormattedMessage();
-
-			if (Objects.equals(
-					logEvent.getLoggerName(), UpgradeProcess.class.getName()) &&
-				formattedMessage.startsWith("Completed upgrade process ")) {
-
-				_upgradeReport.addEventMessage(
-					logEvent.getLoggerName(), formattedMessage);
-			}
-		}
-		else if (logEvent.getLevel() == Level.WARN) {
-			_upgradeReport.addWarningMessage(
-				logEvent.getLoggerName(), message.getFormattedMessage());
-		}
-	}
-
-	@Override
-	public ErrorHandler getHandler() {
-		return null;
-	}
-
-	@Override
-	public Layout<? extends Serializable> getLayout() {
-		return null;
-	}
-
-	@Override
-	public String getName() {
-		return "UpgradeReportLogAppender";
-	}
-
-	@Override
-	public State getState() {
-		return null;
-	}
-
-	@Override
-	public boolean ignoreExceptions() {
-		return false;
-	}
-
-	@Override
-	public void initialize() {
-	}
+public class UpgradeReportLogAppender implements LogListener {
 
 	@Override
 	public boolean isStarted() {
@@ -105,12 +42,22 @@ public class UpgradeReportLogAppender implements Appender {
 	}
 
 	@Override
-	public boolean isStopped() {
-		return !_started;
-	}
+	public void onLogged(
+		String level, String loggerName, String formattedMessage) {
 
-	@Override
-	public void setHandler(ErrorHandler handler) {
+		if (level.equals("INFO")) {
+			if (Objects.equals(loggerName, UpgradeProcess.class.getName()) &&
+				formattedMessage.startsWith("Completed upgrade process ")) {
+
+				_upgradeReport.addEventMessage(loggerName, formattedMessage);
+			}
+		}
+		else if (level.equals("WARN")) {
+			_upgradeReport.addWarningMessage(loggerName, formattedMessage);
+		}
+		else if (level.equals("ERROR")) {
+			_upgradeReport.addErrorMessage(loggerName, formattedMessage);
+		}
 	}
 
 	@Override
@@ -118,8 +65,6 @@ public class UpgradeReportLogAppender implements Appender {
 		_started = true;
 
 		_upgradeReport = new UpgradeReport();
-
-		_rootLogger.addAppender(this);
 	}
 
 	@Override
@@ -133,9 +78,6 @@ public class UpgradeReportLogAppender implements Appender {
 
 		_started = false;
 	}
-
-	private static final Logger _rootLogger =
-		(Logger)LogManager.getRootLogger();
 
 	@Reference
 	private PersistenceManager _persistenceManager;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogListener.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/apache/logging/log4j/core/UpgradeReportLogListener.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 	immediate = true, property = "log.listener.name=UpgradeReportLogListener",
 	service = LogListener.class
 )
-public class UpgradeReportLogAppender implements LogListener {
+public class UpgradeReportLogListener implements LogListener {
 
 	@Override
 	public boolean isStarted() {

--- a/modules/apps/portal/portal-upgrade-test/build.gradle
+++ b/modules/apps/portal/portal-upgrade-test/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-	testIntegrationCompile group: "com.liferay", name: "org.apache.logging.log4j.core", version: "2.17.1.LIFERAY-PATCHED-1"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationCompile group: "org.osgi", name: "osgi.core", version: "6.0.0"

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogListenerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeReportLogListenerTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.log.LogListener;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -42,8 +43,6 @@ import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.logging.log4j.core.Appender;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -57,7 +56,7 @@ import org.junit.runner.RunWith;
  * @author Sam Ziemer
  */
 @RunWith(Arquillian.class)
-public class UpgradeReportLogAppenderTest {
+public class UpgradeReportLogListenerTest {
 
 	@ClassRule
 	@Rule
@@ -82,7 +81,7 @@ public class UpgradeReportLogAppenderTest {
 
 	@After
 	public void tearDown() {
-		_appender.stop();
+		_logListener.stop();
 
 		_reportContent = null;
 
@@ -103,13 +102,13 @@ public class UpgradeReportLogAppenderTest {
 	public void testDatabaseTablesCounts() throws Exception {
 		_db.runSQL("insert into UpgradeReportTable2 (id_) values (1)");
 
-		_appender.start();
+		_logListener.start();
 
 		_db.runSQL("insert into UpgradeReportTable1 (id_) values (1)");
 
 		_db.runSQL("delete from UpgradeReportTable2 where id_ = 1");
 
-		_appender.stop();
+		_logListener.stop();
 
 		if (_reportContent == null) {
 			_reportContent = _getReportContent();
@@ -150,9 +149,9 @@ public class UpgradeReportLogAppenderTest {
 
 	@Test
 	public void testDatabaseTablesIsSorted() throws Exception {
-		_appender.start();
+		_logListener.start();
 
-		_appender.stop();
+		_logListener.stop();
 
 		if (_reportContent == null) {
 			_reportContent = _getReportContent();
@@ -182,7 +181,7 @@ public class UpgradeReportLogAppenderTest {
 
 	@Test
 	public void testInfoEventsInOrder() throws Exception {
-		_appender.start();
+		_logListener.start();
 
 		Log log = LogFactoryUtil.getLog(UpgradeProcess.class);
 
@@ -200,7 +199,7 @@ public class UpgradeReportLogAppenderTest {
 			"Completed upgrade process " + slowerUpgradeProcessName +
 				" in 20401 ms");
 
-		_appender.stop();
+		_logListener.stop();
 
 		String reportContent = _getReportContent();
 
@@ -211,9 +210,9 @@ public class UpgradeReportLogAppenderTest {
 
 	@Test
 	public void testLogEvents() throws Exception {
-		_appender.start();
+		_logListener.start();
 
-		Log log = LogFactoryUtil.getLog(UpgradeReportLogAppenderTest.class);
+		Log log = LogFactoryUtil.getLog(UpgradeReportLogListenerTest.class);
 
 		log.warn("Warning");
 		log.warn("Warning");
@@ -224,7 +223,7 @@ public class UpgradeReportLogAppenderTest {
 			"Completed upgrade process com.liferay.portal.UpgradeTest in " +
 				"20401 ms");
 
-		_appender.stop();
+		_logListener.stop();
 
 		_assertReport("2 occurrences of the following warnings: Warning");
 		_assertReport(
@@ -243,9 +242,9 @@ public class UpgradeReportLogAppenderTest {
 
 		_releaseLocalService.updateRelease(release);
 
-		_appender.start();
+		_logListener.start();
 
-		_appender.stop();
+		_logListener.stop();
 
 		release = _releaseLocalService.fetchRelease(bundleSymbolicName);
 
@@ -261,9 +260,9 @@ public class UpgradeReportLogAppenderTest {
 
 	@Test
 	public void testNoLogEvents() throws Exception {
-		_appender.start();
+		_logListener.start();
 
-		_appender.stop();
+		_logListener.stop();
 
 		_assertReport("No errors thrown during upgrade");
 		_assertReport("No upgrade processes registered");
@@ -272,9 +271,9 @@ public class UpgradeReportLogAppenderTest {
 
 	@Test
 	public void testProperties() throws Exception {
-		_appender.start();
+		_logListener.start();
 
-		_appender.stop();
+		_logListener.stop();
 
 		_assertReport(
 			StringBundler.concat(
@@ -302,7 +301,7 @@ public class UpgradeReportLogAppenderTest {
 
 		_releaseLocalService.updateRelease(release);
 
-		_appender.start();
+		_logListener.start();
 
 		release = _releaseLocalService.getRelease(1);
 
@@ -311,7 +310,7 @@ public class UpgradeReportLogAppenderTest {
 
 		_releaseLocalService.updateRelease(release);
 
-		_appender.stop();
+		_logListener.stop();
 
 		Version latestSchemaVersion =
 			PortalUpgradeProcess.getLatestSchemaVersion();
@@ -353,8 +352,8 @@ public class UpgradeReportLogAppenderTest {
 	private static final Pattern _pattern = Pattern.compile(
 		"(\\w+_?)\\s+(\\d+|-)\\s+(\\d+|-)\n");
 
-	@Inject
-	private Appender _appender;
+	@Inject(filter = "log.listener.name=UpgradeReportLogListener")
+	private LogListener _logListener;
 
 	@Inject
 	private ReleaseLocalService _releaseLocalService;

--- a/portal-impl/src/com/liferay/portal/log/Log4jLogFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/log/Log4jLogFactoryImpl.java
@@ -14,10 +14,22 @@
 
 package com.liferay.portal.log;
 
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactory;
+import com.liferay.portal.kernel.log.LogListener;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.util.BasePortalLifecycle;
+import com.liferay.portal.kernel.util.PortalLifecycle;
+import com.liferay.portal.kernel.util.PortalLifecycleUtil;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.message.Message;
 
 /**
  * @author Brian Wing Shun Chan
@@ -33,6 +45,85 @@ public class Log4jLogFactoryImpl implements LogFactory {
 	public Log getLog(String name) {
 		return new Log4jLogContextLogWrapper(
 			new Log4jLogImpl(LogManager.getLogger(name)));
+	}
+
+	private static volatile ServiceTrackerList<LogListener> _serviceTrackerList;
+	private static volatile LogListenerAppender _logListenerAppender;
+
+	private static class LogListenerAppender extends AbstractAppender {
+
+		public LogListenerAppender() {
+			super(LogListenerAppender.class.getName(), null, null, false, null);
+		}
+
+		@Override
+		public void append(LogEvent logEvent) {
+			ServiceTrackerList<LogListener> serviceTrackerList =
+				_serviceTrackerList;
+
+			if (serviceTrackerList == null) {
+				return;
+			}
+
+			for (LogListener logListener : _serviceTrackerList) {
+				if (!logListener.isStarted()) {
+					continue;
+				}
+
+				Level level = logEvent.getLevel();
+
+				Message message = logEvent.getMessage();
+
+				logListener.onLogged(
+					level.toString(), logEvent.getLoggerName(),
+					message.getFormattedMessage());
+			}
+		}
+
+	}
+
+	static {
+		PortalLifecycleUtil.register(
+			new BasePortalLifecycle() {
+
+				@Override
+				protected void doPortalDestroy() {
+					ServiceTrackerList<LogListener> serviceTrackerList =
+						_serviceTrackerList;
+
+					_serviceTrackerList = null;
+
+					if (serviceTrackerList != null) {
+						serviceTrackerList.close();
+					}
+
+					LogListenerAppender logListenerAppender =
+						_logListenerAppender;
+
+					_logListenerAppender = null;
+
+					if (logListenerAppender != null) {
+						logListenerAppender.stop();
+					}
+				}
+
+				@Override
+				protected void doPortalInit() {
+					_serviceTrackerList = ServiceTrackerListFactory.open(
+						SystemBundleUtil.getBundleContext(), LogListener.class);
+
+					Logger rootLogger = (Logger)LogManager.getRootLogger();
+
+					_logListenerAppender =
+						new LogListenerAppender();
+
+					_logListenerAppender.start();
+
+					rootLogger.addAppender(_logListenerAppender);
+				}
+
+			},
+			PortalLifecycle.METHOD_ALL);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/log/Log4jLogFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/log/Log4jLogFactoryImpl.java
@@ -47,8 +47,8 @@ public class Log4jLogFactoryImpl implements LogFactory {
 			new Log4jLogImpl(LogManager.getLogger(name)));
 	}
 
-	private static volatile ServiceTrackerList<LogListener> _serviceTrackerList;
 	private static volatile LogListenerAppender _logListenerAppender;
+	private static volatile ServiceTrackerList<LogListener> _serviceTrackerList;
 
 	private static class LogListenerAppender extends AbstractAppender {
 
@@ -114,8 +114,7 @@ public class Log4jLogFactoryImpl implements LogFactory {
 
 					Logger rootLogger = (Logger)LogManager.getRootLogger();
 
-					_logListenerAppender =
-						new LogListenerAppender();
+					_logListenerAppender = new LogListenerAppender();
 
 					_logListenerAppender.start();
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.log.LogListener;
 import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
@@ -57,7 +58,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import org.apache.commons.lang.time.StopWatch;
-import org.apache.logging.log4j.core.Appender;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -124,7 +124,7 @@ public class DBUpgrader {
 					ProxyModeThreadLocal.setWithSafeCloseable(false)) {
 
 				if (PropsValues.UPGRADE_REPORT_ENABLED) {
-					_startUpgradeReportLogAppender();
+					_startUpgradeReportLogListener();
 				}
 
 				upgrade();
@@ -143,7 +143,7 @@ public class DBUpgrader {
 		}
 		finally {
 			if (PropsValues.UPGRADE_REPORT_ENABLED) {
-				_stopUpgradeReportLogAppender();
+				_stopUpgradeReportLogListener();
 			}
 		}
 
@@ -266,32 +266,32 @@ public class DBUpgrader {
 			).build());
 	}
 
-	private static void _startUpgradeReportLogAppender() {
+	private static void _startUpgradeReportLogListener() {
 		ServiceLatch serviceLatch = SystemBundleUtil.newServiceLatch();
 
-		serviceLatch.<Appender>waitFor(
+		serviceLatch.<LogListener>waitFor(
 			StringBundler.concat(
-				"(&(appender.name=UpgradeReportLogAppender)(objectClass=",
-				Appender.class.getName(), "))"),
-			appender -> {
-				_appender = appender;
+				"(&(log.listener.name=UpgradeReportLogListener)(objectClass=",
+				LogListener.class.getName(), "))"),
+			logListener -> {
+				_logListener = logListener;
 
-				_appender.start();
+				_logListener.start();
 			});
 		serviceLatch.openOn(
 			() -> {
 			});
 	}
 
-	private static void _stopUpgradeReportLogAppender() {
-		if (_appender != null) {
-			_appender.stop();
+	private static void _stopUpgradeReportLogListener() {
+		if (_logListener != null) {
+			_logListener.stop();
 		}
 
-		if (_appenderServiceReference != null) {
+		if (_logListenerServiceReference != null) {
 			BundleContext bundleContext = SystemBundleUtil.getBundleContext();
 
-			bundleContext.ungetService(_appenderServiceReference);
+			bundleContext.ungetService(_logListenerServiceReference);
 		}
 	}
 
@@ -423,8 +423,8 @@ public class DBUpgrader {
 
 	private static final Log _log = LogFactoryUtil.getLog(DBUpgrader.class);
 
-	private static volatile Appender _appender;
-	private static volatile ServiceReference<Appender>
-		_appenderServiceReference;
+	private static volatile LogListener _logListener;
+	private static volatile ServiceReference<LogListener>
+		_logListenerServiceReference;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/log/LogListener.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/log/LogListener.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.log;
+
+/**
+ * @author Dante Wang
+ */
+public interface LogListener {
+
+	public boolean isStarted();
+
+	public void onLogged(
+		String level, String loggerName, String formattedMessage);
+
+	public void start();
+
+	public void stop();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/log/LogListener.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/log/LogListener.java
@@ -19,13 +19,17 @@ package com.liferay.portal.kernel.log;
  */
 public interface LogListener {
 
-	public boolean isStarted();
+	public default boolean isStarted() {
+		return true;
+	}
 
 	public void onLogged(
 		String level, String loggerName, String formattedMessage);
 
-	public void start();
+	public default void start() {
+	}
 
-	public void stop();
+	public default void stop() {
+	}
 
 }


### PR DESCRIPTION
- LPS-X Add LogListener to allow for listening to log output without depending on Log4J API
- LPS-X Apply to UpgradeReportLogAppender
- LPS-X Rename
- LPS-X Make status related methods default so optional to implement
- LPS-X Apply to OutputStreamContainerFactoryTrackerImpl; it prints a very simple layout which can be simply concatenated, no need to use PatternLayout.
- LPS-X Update test
- LPS-X Remove dependencies
- LPS-X Auto SF
