### PR TITLE
[bug fix] LPS-150847 

### DIFF
--- a/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java
+++ b/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java
@@ -69,7 +69,7 @@ public class ZipWriterImpl implements ZipWriter {
 
 		URI fileURI = _file.toURI();
 
-		_uri = URI.create("jar:file:" + fileURI.getPath());
+		_uri = URI.create("jar:file:" + fileURI.getRawPath());
 
 		try (FileSystem fileSystem = FileSystems.newFileSystem(
 				_uri, Collections.singletonMap("create", "true"))) {


### PR DESCRIPTION
Hi @dantewang,

This PR is for https://issues.liferay.com/browse/LPS-150847.  Thanks!

Use getRawPath instead of getPath to avoid URISyntaxException.
If the given string contains illegal characters(violates RFC 2396), the method will throw URISyntaxException. 
Method `getRawPath()` returns the exact value of the path without decoding the sequence of escaped octets if any.