### PR TITLE
[Bug fix]LPS 155485

### DIFF
--- a/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_decline_body.tmpl
+++ b/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_decline_body.tmpl
@@ -4,4 +4,4 @@
 
 Sincerely,<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_instance_deleted_body.tmpl
+++ b/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_instance_deleted_body.tmpl
@@ -5,4 +5,4 @@ The event <a href="[$EVENT_URL$]">[$EVENT_TITLE$]</a>, that you were invited to 
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_invite_body.tmpl
+++ b/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_invite_body.tmpl
@@ -5,4 +5,4 @@ You have been invited to event <a href="[$EVENT_URL$]">[$EVENT_TITLE$]</a> that 
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_moved_to_trash_body.tmpl
+++ b/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_moved_to_trash_body.tmpl
@@ -5,4 +5,4 @@ The event <a href="[$EVENT_URL$]">[$EVENT_TITLE$]</a>, that you were invited to,
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_reminder_body.tmpl
+++ b/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_reminder_body.tmpl
@@ -5,4 +5,4 @@ Your event with the title <a href="[$EVENT_URL$]">[$EVENT_TITLE$]</a> will start
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_update_body.tmpl
+++ b/modules/apps/calendar/calendar-api/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_update_body.tmpl
@@ -5,4 +5,4 @@ The event <a href="[$EVENT_URL$]">[$EVENT_TITLE$]</a>, that you were invited to,
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_notification_templates.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_notification_templates.jspf
@@ -144,10 +144,10 @@ String notificationTemplateBody = BeanPropertiesUtil.getString(calendarNotificat
 				<%= HtmlUtil.escape(fromName) %>
 			</dd>
 			<dt>
-				[$PORTAL_URL$]
+				[$PORTAL_FRIENDLY_URL$]
 			</dt>
 			<dd>
-				<%= company.getVirtualHostname() %>
+				<%= company.getVirtualHostname() + PortalUtil.getPathContext() %>
 			</dd>
 
 			<%

--- a/modules/apps/flags/flags-service/src/main/resources/com/liferay/flags/dependencies/email_flag_body.tmpl
+++ b/modules/apps/flags/flags-service/src/main/resources/com/liferay/flags/dependencies/email_flag_body.tmpl
@@ -11,4 +11,4 @@ You are receiving this email because you are administrator of [$SITE_NAME$]. Ple
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/dependencies/email_article_approval_denied_body.tmpl
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/dependencies/email_article_approval_denied_body.tmpl
@@ -7,4 +7,4 @@ Your article with the ID [$ARTICLE_ID$] and version [$ARTICLE_VERSION$] and titl
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/dependencies/email_article_approval_granted_body.tmpl
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/dependencies/email_article_approval_granted_body.tmpl
@@ -11,4 +11,4 @@ Your article can be found at:<br /><br />
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/email.notifications/definition_of_terms.jspf
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/email.notifications/definition_of_terms.jspf
@@ -53,10 +53,10 @@
 	</c:if>
 
 	<dt>
-		[$PORTAL_URL$]
+		[$PORTAL_FRIENDLY_URL$]
 	</dt>
 	<dd>
-		<%= company.getPortalURL(GroupConstants.DEFAULT_PARENT_GROUP_ID) %>
+		<%= company.getPortalURL(GroupConstants.DEFAULT_PARENT_GROUP_ID) + PortalUtil.getPathContext() %>
 	</dd>
 	<dt class="password-changed-notification">
 		[$REMOTE_ADDRESS$]

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/configuration/dependencies/email_page_added_body.tmpl
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/configuration/dependencies/email_page_added_body.tmpl
@@ -10,6 +10,6 @@
 
 	<p>
 		[$COMPANY_NAME$] Wiki<br />
-		[$PORTAL_URL$]
+		[$PORTAL_FRIENDLY_URL$]
 	</p>
 </div>

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/configuration/dependencies/email_page_updated_body.tmpl
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/configuration/dependencies/email_page_updated_body.tmpl
@@ -10,6 +10,6 @@
 
 	<p>
 		[$COMPANY_NAME$] Wiki<br />
-		[$PORTAL_URL$]
+		[$PORTAL_FRIENDLY_URL$]
 	</p>
 </div>

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-api/src/main/resources/com/liferay/multi/factor/authentication/email/otp/configuration/dependencies/email_otp_sent_body.tmpl
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-api/src/main/resources/com/liferay/multi/factor/authentication/email/otp/configuration/dependencies/email_otp_sent_body.tmpl
@@ -1,6 +1,6 @@
 [$TO_NAME$],<br /><br />
 
-Somebody requested a one-time password to access [$PORTAL_URL$]. <b>Ignore this email if you did not make the request.</b><br /><br />
+Somebody requested a one-time password to access [$PORTAL_FRIENDLY_URL$]. <b>Ignore this email if you did not make the request.</b><br /><br />
 
 Your one-time password is: <pre>[$ONE_TIME_PASSWORD$]</pre><br /><br />
 
@@ -9,4 +9,4 @@ The request was made from [$REMOTE_ADDRESS$] / [$REMOTE_HOST$].<br /><br />
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-api/src/main/resources/com/liferay/multi/factor/authentication/email/otp/configuration/dependencies/email_otp_sent_subject.tmpl
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-api/src/main/resources/com/liferay/multi/factor/authentication/email/otp/configuration/dependencies/email_otp_sent_subject.tmpl
@@ -1,1 +1,1 @@
-[$PORTAL_URL$]: Your One-Time Password
+[$PORTAL_FRIENDLY_URL$]: Your One-Time Password

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/java/com/liferay/multi/factor/authentication/email/otp/web/internal/portlet/action/SendMFAEmailOTPMVCResourceCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/java/com/liferay/multi/factor/authentication/email/otp/web/internal/portlet/action/SendMFAEmailOTPMVCResourceCommand.java
@@ -207,6 +207,10 @@ public class SendMFAEmailOTPMVCResourceCommand implements MVCResourceCommand {
 		mailTemplateContextBuilder.put(
 			"[$PORTAL_URL$]", _portal.getPortalURL(httpServletRequest));
 		mailTemplateContextBuilder.put(
+			"[$PORTAL_FRIENDLY_URL$]",
+			_portal.getPortalURL(httpServletRequest) +
+				_portal.getPathContext());
+		mailTemplateContextBuilder.put(
 			"[$REMOTE_ADDRESS$]", httpServletRequest.getRemoteAddr());
 		mailTemplateContextBuilder.put(
 			"[$REMOTE_HOST$]",

--- a/portal-impl/src/com/liferay/portal/service/impl/MembershipRequestLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/MembershipRequestLocalServiceImpl.java
@@ -370,6 +370,9 @@ public class MembershipRequestLocalServiceImpl
 		mailTemplateContextBuilder.put(
 			"[$PORTAL_URL$]", company.getPortalURL(0));
 		mailTemplateContextBuilder.put(
+			"[$PORTAL_FRIENDLY_URL$]",
+			company.getPortalURL(0) + PortalUtil.getPathContext());
+		mailTemplateContextBuilder.put(
 			"[$REPLY_COMMENTS$]",
 			HtmlUtil.escape(membershipRequest.getReplyComments()));
 		mailTemplateContextBuilder.put(

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -3718,6 +3718,9 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		mailTemplateContextBuilder.put(
 			"[$PORTAL_URL$]", serviceContext.getPortalURL());
 		mailTemplateContextBuilder.put(
+			"[$PORTAL_FRIENDLY_URL$]",
+			serviceContext.getPortalURL() + PortalUtil.getPathContext());
+		mailTemplateContextBuilder.put(
 			"[$REMOTE_ADDRESS$]", serviceContext.getRemoteAddr());
 		mailTemplateContextBuilder.put(
 			"[$REMOTE_HOST$]", HtmlUtil.escape(serviceContext.getRemoteHost()));
@@ -6097,7 +6100,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		String fromName = PrefsPropsUtil.getString(
 			user.getCompanyId(), PropsKeys.ADMIN_EMAIL_FROM_NAME);
 		String passwordResetURL = StringPool.BLANK;
-		String portalURL = serviceContext.getPortalURL();
 
 		PortletPreferences companyPortletPreferences =
 			PrefsPropsUtil.getPreferences(user.getCompanyId(), true);
@@ -6158,7 +6160,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		mailTemplateContextBuilder.put("[$FROM_ADDRESS$]", fromAddress);
 		mailTemplateContextBuilder.put(
 			"[$FROM_NAME$]", HtmlUtil.escape(fromName));
-		mailTemplateContextBuilder.put("[$PORTAL_URL$]", portalURL);
+		mailTemplateContextBuilder.put(
+			"[$PORTAL_URL$]", serviceContext.getPortalURL());
+		mailTemplateContextBuilder.put(
+			"[$PORTAL_FRIENDLY_URL$]",
+			serviceContext.getPortalURL() + PortalUtil.getPathContext());
 		mailTemplateContextBuilder.put(
 			"[$TO_ADDRESS$]", user.getEmailAddress());
 		mailTemplateContextBuilder.put(
@@ -6330,6 +6336,9 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			"[$PASSWORD_RESET_URL$]", passwordResetURL);
 		mailTemplateContextBuilder.put(
 			"[$PORTAL_URL$]", serviceContext.getPortalURL());
+		mailTemplateContextBuilder.put(
+			"[$PORTAL_FRIENDLY_URL$]",
+			serviceContext.getPortalURL() + PortalUtil.getPathContext());
 		mailTemplateContextBuilder.put(
 			"[$REMOTE_ADDRESS$]", serviceContext.getRemoteAddr());
 		mailTemplateContextBuilder.put(

--- a/portal-impl/src/com/liferay/portlet/admin/dependencies/email_password_changed_body.tmpl
+++ b/portal-impl/src/com/liferay/portlet/admin/dependencies/email_password_changed_body.tmpl
@@ -1,10 +1,10 @@
 Dear [$TO_NAME$],<br /><br />
 
-Your password for [$PORTAL_URL$] has been changed.<br /><br />
+Your password for [$PORTAL_FRIENDLY_URL$] has been changed.<br /><br />
 
 The request for a new password was made from [$REMOTE_ADDRESS$] / [$REMOTE_HOST$].<br /><br />
 
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/portal-impl/src/com/liferay/portlet/admin/dependencies/email_password_changed_subject.tmpl
+++ b/portal-impl/src/com/liferay/portlet/admin/dependencies/email_password_changed_subject.tmpl
@@ -1,1 +1,1 @@
-[$PORTAL_URL$]: Your Password Has Been Changed
+[$PORTAL_FRIENDLY_URL$]: Your Password Has Been Changed

--- a/portal-impl/src/com/liferay/portlet/admin/dependencies/email_password_reset_body.tmpl
+++ b/portal-impl/src/com/liferay/portlet/admin/dependencies/email_password_reset_body.tmpl
@@ -1,10 +1,10 @@
 Dear [$TO_NAME$],<br /><br />
 
-You can reset your password for [$PORTAL_URL$] at [$PASSWORD_RESET_URL$].<br /><br />
+You can reset your password for [$PORTAL_FRIENDLY_URL$] at [$PASSWORD_RESET_URL$].<br /><br />
 
 The request for a new password was made from [$REMOTE_ADDRESS$] / [$REMOTE_HOST$].<br /><br />
 
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/portal-impl/src/com/liferay/portlet/admin/dependencies/email_password_reset_subject.tmpl
+++ b/portal-impl/src/com/liferay/portlet/admin/dependencies/email_password_reset_subject.tmpl
@@ -1,1 +1,1 @@
-[$PORTAL_URL$]: Reset Your Password
+[$PORTAL_FRIENDLY_URL$]: Reset Your Password

--- a/portal-impl/src/com/liferay/portlet/admin/dependencies/email_user_added_no_password_body.tmpl
+++ b/portal-impl/src/com/liferay/portlet/admin/dependencies/email_user_added_no_password_body.tmpl
@@ -1,8 +1,8 @@
 Dear new user,<br /><br />
 
-Welcome! You recently created an account at [$PORTAL_URL$].<br /><br />
+Welcome! You recently created an account at [$PORTAL_FRIENDLY_URL$].<br /><br />
 
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/portal-impl/src/com/liferay/portlet/admin/dependencies/email_user_added_reset_password_body.tmpl
+++ b/portal-impl/src/com/liferay/portlet/admin/dependencies/email_user_added_reset_password_body.tmpl
@@ -1,10 +1,10 @@
 Dear new user,<br /><br />
 
-Welcome! You recently created an account at [$PORTAL_URL$].
+Welcome! You recently created an account at [$PORTAL_FRIENDLY_URL$].
 
 Your can setup your password here: [$PASSWORD_SETUP_URL$]<br /><br /> Enjoy!<br /><br />
 
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/portal-impl/src/com/liferay/portlet/admin/dependencies/email_user_added_subject.tmpl
+++ b/portal-impl/src/com/liferay/portlet/admin/dependencies/email_user_added_subject.tmpl
@@ -1,1 +1,1 @@
-[$PORTAL_URL$]: Your New Account
+[$PORTAL_FRIENDLY_URL$]: Your New Account

--- a/portal-impl/src/com/liferay/portlet/admin/dependencies/email_verification_body.tmpl
+++ b/portal-impl/src/com/liferay/portlet/admin/dependencies/email_verification_body.tmpl
@@ -1,10 +1,10 @@
 Dear new user,<br /><br />
 
-Please verify your email address for [$PORTAL_URL$] at [$EMAIL_VERIFICATION_URL$].<br /><br />
+Please verify your email address for [$PORTAL_FRIENDLY_URL$] at [$EMAIL_VERIFICATION_URL$].<br /><br />
 
 Your verification code is [$EMAIL_VERIFICATION_CODE$]<br /><br />
 
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/portal-impl/src/com/liferay/portlet/admin/dependencies/email_verification_subject.tmpl
+++ b/portal-impl/src/com/liferay/portlet/admin/dependencies/email_verification_subject.tmpl
@@ -1,1 +1,1 @@
-[$PORTAL_URL$]: Email Address Verification
+[$PORTAL_FRIENDLY_URL$]: Email Address Verification

--- a/portal-impl/src/com/liferay/portlet/announcements/dependencies/email_body.tmpl
+++ b/portal-impl/src/com/liferay/portlet/announcements/dependencies/email_body.tmpl
@@ -3,4 +3,4 @@
 --<br />
 [$ENTRY_TITLE$]<br />
 [$ENTRY_URL$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsEntryLocalServiceImpl.java
@@ -679,6 +679,9 @@ public class AnnouncementsEntryLocalServiceImpl
 		mailTemplateContextBuilder.put(
 			"[$PORTAL_URL$]", company.getPortalURL(0));
 		mailTemplateContextBuilder.put(
+			"[$PORTAL_FRIENDLY_URL$]",
+			company.getPortalURL(0) + PortalUtil.getPathContext());
+		mailTemplateContextBuilder.put(
 			"[$PORTLET_NAME$]",
 			new EscapableLocalizableFunction(
 				locale -> LanguageUtil.get(

--- a/portal-impl/src/com/liferay/portlet/messageboards/dependencies/email_message_added_body.tmpl
+++ b/portal-impl/src/com/liferay/portlet/messageboards/dependencies/email_message_added_body.tmpl
@@ -3,4 +3,4 @@
 [$COMPANY_NAME$] Message Boards<br />
 [$MESSAGE_URL$]<br />
 [$MAILING_LIST_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/portal-impl/src/com/liferay/portlet/messageboards/dependencies/email_message_updated_body.tmpl
+++ b/portal-impl/src/com/liferay/portlet/messageboards/dependencies/email_message_updated_body.tmpl
@@ -3,4 +3,4 @@
 [$COMPANY_NAME$] Message Boards<br />
 [$MESSAGE_URL$]<br />
 [$MAILING_LIST_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/portal-impl/src/com/liferay/portlet/sites/dependencies/email_membership_reply_body.tmpl
+++ b/portal-impl/src/com/liferay/portlet/sites/dependencies/email_membership_reply_body.tmpl
@@ -11,4 +11,4 @@ Here are some comments made by the site administrator:<br /><br />
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/portal-impl/src/com/liferay/portlet/sites/dependencies/email_membership_request_body.tmpl
+++ b/portal-impl/src/com/liferay/portlet/sites/dependencies/email_membership_request_body.tmpl
@@ -13,4 +13,4 @@ The user added the following comments to the request:<br /><br />
 Sincerely,<br />
 [$FROM_NAME$]<br />
 [$FROM_ADDRESS$]<br />
-[$PORTAL_URL$]
+[$PORTAL_FRIENDLY_URL$]

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -357,6 +357,11 @@ public class SubscriptionSender implements Serializable {
 				"[$PORTAL_URL$]", company.getPortalURL(groupId));
 		}
 
+		setContextAttribute(
+			"[$PORTAL_FRIENDLY_URL$]",
+			getContextAttribute("[$PORTAL_URL$]") +
+				PortalUtil.getPathContext());
+
 		if (groupId > 0) {
 			Group group = GroupLocalServiceUtil.getGroup(groupId);
 


### PR DESCRIPTION
Hi @dantewang 

This is for [LPS-155485](https://issues.liferay.com/browse/LPS-155485): Wrong PORTAL_URL in email templates in non-root context.

The bug?  is only related to page display.  I added an attribute `[PORTAL_FRIENDLY_URL]` to the templates to ensure the display URL contains path context.  thanks!