### PR TITLE
LPS 154828 6 9 2

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/util/PingbackMethodImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/util/PingbackMethodImpl.java
@@ -46,9 +46,7 @@ import com.liferay.portal.kernel.xmlrpc.XmlRpc;
 import com.liferay.portal.kernel.xmlrpc.XmlRpcConstants;
 import com.liferay.portal.util.PropsValues;
 
-import java.net.InetAddress;
 import java.net.URL;
-import java.net.UnknownHostException;
 
 import java.util.HashMap;
 import java.util.List;
@@ -138,22 +136,12 @@ public class PingbackMethodImpl implements Method {
 		}
 	}
 
-	public void setInetAddressLookup(InetAddressLookup inetAddressLookup) {
-		_inetAddressLookup = inetAddressLookup;
-	}
-
 	public void setPingbackProperties(PingbackProperties pingbackProperties) {
 		_pingbackProperties = pingbackProperties;
 	}
 
 	public void setPortletIdLookup(PortletIdLookup portletIdLookup) {
 		_portletIdLookup = portletIdLookup;
-	}
-
-	public interface InetAddressLookup {
-
-		public InetAddress getInetAddressByName(String domain);
-
 	}
 
 	public interface PingbackProperties {
@@ -348,16 +336,6 @@ public class PingbackMethodImpl implements Method {
 		return StringPool.BLANK;
 	}
 
-	private InetAddress _getInetAddressByName(String domain)
-		throws UnknownHostException {
-
-		if (_inetAddressLookup != null) {
-			return _inetAddressLookup.getInetAddressByName(domain);
-		}
-
-		return InetAddressUtil.getInetAddressByName(domain);
-	}
-
 	private int _getLinkbackExcerptLength() {
 		if (_pingbackProperties != null) {
 			return _pingbackProperties.getLinkbackExcerptLength();
@@ -406,8 +384,7 @@ public class PingbackMethodImpl implements Method {
 		try {
 			URL url = new URL(_sourceURI);
 
-			return InetAddressUtil.isLocalInetAddress(
-				_getInetAddressByName(url.getHost()));
+			return InetAddressUtil.isLocalHost(url.getHost());
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -466,7 +443,6 @@ public class PingbackMethodImpl implements Method {
 	@Reference
 	private Http _http;
 
-	private InetAddressLookup _inetAddressLookup;
 	private PingbackProperties _pingbackProperties;
 
 	@Reference

--- a/modules/apps/blogs/blogs-service/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java
+++ b/modules/apps/blogs/blogs-service/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java
@@ -411,7 +411,6 @@ public class PingbackMethodImplTest {
 	private PingbackMethodImpl _getPingbackMethodImpl() {
 		PingbackMethodImpl pingbackMethodImpl = new PingbackMethodImpl();
 
-		pingbackMethodImpl.setInetAddressLookup(_inetAddressLookup);
 		pingbackMethodImpl.setPingbackProperties(_pingbackProperties);
 		pingbackMethodImpl.setPortletIdLookup(_portletIdLookup);
 
@@ -739,9 +738,6 @@ public class PingbackMethodImplTest {
 
 	@Mock
 	private Http _http;
-
-	@Mock
-	private PingbackMethodImpl.InetAddressLookup _inetAddressLookup;
 
 	@Mock
 	private Language _language;

--- a/modules/apps/commerce/commerce-currency-service/src/main/java/com/liferay/commerce/currency/internal/util/ECBExchangeRateProvider.java
+++ b/modules/apps/commerce/commerce-currency-service/src/main/java/com/liferay/commerce/currency/internal/util/ECBExchangeRateProvider.java
@@ -159,18 +159,13 @@ public class ECBExchangeRateProvider implements ExchangeRateProvider {
 		if (url == null) {
 			url = new URL(_url);
 
-			if (_isLocalNetworkURL(url)) {
+			if (InetAddressUtil.isLocalHost(url.getHost())) {
 				throw new PortalException(
 					"Invalid European Central Bank URL: " + url);
 			}
 		}
 
 		return url;
-	}
-
-	private boolean _isLocalNetworkURL(URL url) throws Exception {
-		return InetAddressUtil.isLocalInetAddress(
-			InetAddressUtil.getInetAddressByName(url.getHost()));
 	}
 
 	@Reference

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManager.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManager.java
@@ -50,7 +50,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 
-import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLConnection;
 
@@ -298,9 +297,7 @@ public class DLOpenerGoogleDriveManager
 					"Only HTTP links are allowed: " + url);
 			}
 
-			if (InetAddressUtil.isLocalInetAddress(
-					InetAddress.getByName(url.getHost()))) {
-
+			if (InetAddressUtil.isLocalHost(url.getHost())) {
 				throw new SecurityException(
 					"Local links are not allowed: " + url);
 			}

--- a/modules/apps/document-library/document-library-asset-auto-tagger-microsoft-cognitive-services/src/main/java/com/liferay/document/library/asset/auto/tagger/microsoft/cognitive/services/internal/MSCognitiveServicesImageAssetAutoTagProvider.java
+++ b/modules/apps/document-library/document-library-asset-auto-tagger-microsoft-cognitive-services/src/main/java/com/liferay/document/library/asset/auto/tagger/microsoft/cognitive/services/internal/MSCognitiveServicesImageAssetAutoTagProvider.java
@@ -104,9 +104,7 @@ public class MSCognitiveServicesImageAssetAutoTagProvider
 
 		URL url = new URL(apiEndpoint);
 
-		if (InetAddressUtil.isLocalInetAddress(
-				InetAddressUtil.getInetAddressByName(url.getHost()))) {
-
+		if (InetAddressUtil.isLocalHost(url.getHost())) {
 			throw new SecurityException(
 				"Microsoft Cognitive Services Image Auto Tagging API " +
 					"endpoint is a local address");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMDataProviderInstanceLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMDataProviderInstanceLocalServiceImpl.java
@@ -392,8 +392,7 @@ public class DDMDataProviderInstanceLocalServiceImpl
 		try {
 			URL url = new URL(value);
 
-			return InetAddressUtil.isLocalInetAddress(
-				InetAddressUtil.getInetAddressByName(url.getHost()));
+			return InetAddressUtil.isLocalHost(url.getHost());
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -55,7 +55,6 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.staging.StagingGroupHelper;
 
-import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
@@ -1194,10 +1193,7 @@ public class LayoutReferencesExportImportContentProcessor
 				}
 			}
 
-			if ((uri != null) &&
-				InetAddressUtil.isLocalInetAddress(
-					InetAddress.getByName(uri.getHost()))) {
-
+			if ((uri != null) && InetAddressUtil.isLocalHost(uri.getHost())) {
 				return StringBundler.concat(
 					uri.getScheme(), "://", uri.getHost(), StringPool.COLON,
 					uri.getPort());

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -50,7 +50,6 @@ import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListen
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -128,7 +127,7 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 				triggerState.toString(), new Date(),
 				_jsonFactory.createJSONObject(_jsonFactory.serialize(message)));
 
-			auditMessage.setServerName(InetAddressUtil.getLocalHostName());
+			auditMessage.setServerName(_portal.getComputerName());
 			auditMessage.setServerPort(_portal.getPortalLocalPort(false));
 
 			_auditRouter.route(auditMessage);

--- a/modules/apps/portal-security/portal-security-auto-login/src/main/java/com/liferay/portal/security/auto/login/request/header/RequestHeaderAutoLogin.java
+++ b/modules/apps/portal-security/portal-security-auto-login/src/main/java/com/liferay/portal/security/auto/login/request/header/RequestHeaderAutoLogin.java
@@ -20,12 +20,12 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
-import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
 import com.liferay.portal.kernel.security.auto.login.AutoLogin;
 import com.liferay.portal.kernel.security.auto.login.BaseAutoLogin;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -133,8 +133,8 @@ public class RequestHeaderAutoLogin extends BaseAutoLogin {
 			hostsAllowed.add(hostAllowed);
 		}
 
-		return AccessControlUtil.isAccessAllowed(
-			httpServletRequest, hostsAllowed);
+		return InetAddressUtil.isHostAllowed(
+			httpServletRequest.getRemoteAddr(), hostsAllowed);
 	}
 
 	protected boolean isEnabled(long companyId) {

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-ip-address-impl/src/main/java/com/liferay/multi/factor/authentication/ip/address/internal/checker/IPAddressHeadlessMFAChecker.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-ip-address-impl/src/main/java/com/liferay/multi/factor/authentication/ip/address/internal/checker/IPAddressHeadlessMFAChecker.java
@@ -22,10 +22,10 @@ import com.liferay.portal.kernel.audit.AuditMessage;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -74,8 +74,9 @@ public class IPAddressHeadlessMFAChecker implements HeadlessMFAChecker {
 			return false;
 		}
 
-		if (AccessControlUtil.isAccessAllowed(
-				httpServletRequest, _allowedIpAddressesAndNetmasks)) {
+		if (InetAddressUtil.isHostAllowed(
+				httpServletRequest.getRemoteAddr(),
+				_allowedIpAddressesAndNetmasks)) {
 
 			_routeAuditMessage(
 				_mfaIPAddressAuditMessageBuilder.

--- a/portal-impl/src/com/liferay/portal/security/access/control/AllowedHostsAccessControlPolicy.java
+++ b/portal-impl/src/com/liferay/portal/security/access/control/AllowedHostsAccessControlPolicy.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
 import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.security.access.control.BaseAccessControlPolicy;
 import com.liferay.portal.kernel.security.auth.AccessControlContext;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -73,8 +74,8 @@ public class AllowedHostsAccessControlPolicy extends BaseAccessControlPolicy {
 
 		Set<String> hostsAllowedSet = SetUtil.fromArray(hostsAllowed);
 
-		if (!AccessControlUtil.isAccessAllowed(
-				httpServletRequest, hostsAllowedSet)) {
+		if (!InetAddressUtil.isHostAllowed(
+				httpServletRequest.getRemoteAddr(), hostsAllowedSet)) {
 
 			throw new SecurityException(
 				"Access denied for " + httpServletRequest.getRemoteAddr());

--- a/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.servlet.ProtectedServletRequest;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -283,8 +284,8 @@ public class AuthVerifierFilter extends BasePortalFilter {
 
 		String remoteAddr = httpServletRequest.getRemoteAddr();
 
-		if (AccessControlUtil.isAccessAllowed(
-				httpServletRequest, _hostsAllowed)) {
+		if (InetAddressUtil.isHostAllowed(
+				httpServletRequest.getRemoteAddr(), _hostsAllowed)) {
 
 			if (_log.isDebugEnabled()) {
 				_log.debug("Access allowed for " + remoteAddr);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.auth.http.HttpAuthManagerUtil;
@@ -33,6 +32,7 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.ProtectedServletRequest;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -225,8 +225,8 @@ public abstract class BaseAuthFilter extends BasePortalFilter {
 			HttpServletResponse httpServletResponse, FilterChain filterChain)
 		throws Exception {
 
-		if (AccessControlUtil.isAccessAllowed(
-				httpServletRequest, _hostsAllowed)) {
+		if (InetAddressUtil.isHostAllowed(
+				httpServletRequest.getRemoteAddr(), _hostsAllowed)) {
 
 			if (_log.isDebugEnabled()) {
 				_log.debug(

--- a/portal-impl/src/com/liferay/portal/struts/JSONAction.java
+++ b/portal-impl/src/com/liferay/portal/struts/JSONAction.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -173,8 +174,8 @@ public abstract class JSONAction implements Action {
 		}
 
 		if (PropsValues.JSON_SERVICE_AUTH_TOKEN_ENABLED &&
-			!AccessControlUtil.isAccessAllowed(
-				httpServletRequest, _hostsAllowed)) {
+			!InetAddressUtil.isHostAllowed(
+				httpServletRequest.getRemoteAddr(), _hostsAllowed)) {
 
 			AuthTokenUtil.checkCSRFToken(
 				httpServletRequest, getCSRFOrigin(httpServletRequest));

--- a/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
+++ b/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
@@ -1110,9 +1110,7 @@ public class TemplateContextHelper {
 			if (_disableLocalNetworkAccess) {
 				URL url = new URL(location);
 
-				if (InetAddressUtil.isLocalInetAddress(
-						InetAddressUtil.getInetAddressByName(url.getHost()))) {
-
+				if (InetAddressUtil.isLocalHost(url.getHost())) {
 					return true;
 				}
 			}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
@@ -88,9 +88,7 @@ public class InetAddressUtil {
 		return InetAddress.getByName("127.0.0.1");
 	}
 
-	public static boolean isHostAllowed(String host, Set<String> allowedHosts)
-		throws UnknownHostException {
-
+	public static boolean isHostAllowed(String host, Set<String> allowedHosts) {
 		if (allowedHosts.isEmpty()) {
 			return true;
 		}
@@ -105,7 +103,12 @@ public class InetAddressUtil {
 		InetAddress inetAddress = _localHosts.get(host);
 
 		if (inetAddress == null) {
-			inetAddress = getInetAddressByName(host);
+			try {
+				inetAddress = getInetAddressByName(host);
+			}
+			catch (UnknownHostException unknownHostException) {
+				return false;
+			}
 		}
 
 		if (allowedHosts.contains(inetAddress.getHostAddress())) {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
@@ -18,9 +18,15 @@ import com.liferay.portal.kernel.concurrent.DefaultNoticeableFuture;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
+import java.net.Inet4Address;
 import java.net.InetAddress;
+import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -79,6 +85,14 @@ public class InetAddressUtil {
 		return InetAddress.getByName("127.0.0.1");
 	}
 
+	public static boolean isLocalHost(String host) throws UnknownHostException {
+		if (_localHosts.contains(host)) {
+			return true;
+		}
+
+		return isLocalInetAddress(getInetAddressByName(host));
+	}
+
 	public static boolean isLocalInetAddress(InetAddress inetAddress) {
 		if (inetAddress.isAnyLocalAddress() ||
 			inetAddress.isLinkLocalAddress() ||
@@ -101,5 +115,28 @@ public class InetAddressUtil {
 	private static final AtomicInteger _atomicInteger = new AtomicInteger(
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.DNS_SECURITY_THREAD_LIMIT)));
+	private static final Set<String> _localHosts = new HashSet<>();
+
+	static {
+		try {
+			List<NetworkInterface> networkInterfaces = Collections.list(
+				NetworkInterface.getNetworkInterfaces());
+
+			for (NetworkInterface networkInterface : networkInterfaces) {
+				List<InetAddress> inetAddresses = Collections.list(
+					networkInterface.getInetAddresses());
+
+				for (InetAddress inetAddress : inetAddresses) {
+					if (inetAddress instanceof Inet4Address) {
+						_localHosts.add(inetAddress.getHostAddress());
+						_localHosts.add(inetAddress.getHostName());
+					}
+				}
+			}
+		}
+		catch (Exception exception) {
+			_log.error("Unable to initalize local hosts", exception);
+		}
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
@@ -90,10 +90,8 @@ public class InetAddressUtil {
 			return true;
 		}
 
-		return isLocalInetAddress(getInetAddressByName(host));
-	}
+		InetAddress inetAddress = getInetAddressByName(host);
 
-	public static boolean isLocalInetAddress(InetAddress inetAddress) {
 		if (inetAddress.isAnyLocalAddress() ||
 			inetAddress.isLinkLocalAddress() ||
 			inetAddress.isLoopbackAddress() ||

--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
@@ -15,16 +15,12 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.portal.kernel.concurrent.DefaultNoticeableFuture;
-import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
-import java.net.Inet4Address;
 import java.net.InetAddress;
-import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 
-import java.util.Enumeration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -77,34 +73,6 @@ public class InetAddressUtil {
 		}
 	}
 
-	public static String getLocalHostName() throws Exception {
-		return LocalHostNameHolder._LOCAL_HOST_NAME;
-	}
-
-	public static InetAddress getLocalInetAddress() throws Exception {
-		Enumeration<NetworkInterface> enumeration1 =
-			NetworkInterface.getNetworkInterfaces();
-
-		while (enumeration1.hasMoreElements()) {
-			NetworkInterface networkInterface = enumeration1.nextElement();
-
-			Enumeration<InetAddress> enumeration2 =
-				networkInterface.getInetAddresses();
-
-			while (enumeration2.hasMoreElements()) {
-				InetAddress inetAddress = enumeration2.nextElement();
-
-				if (!inetAddress.isLoopbackAddress() &&
-					(inetAddress instanceof Inet4Address)) {
-
-					return inetAddress;
-				}
-			}
-		}
-
-		throw new SystemException("No local internet address");
-	}
-
 	public static InetAddress getLoopbackInetAddress()
 		throws UnknownHostException {
 
@@ -133,22 +101,5 @@ public class InetAddressUtil {
 	private static final AtomicInteger _atomicInteger = new AtomicInteger(
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.DNS_SECURITY_THREAD_LIMIT)));
-
-	private static class LocalHostNameHolder {
-
-		private static final String _LOCAL_HOST_NAME;
-
-		static {
-			try {
-				InetAddress inetAddress = getLocalInetAddress();
-
-				_LOCAL_HOST_NAME = inetAddress.getHostName();
-			}
-			catch (Exception exception) {
-				throw new ExceptionInInitializerError(exception);
-			}
-		}
-
-	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
@@ -15,6 +15,8 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.portal.kernel.concurrent.DefaultNoticeableFuture;
+import com.liferay.portal.kernel.internal.security.access.control.AllowedIPAddressesValidator;
+import com.liferay.portal.kernel.internal.security.access.control.AllowedIPAddressesValidatorFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
@@ -106,7 +108,20 @@ public class InetAddressUtil {
 			inetAddress = getInetAddressByName(host);
 		}
 
-		return allowedHosts.contains(inetAddress.getHostAddress());
+		if (allowedHosts.contains(inetAddress.getHostAddress())) {
+			return true;
+		}
+
+		for (String allowedHost : allowedHosts) {
+			AllowedIPAddressesValidator allowedIPAddressesValidator =
+				AllowedIPAddressesValidatorFactory.create(allowedHost);
+
+			if (allowedIPAddressesValidator.isAllowedIPAddress(host)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public static boolean isLocalHost(String host) throws UnknownHostException {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
@@ -40,11 +40,8 @@ public class InetAddressUtil {
 	public static InetAddress getInetAddressByName(String domain)
 		throws UnknownHostException {
 
-		AtomicInteger atomicInteger = new AtomicInteger(
-			_DNS_SECURITY_THREAD_LIMIT);
-
 		try {
-			if (atomicInteger.getAndDecrement() <= 0) {
+			if (_atomicInteger.getAndDecrement() <= 0) {
 				_log.error(
 					"Thread limit exceeded to resolve domain: " + domain);
 
@@ -76,7 +73,7 @@ public class InetAddressUtil {
 				"Unable to resolve domain: " + domain);
 		}
 		finally {
-			atomicInteger.incrementAndGet();
+			_atomicInteger.incrementAndGet();
 		}
 	}
 
@@ -130,11 +127,12 @@ public class InetAddressUtil {
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.DNS_SECURITY_ADDRESS_TIMEOUT_SECONDS));
 
-	private static final int _DNS_SECURITY_THREAD_LIMIT = GetterUtil.getInteger(
-		PropsUtil.get(PropsKeys.DNS_SECURITY_THREAD_LIMIT));
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		InetAddressUtil.class);
+
+	private static final AtomicInteger _atomicInteger = new AtomicInteger(
+		GetterUtil.getInteger(
+			PropsUtil.get(PropsKeys.DNS_SECURITY_THREAD_LIMIT)));
 
 	private static class LocalHostNameHolder {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/InetAddressUtil.java
@@ -24,8 +24,9 @@ import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -85,8 +86,31 @@ public class InetAddressUtil {
 		return InetAddress.getByName("127.0.0.1");
 	}
 
+	public static boolean isHostAllowed(String host, Set<String> allowedHosts)
+		throws UnknownHostException {
+
+		if (allowedHosts.isEmpty()) {
+			return true;
+		}
+
+		if (allowedHosts.contains(host) ||
+			(allowedHosts.contains("SERVER_IP") &&
+			 _localHosts.containsKey(host))) {
+
+			return true;
+		}
+
+		InetAddress inetAddress = _localHosts.get(host);
+
+		if (inetAddress == null) {
+			inetAddress = getInetAddressByName(host);
+		}
+
+		return allowedHosts.contains(inetAddress.getHostAddress());
+	}
+
 	public static boolean isLocalHost(String host) throws UnknownHostException {
-		if (_localHosts.contains(host)) {
+		if (_localHosts.containsKey(host)) {
 			return true;
 		}
 
@@ -113,7 +137,7 @@ public class InetAddressUtil {
 	private static final AtomicInteger _atomicInteger = new AtomicInteger(
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.DNS_SECURITY_THREAD_LIMIT)));
-	private static final Set<String> _localHosts = new HashSet<>();
+	private static final Map<String, InetAddress> _localHosts = new HashMap<>();
 
 	static {
 		try {
@@ -126,8 +150,9 @@ public class InetAddressUtil {
 
 				for (InetAddress inetAddress : inetAddresses) {
 					if (inetAddress instanceof Inet4Address) {
-						_localHosts.add(inetAddress.getHostAddress());
-						_localHosts.add(inetAddress.getHostName());
+						_localHosts.put(
+							inetAddress.getHostAddress(), inetAddress);
+						_localHosts.put(inetAddress.getHostName(), inetAddress);
 					}
 				}
 			}


### PR DESCRIPTION
- LPS-154828 The AtomicInteger should be a field, otherwise the limit won't work
- LPS-154828 Use computer name initialized in portal instance to remove the only usage of InetAddressUtil#getLocalHostName()
- LPS-154828 Remove unused method
- LPS-154828 Add cache to check local host name to reduce DNS resolving
- LPS-154828 Apply usages
- LPS-154828 Apply to PingbackMethodImpl and fix unit test
- LPS-154828 Inline the only usage
- LPS-154828 Add method to check if host is allowed
- LPS-154828 Employ AllowedIPAddressValidator to perform additional checking
- LPS-154828 Temp: return false when UnknownHostException in isHostAllowed() method
- LPS-154828 Apply to replace AccessControlUtil.isAccessAllowed()
