### PR TITLE
LPS 159586 8 17 2

### DIFF
--- a/modules/apps/commerce/commerce-price-list-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-price-list-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Price List API
 Bundle-SymbolicName: com.liferay.commerce.price.list.api
-Bundle-Version: 14.2.1
+Bundle-Version: 15.0.0
 Export-Package:\
 	com.liferay.commerce.price.list.configuration,\
 	com.liferay.commerce.price.list.constants,\

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalService.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalService.java
@@ -134,7 +134,7 @@ public interface CommercePriceListLocalService
 
 	public void checkCommercePriceLists() throws PortalException;
 
-	public void cleanPriceListCache(long companyId);
+	public void cleanPriceListCache();
 
 	/**
 	 * Creates a new commerce price list with the primary key. Does not add the commerce price list to the database.
@@ -375,7 +375,7 @@ public interface CommercePriceListLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Optional<CommercePriceList> getCommercePriceList(
-			long companyId, long groupId, long commerceAccountId,
+			long groupId, long commerceAccountId,
 			long[] commerceAccountGroupIds)
 		throws PortalException;
 

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalService.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalService.java
@@ -49,7 +49,6 @@ import java.io.Serializable;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -374,7 +373,7 @@ public interface CommercePriceListLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public Optional<CommercePriceList> getCommercePriceList(
+	public CommercePriceList getCommercePriceList(
 			long groupId, long commerceAccountId,
 			long[] commerceAccountGroupIds)
 		throws PortalException;

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceUtil.java
@@ -453,7 +453,7 @@ public class CommercePriceListLocalServiceUtil {
 		return getService().getCommercePriceList(commercePriceListId);
 	}
 
-	public static java.util.Optional<CommercePriceList> getCommercePriceList(
+	public static CommercePriceList getCommercePriceList(
 			long groupId, long commerceAccountId,
 			long[] commerceAccountGroupIds)
 		throws PortalException {

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceUtil.java
@@ -134,8 +134,8 @@ public class CommercePriceListLocalServiceUtil {
 		getService().checkCommercePriceLists();
 	}
 
-	public static void cleanPriceListCache(long companyId) {
-		getService().cleanPriceListCache(companyId);
+	public static void cleanPriceListCache() {
+		getService().cleanPriceListCache();
 	}
 
 	/**
@@ -454,12 +454,12 @@ public class CommercePriceListLocalServiceUtil {
 	}
 
 	public static java.util.Optional<CommercePriceList> getCommercePriceList(
-			long companyId, long groupId, long commerceAccountId,
+			long groupId, long commerceAccountId,
 			long[] commerceAccountGroupIds)
 		throws PortalException {
 
 		return getService().getCommercePriceList(
-			companyId, groupId, commerceAccountId, commerceAccountGroupIds);
+			groupId, commerceAccountId, commerceAccountGroupIds);
 	}
 
 	public static CommercePriceList

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceWrapper.java
@@ -139,8 +139,8 @@ public class CommercePriceListLocalServiceWrapper
 	}
 
 	@Override
-	public void cleanPriceListCache(long companyId) {
-		_commercePriceListLocalService.cleanPriceListCache(companyId);
+	public void cleanPriceListCache() {
+		_commercePriceListLocalService.cleanPriceListCache();
 	}
 
 	/**
@@ -503,12 +503,12 @@ public class CommercePriceListLocalServiceWrapper
 
 	@Override
 	public java.util.Optional<CommercePriceList> getCommercePriceList(
-			long companyId, long groupId, long commerceAccountId,
+			long groupId, long commerceAccountId,
 			long[] commerceAccountGroupIds)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commercePriceListLocalService.getCommercePriceList(
-			companyId, groupId, commerceAccountId, commerceAccountGroupIds);
+			groupId, commerceAccountId, commerceAccountGroupIds);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceWrapper.java
@@ -502,7 +502,7 @@ public class CommercePriceListLocalServiceWrapper
 	}
 
 	@Override
-	public java.util.Optional<CommercePriceList> getCommercePriceList(
+	public CommercePriceList getCommercePriceList(
 			long groupId, long commerceAccountId,
 			long[] commerceAccountGroupIds)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/commerce/commerce-price-list-api/src/main/resources/com/liferay/commerce/price/list/service/packageinfo
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/resources/com/liferay/commerce/price/list/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.2.1
+version 8.0.0

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/search/CommercePriceListIndexer.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/search/CommercePriceListIndexer.java
@@ -203,6 +203,8 @@ public class CommercePriceListIndexer extends BaseIndexer<CommercePriceList> {
 		deleteDocument(
 			commercePriceList.getCompanyId(),
 			commercePriceList.getCommercePriceListId());
+
+		_commercePriceListLocalService.cleanPriceListCache();
 	}
 
 	@Override
@@ -301,6 +303,8 @@ public class CommercePriceListIndexer extends BaseIndexer<CommercePriceList> {
 			_log.debug(
 				"Document " + commercePriceList + " indexed successfully");
 		}
+
+		_commercePriceListLocalService.cleanPriceListCache();
 
 		return document;
 	}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListAccountRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListAccountRelLocalServiceImpl.java
@@ -63,8 +63,7 @@ public class CommercePriceListAccountRelLocalServiceImpl
 
 		reindexCommercePriceList(commercePriceListId);
 
-		commercePriceListLocalService.cleanPriceListCache(
-			serviceContext.getCompanyId());
+		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListAccountRel;
 	}
@@ -84,8 +83,7 @@ public class CommercePriceListAccountRelLocalServiceImpl
 		reindexCommercePriceList(
 			commercePriceListAccountRel.getCommercePriceListId());
 
-		commercePriceListLocalService.cleanPriceListCache(
-			commercePriceListAccountRel.getCompanyId());
+		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListAccountRel;
 	}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListAccountRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListAccountRelLocalServiceImpl.java
@@ -63,8 +63,6 @@ public class CommercePriceListAccountRelLocalServiceImpl
 
 		reindexCommercePriceList(commercePriceListId);
 
-		commercePriceListLocalService.cleanPriceListCache();
-
 		return commercePriceListAccountRel;
 	}
 
@@ -82,8 +80,6 @@ public class CommercePriceListAccountRelLocalServiceImpl
 
 		reindexCommercePriceList(
 			commercePriceListAccountRel.getCommercePriceListId());
-
-		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListAccountRel;
 	}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListChannelRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListChannelRelLocalServiceImpl.java
@@ -63,8 +63,6 @@ public class CommercePriceListChannelRelLocalServiceImpl
 
 		reindexCommercePriceList(commercePriceListId);
 
-		commercePriceListLocalService.cleanPriceListCache();
-
 		return commercePriceListChannelRel;
 	}
 
@@ -82,8 +80,6 @@ public class CommercePriceListChannelRelLocalServiceImpl
 
 		reindexCommercePriceList(
 			commercePriceListChannelRel.getCommercePriceListId());
-
-		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListChannelRel;
 	}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListChannelRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListChannelRelLocalServiceImpl.java
@@ -63,8 +63,7 @@ public class CommercePriceListChannelRelLocalServiceImpl
 
 		reindexCommercePriceList(commercePriceListId);
 
-		commercePriceListLocalService.cleanPriceListCache(
-			serviceContext.getCompanyId());
+		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListChannelRel;
 	}
@@ -84,8 +83,7 @@ public class CommercePriceListChannelRelLocalServiceImpl
 		reindexCommercePriceList(
 			commercePriceListChannelRel.getCommercePriceListId());
 
-		commercePriceListLocalService.cleanPriceListCache(
-			commercePriceListChannelRel.getCompanyId());
+		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListChannelRel;
 	}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListCommerceAccountGroupRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListCommerceAccountGroupRelLocalServiceImpl.java
@@ -75,8 +75,7 @@ public class CommercePriceListCommerceAccountGroupRelLocalServiceImpl
 
 		reindexPriceList(commercePriceListId);
 
-		commercePriceListLocalService.cleanPriceListCache(
-			serviceContext.getCompanyId());
+		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListCommerceAccountGroupRel;
 	}
@@ -107,8 +106,7 @@ public class CommercePriceListCommerceAccountGroupRelLocalServiceImpl
 		reindexPriceList(
 			commercePriceListCommerceAccountGroupRel.getCommercePriceListId());
 
-		commercePriceListLocalService.cleanPriceListCache(
-			commercePriceListCommerceAccountGroupRel.getCompanyId());
+		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListCommerceAccountGroupRel;
 	}
@@ -228,8 +226,7 @@ public class CommercePriceListCommerceAccountGroupRelLocalServiceImpl
 
 		// Cache
 
-		commercePriceListLocalService.cleanPriceListCache(
-			serviceContext.getScopeGroupId());
+		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListCommerceAccountGroupRelPersistence.update(
 			commercePriceListCommerceAccountGroupRel);

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListCommerceAccountGroupRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListCommerceAccountGroupRelLocalServiceImpl.java
@@ -75,8 +75,6 @@ public class CommercePriceListCommerceAccountGroupRelLocalServiceImpl
 
 		reindexPriceList(commercePriceListId);
 
-		commercePriceListLocalService.cleanPriceListCache();
-
 		return commercePriceListCommerceAccountGroupRel;
 	}
 
@@ -105,8 +103,6 @@ public class CommercePriceListCommerceAccountGroupRelLocalServiceImpl
 
 		reindexPriceList(
 			commercePriceListCommerceAccountGroupRel.getCommercePriceListId());
-
-		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListCommerceAccountGroupRel;
 	}
@@ -223,10 +219,6 @@ public class CommercePriceListCommerceAccountGroupRelLocalServiceImpl
 
 		reindexPriceList(
 			commercePriceListCommerceAccountGroupRel.getCommercePriceListId());
-
-		// Cache
-
-		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListCommerceAccountGroupRelPersistence.update(
 			commercePriceListCommerceAccountGroupRel);

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListDiscountRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListDiscountRelLocalServiceImpl.java
@@ -58,6 +58,8 @@ public class CommercePriceListDiscountRelLocalServiceImpl
 		commercePriceListDiscountRel.setOrder(order);
 		commercePriceListDiscountRel.setExpandoBridgeAttributes(serviceContext);
 
+		reindexPriceList(commercePriceListId);
+
 		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListDiscountRelPersistence.update(

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListDiscountRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListDiscountRelLocalServiceImpl.java
@@ -60,8 +60,6 @@ public class CommercePriceListDiscountRelLocalServiceImpl
 
 		reindexPriceList(commercePriceListId);
 
-		commercePriceListLocalService.cleanPriceListCache();
-
 		return commercePriceListDiscountRelPersistence.update(
 			commercePriceListDiscountRel);
 	}
@@ -79,8 +77,6 @@ public class CommercePriceListDiscountRelLocalServiceImpl
 			commercePriceListDiscountRel.getCommercePriceListDiscountRelId());
 
 		reindexPriceList(commercePriceListDiscountRel.getCommercePriceListId());
-
-		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListDiscountRel;
 	}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListDiscountRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListDiscountRelLocalServiceImpl.java
@@ -58,8 +58,7 @@ public class CommercePriceListDiscountRelLocalServiceImpl
 		commercePriceListDiscountRel.setOrder(order);
 		commercePriceListDiscountRel.setExpandoBridgeAttributes(serviceContext);
 
-		commercePriceListLocalService.cleanPriceListCache(
-			serviceContext.getCompanyId());
+		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListDiscountRelPersistence.update(
 			commercePriceListDiscountRel);
@@ -79,8 +78,7 @@ public class CommercePriceListDiscountRelLocalServiceImpl
 
 		reindexPriceList(commercePriceListDiscountRel.getCommercePriceListId());
 
-		commercePriceListLocalService.cleanPriceListCache(
-			commercePriceListDiscountRel.getCompanyId());
+		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListDiscountRel;
 	}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
@@ -52,7 +52,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
@@ -69,7 +68,6 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.SortFactoryUtil;
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
@@ -558,8 +556,6 @@ public class CommercePriceListLocalServiceImpl
 			long[] commerceAccountGroupIds)
 		throws PortalException {
 
-		Company company = _companyLocalService.getCompany(companyId);
-
 		if (commerceAccountGroupIds == null) {
 			commerceAccountGroupIds = new long[0];
 		}
@@ -575,7 +571,7 @@ public class CommercePriceListLocalServiceImpl
 
 		PortalCache<String, Serializable> portalCache =
 			(PortalCache<String, Serializable>)_multiVMPool.getPortalCache(
-				"PRICE_LISTS_" + company.getCompanyId());
+				"PRICE_LISTS_" + companyId);
 
 		boolean priceListCalculated = GetterUtil.getBoolean(
 			portalCache.get(cacheKey + "_calculated"));
@@ -588,8 +584,7 @@ public class CommercePriceListLocalServiceImpl
 		}
 
 		SearchContext searchContext = buildSearchContext(
-			company.getCompanyId(), groupId, commerceAccountId,
-			commerceAccountGroupIds);
+			companyId, groupId, commerceAccountId, commerceAccountGroupIds);
 
 		Indexer<CommercePriceList> indexer =
 			IndexerRegistryUtil.nullSafeGetIndexer(CommercePriceList.class);
@@ -1765,9 +1760,6 @@ public class CommercePriceListLocalServiceImpl
 	@ServiceReference(type = CommercePriceModifierLocalService.class)
 	private CommercePriceModifierLocalService
 		_commercePriceModifierLocalService;
-
-	@ServiceReference(type = CompanyLocalService.class)
-	private CompanyLocalService _companyLocalService;
 
 	@ServiceReference(type = ExpandoRowLocalService.class)
 	private ExpandoRowLocalService _expandoRowLocalService;

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
@@ -68,6 +68,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.SortFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
@@ -318,10 +319,10 @@ public class CommercePriceListLocalServiceImpl
 	}
 
 	@Override
-	public void cleanPriceListCache(long companyId) {
+	public void cleanPriceListCache() {
 		PortalCache<String, Serializable> portalCache =
 			(PortalCache<String, Serializable>)_multiVMPool.getPortalCache(
-				"PRICE_LISTS_" + companyId);
+				"PRICE_LISTS_" + CompanyThreadLocal.getCompanyId());
 
 		portalCache.removeAll();
 	}
@@ -552,7 +553,7 @@ public class CommercePriceListLocalServiceImpl
 
 	@Override
 	public Optional<CommercePriceList> getCommercePriceList(
-			long companyId, long groupId, long commerceAccountId,
+			long groupId, long commerceAccountId,
 			long[] commerceAccountGroupIds)
 		throws PortalException {
 
@@ -568,6 +569,8 @@ public class CommercePriceListLocalServiceImpl
 		String cacheKey = StringBundler.concat(
 			groupId, StringPool.POUND, commerceAccountId, StringPool.POUND,
 			StringUtil.merge(commerceAccountGroupIds));
+
+		long companyId = CompanyThreadLocal.getCompanyId();
 
 		PortalCache<String, Serializable> portalCache =
 			(PortalCache<String, Serializable>)_multiVMPool.getPortalCache(

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
@@ -322,7 +322,7 @@ public class CommercePriceListLocalServiceImpl
 	public void cleanPriceListCache() {
 		PortalCache<String, Serializable> portalCache =
 			(PortalCache<String, Serializable>)_multiVMPool.getPortalCache(
-				"PRICE_LISTS_" + CompanyThreadLocal.getCompanyId());
+				"PRICE_LISTS", false, true);
 
 		portalCache.removeAll();
 	}
@@ -570,11 +570,9 @@ public class CommercePriceListLocalServiceImpl
 			groupId, StringPool.POUND, commerceAccountId, StringPool.POUND,
 			StringUtil.merge(commerceAccountGroupIds));
 
-		long companyId = CompanyThreadLocal.getCompanyId();
-
 		PortalCache<String, Serializable> portalCache =
 			(PortalCache<String, Serializable>)_multiVMPool.getPortalCache(
-				"PRICE_LISTS_" + companyId);
+				"PRICE_LISTS", false, true);
 
 		boolean priceListCalculated = GetterUtil.getBoolean(
 			portalCache.get(cacheKey + "_calculated"));
@@ -587,7 +585,8 @@ public class CommercePriceListLocalServiceImpl
 		}
 
 		SearchContext searchContext = buildSearchContext(
-			companyId, groupId, commerceAccountId, commerceAccountGroupIds);
+			CompanyThreadLocal.getCompanyId(), groupId, commerceAccountId,
+			commerceAccountGroupIds);
 
 		Indexer<CommercePriceList> indexer =
 			IndexerRegistryUtil.nullSafeGetIndexer(CommercePriceList.class);

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
@@ -234,7 +234,7 @@ public class CommercePriceListLocalServiceImpl
 
 		// Cache
 
-		cleanPriceListCache(user.getCompanyId());
+		cleanPriceListCache();
 
 		// Resources
 
@@ -491,7 +491,7 @@ public class CommercePriceListLocalServiceImpl
 
 		// Cache
 
-		cleanPriceListCache(commercePriceList.getCompanyId());
+		cleanPriceListCache();
 
 		return commercePriceList;
 	}
@@ -1172,7 +1172,7 @@ public class CommercePriceListLocalServiceImpl
 		commercePriceList = startWorkflowInstance(
 			user.getUserId(), commercePriceList, serviceContext);
 
-		cleanPriceListCache(commercePriceList.getCompanyId());
+		cleanPriceListCache();
 
 		return commercePriceList;
 	}
@@ -1191,7 +1191,7 @@ public class CommercePriceListLocalServiceImpl
 			commercePriceList = commercePriceListPersistence.update(
 				commercePriceList);
 
-			cleanPriceListCache(commercePriceList.getCompanyId());
+			cleanPriceListCache();
 
 			doReindex(commercePriceList.getCommercePriceListId());
 		}
@@ -1212,7 +1212,7 @@ public class CommercePriceListLocalServiceImpl
 		commercePriceList = commercePriceListPersistence.update(
 			commercePriceList);
 
-		cleanPriceListCache(commercePriceList.getCompanyId());
+		cleanPriceListCache();
 
 		return commercePriceList;
 	}
@@ -1260,7 +1260,7 @@ public class CommercePriceListLocalServiceImpl
 		commercePriceList = commercePriceListPersistence.update(
 			commercePriceList);
 
-		cleanPriceListCache(commercePriceList.getCompanyId());
+		cleanPriceListCache();
 
 		return commercePriceList;
 	}
@@ -1362,7 +1362,7 @@ public class CommercePriceListLocalServiceImpl
 				WorkflowConstants.STATUS_APPROVED, serviceContext,
 				new HashMap<String, Serializable>());
 
-			cleanPriceListCache(commercePriceList.getCompanyId());
+			cleanPriceListCache();
 		}
 	}
 
@@ -1397,7 +1397,7 @@ public class CommercePriceListLocalServiceImpl
 					WorkflowConstants.STATUS_EXPIRED, serviceContext,
 					new HashMap<String, Serializable>());
 
-				cleanPriceListCache(commercePriceList.getCompanyId());
+				cleanPriceListCache();
 			}
 		}
 	}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
@@ -96,7 +96,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.LongStream;
 
 /**
@@ -565,7 +564,7 @@ public class CommercePriceListLocalServiceImpl
 	}
 
 	@Override
-	public Optional<CommercePriceList> getCommercePriceList(
+	public CommercePriceList getCommercePriceList(
 			long groupId, long commerceAccountId,
 			long[] commerceAccountGroupIds)
 		throws PortalException {
@@ -586,7 +585,7 @@ public class CommercePriceListLocalServiceImpl
 		CommercePriceList commercePriceList = _portalCache.get(cacheKey);
 
 		if (commercePriceList == _dummyCommercePriceList) {
-			return Optional.empty();
+			return null;
 		}
 
 		SearchContext searchContext = buildSearchContext(
@@ -603,7 +602,7 @@ public class CommercePriceListLocalServiceImpl
 		if (documents.isEmpty()) {
 			_portalCache.put(cacheKey, _dummyCommercePriceList);
 
-			return Optional.empty();
+			return null;
 		}
 
 		Document document = documents.get(0);
@@ -616,12 +615,12 @@ public class CommercePriceListLocalServiceImpl
 		if (commercePriceList == null) {
 			_portalCache.put(cacheKey, _dummyCommercePriceList);
 
-			return Optional.empty();
+			return null;
 		}
 
 		_portalCache.put(cacheKey, commercePriceList);
 
-		return Optional.of(commercePriceList);
+		return commercePriceList;
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
@@ -579,6 +579,9 @@ public class CommercePriceListLocalServiceImpl
 		if (commercePriceList == _dummyCommercePriceList) {
 			return null;
 		}
+		else if (commercePriceList != null) {
+			return commercePriceList;
+		}
 
 		SearchContext searchContext = buildSearchContext(
 			CompanyThreadLocal.getCompanyId(), groupId, commerceAccountId,

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
@@ -80,6 +80,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.ProxyFactory;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -317,7 +318,7 @@ public class CommercePriceListLocalServiceImpl
 		super.afterPropertiesSet();
 
 		_portalCache =
-			(PortalCache<String, Serializable>)_multiVMPool.getPortalCache(
+			(PortalCache<String, CommercePriceList>)_multiVMPool.getPortalCache(
 				"PRICE_LISTS", false, true);
 	}
 
@@ -582,14 +583,10 @@ public class CommercePriceListLocalServiceImpl
 			groupId, StringPool.POUND, commerceAccountId, StringPool.POUND,
 			StringUtil.merge(commerceAccountGroupIds));
 
-		boolean priceListCalculated = GetterUtil.getBoolean(
-			_portalCache.get(cacheKey + "_calculated"));
+		CommercePriceList commercePriceList = _portalCache.get(cacheKey);
 
-		CommercePriceList commercePriceList =
-			(CommercePriceList)_portalCache.get(cacheKey);
-
-		if (priceListCalculated) {
-			return Optional.ofNullable(commercePriceList);
+		if (commercePriceList == _dummyCommercePriceList) {
+			return Optional.empty();
 		}
 
 		SearchContext searchContext = buildSearchContext(
@@ -604,7 +601,7 @@ public class CommercePriceListLocalServiceImpl
 		List<Document> documents = hits.toList();
 
 		if (documents.isEmpty()) {
-			_portalCache.put(cacheKey + "_calculated", true);
+			_portalCache.put(cacheKey, _dummyCommercePriceList);
 
 			return Optional.empty();
 		}
@@ -616,11 +613,15 @@ public class CommercePriceListLocalServiceImpl
 
 		commercePriceList = fetchCommercePriceList(commercePriceListId);
 
+		if (commercePriceList == null) {
+			_portalCache.put(cacheKey, _dummyCommercePriceList);
+
+			return Optional.empty();
+		}
+
 		_portalCache.put(cacheKey, commercePriceList);
 
-		_portalCache.put(cacheKey + "_calculated", true);
-
-		return Optional.ofNullable(commercePriceList);
+		return Optional.of(commercePriceList);
 	}
 
 	@Override
@@ -1764,6 +1765,9 @@ public class CommercePriceListLocalServiceImpl
 	private static final Log _log = LogFactoryUtil.getLog(
 		CommercePriceListLocalServiceImpl.class);
 
+	private static final CommercePriceList _dummyCommercePriceList =
+		ProxyFactory.newDummyInstance(CommercePriceList.class);
+
 	@ServiceReference(type = CommerceCurrencyLocalService.class)
 	private CommerceCurrencyLocalService _commerceCurrencyLocalService;
 
@@ -1777,7 +1781,7 @@ public class CommercePriceListLocalServiceImpl
 	@ServiceReference(type = MultiVMPool.class)
 	private MultiVMPool _multiVMPool;
 
-	private PortalCache<String, Serializable> _portalCache;
+	private PortalCache<String, CommercePriceList> _portalCache;
 
 	@ServiceReference(type = WorkflowInstanceLinkLocalService.class)
 	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
@@ -232,10 +232,6 @@ public class CommercePriceListLocalServiceImpl
 		commercePriceList = startWorkflowInstance(
 			user.getUserId(), commercePriceList, serviceContext);
 
-		// Cache
-
-		cleanPriceListCache();
-
 		// Resources
 
 		resourceLocalService.addModelResources(
@@ -500,10 +496,6 @@ public class CommercePriceListLocalServiceImpl
 			commercePriceList.getCompanyId(), commercePriceList.getGroupId(),
 			CommercePriceList.class.getName(),
 			commercePriceList.getCommercePriceListId());
-
-		// Cache
-
-		cleanPriceListCache();
 
 		return commercePriceList;
 	}
@@ -1179,8 +1171,6 @@ public class CommercePriceListLocalServiceImpl
 		commercePriceList = startWorkflowInstance(
 			user.getUserId(), commercePriceList, serviceContext);
 
-		cleanPriceListCache();
-
 		return commercePriceList;
 	}
 
@@ -1198,8 +1188,6 @@ public class CommercePriceListLocalServiceImpl
 			commercePriceList = commercePriceListPersistence.update(
 				commercePriceList);
 
-			cleanPriceListCache();
-
 			doReindex(commercePriceList.getCommercePriceListId());
 		}
 	}
@@ -1216,12 +1204,7 @@ public class CommercePriceListLocalServiceImpl
 
 		commercePriceList.setExternalReferenceCode(externalReferenceCode);
 
-		commercePriceList = commercePriceListPersistence.update(
-			commercePriceList);
-
-		cleanPriceListCache();
-
-		return commercePriceList;
+		return commercePriceListPersistence.update(commercePriceList);
 	}
 
 	@Indexable(type = IndexableType.REINDEX)
@@ -1264,12 +1247,7 @@ public class CommercePriceListLocalServiceImpl
 		commercePriceList.setStatusByUserName(user.getFullName());
 		commercePriceList.setStatusDate(modifiedDate);
 
-		commercePriceList = commercePriceListPersistence.update(
-			commercePriceList);
-
-		cleanPriceListCache();
-
-		return commercePriceList;
+		return commercePriceListPersistence.update(commercePriceList);
 	}
 
 	protected SearchContext buildSearchContext(
@@ -1368,8 +1346,6 @@ public class CommercePriceListLocalServiceImpl
 				userId, commercePriceList.getCommercePriceListId(),
 				WorkflowConstants.STATUS_APPROVED, serviceContext,
 				new HashMap<String, Serializable>());
-
-			cleanPriceListCache();
 		}
 	}
 
@@ -1403,8 +1379,6 @@ public class CommercePriceListLocalServiceImpl
 					userId, commercePriceList.getCommercePriceListId(),
 					WorkflowConstants.STATUS_EXPIRED, serviceContext,
 					new HashMap<String, Serializable>());
-
-				cleanPriceListCache();
 			}
 		}
 	}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListOrderTypeRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListOrderTypeRelLocalServiceImpl.java
@@ -75,8 +75,6 @@ public class CommercePriceListOrderTypeRelLocalServiceImpl
 
 		reindexCommercePriceList(commercePriceListId);
 
-		commercePriceListLocalService.cleanPriceListCache();
-
 		return commercePriceListOrderTypeRel;
 	}
 
@@ -94,8 +92,6 @@ public class CommercePriceListOrderTypeRelLocalServiceImpl
 
 		reindexCommercePriceList(
 			commercePriceListOrderTypeRel.getCommercePriceListId());
-
-		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListOrderTypeRel;
 	}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListOrderTypeRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListOrderTypeRelLocalServiceImpl.java
@@ -75,8 +75,7 @@ public class CommercePriceListOrderTypeRelLocalServiceImpl
 
 		reindexCommercePriceList(commercePriceListId);
 
-		commercePriceListLocalService.cleanPriceListCache(
-			serviceContext.getCompanyId());
+		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListOrderTypeRel;
 	}
@@ -96,8 +95,7 @@ public class CommercePriceListOrderTypeRelLocalServiceImpl
 		reindexCommercePriceList(
 			commercePriceListOrderTypeRel.getCommercePriceListId());
 
-		commercePriceListLocalService.cleanPriceListCache(
-			commercePriceListOrderTypeRel.getCompanyId());
+		commercePriceListLocalService.cleanPriceListCache();
 
 		return commercePriceListOrderTypeRel;
 	}

--- a/modules/apps/commerce/commerce-taglib/src/main/java/com/liferay/commerce/taglib/servlet/taglib/TierPriceTag.java
+++ b/modules/apps/commerce/commerce-taglib/src/main/java/com/liferay/commerce/taglib/servlet/taglib/TierPriceTag.java
@@ -36,7 +36,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.taglib.util.IncludeTag;
 
 import java.util.List;
-import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
@@ -56,13 +55,10 @@ public class TierPriceTag extends IncludeTag {
 				(CommerceContext)httpServletRequest.getAttribute(
 					CommerceWebKeys.COMMERCE_CONTEXT);
 
-			Optional<CommercePriceList> commercePriceListOptional =
-				_getPriceList(_cpInstanceId, commerceContext);
+			CommercePriceList commercePriceList = _getPriceList(
+				_cpInstanceId, commerceContext);
 
-			if (commercePriceListOptional.isPresent()) {
-				CommercePriceList commercePriceList =
-					commercePriceListOptional.get();
-
+			if (commercePriceList != null) {
 				CommercePriceEntry commercePriceEntry =
 					CommercePriceEntryLocalServiceUtil.fetchCommercePriceEntry(
 						_cpInstanceId,
@@ -175,14 +171,14 @@ public class TierPriceTag extends IncludeTag {
 
 	protected CommercePriceFormatter commercePriceFormatter;
 
-	private Optional<CommercePriceList> _getPriceList(
+	private CommercePriceList _getPriceList(
 			long cpInstanceId, CommerceContext commerceContext)
 		throws PortalException {
 
 		CommerceAccount commerceAccount = commerceContext.getCommerceAccount();
 
 		if (commerceAccount == null) {
-			return Optional.empty();
+			return null;
 		}
 
 		CPInstance cpInstance = CPInstanceLocalServiceUtil.getCPInstance(

--- a/modules/apps/commerce/commerce-taglib/src/main/java/com/liferay/commerce/taglib/servlet/taglib/TierPriceTag.java
+++ b/modules/apps/commerce/commerce-taglib/src/main/java/com/liferay/commerce/taglib/servlet/taglib/TierPriceTag.java
@@ -189,8 +189,7 @@ public class TierPriceTag extends IncludeTag {
 			cpInstanceId);
 
 		return _commercePriceListLocalService.getCommercePriceList(
-			commerceAccount.getCompanyId(), cpInstance.getGroupId(),
-			commerceAccount.getCommerceAccountId(),
+			cpInstance.getGroupId(), commerceAccount.getCommerceAccountId(),
 			commerceContext.getCommerceAccountGroupIds());
 	}
 


### PR DESCRIPTION
- LPS-159586 Clean up, no need to check company existence. The method is only used for showing tiered price on a Commerce product detail page, when the company always exists.
- LPS-159586 Clean up, no need to pass the companyId; the company this method operates on should always be same with the company of the current request.
- LPS-159586 gw buildService
- LPS-159586 Apply
- LPS-159586 Use sharded portal cache to automatically handle per-company cache
- LPS-159586 Make the cache's lifecycle same with the local service
- LPS-159586 Clean up, use a dummy CommercePriceList as placeholder to avoid saving a separate flag
- LPS-159586 Clean up, no need to return an Optional here
- LPS-159586 gw buildService
- LPS-159586 Apply
- LPS-159586 Fix possible bug by adding reindex of CommercePriceList to CommercePriceListDiscountRelLocalServiceImpl#addCommercePriceListDiscountRel, because 1) the deletion of this entity triggers the reindex of CommercePriceList; 2) if it doesn't reindex, it shouldn't need to clean the cache of CommercePriceList index search results.
- LPS-159586 Centralize the search result cache clean up into the indexer when reindexing or deleting the index, so that the local services does not need to manually call it.
- LPS-159586 Fix: if the cache has actual content, return it
