### PR TITLE
LPS 161990

### DIFF
--- a/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/mime/MimeTypesImpl.java
+++ b/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/mime/MimeTypesImpl.java
@@ -91,6 +91,10 @@ public class MimeTypesImpl implements MimeTypes, MimeTypesReaderMetKeys {
 			return contentType;
 		}
 
+		if (inputStream == null) {
+			return null;
+		}
+
 		Metadata metadata = new Metadata();
 
 		if (Validator.isNotNull(fileName)) {
@@ -98,7 +102,7 @@ public class MimeTypesImpl implements MimeTypes, MimeTypesReaderMetKeys {
 				Metadata.RESOURCE_NAME_KEY, HtmlUtil.escapeURL(fileName));
 		}
 
-		if ((inputStream != null) && !inputStream.markSupported()) {
+		if (!inputStream.markSupported()) {
 			inputStream = new UnsyncBufferedInputStream(inputStream);
 		}
 

--- a/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/mime/MimeTypesImpl.java
+++ b/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/mime/MimeTypesImpl.java
@@ -149,6 +149,12 @@ public class MimeTypesImpl implements MimeTypes, MimeTypesReaderMetKeys {
 				"tika-mimetypes.xml"),
 			_extensionsMap);
 
+		for (Map.Entry<String, Set<String>> entry : _extensionsMap.entrySet()) {
+			for (String mimeType : entry.getValue()) {
+				_contentTypes.put(mimeType, entry.getKey());
+			}
+		}
+
 		Map<String, Set<String>> extensionsMap = new HashMap<>();
 
 		read(


### PR DESCRIPTION
- LPS-161990 Return null if the content type can not be determined (overriding Tika's default behavior which returns application/octet-stream
- LPS-151990 Also populate default types into _contentTypes
