### PR TITLE
LPS-161990 Fix on MimeTypesImpl

### DIFF
--- a/modules/apps/portal/portal-tika-test/src/testIntegration/java/com/liferay/portal/tika/test/MimeTypesImplTest.java
+++ b/modules/apps/portal/portal-tika-test/src/testIntegration/java/com/liferay/portal/tika/test/MimeTypesImplTest.java
@@ -23,6 +23,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.InputStream;
 
+import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -40,6 +42,20 @@ public class MimeTypesImplTest {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testApplicationOctetStream() {
+		Set<String> validExtensions = _mimeTypes.getExtensions(
+			ContentTypes.APPLICATION_OCTET_STREAM);
+
+		for (String validExtension : validExtensions) {
+			Assert.assertEquals(
+				ContentTypes.APPLICATION_OCTET_STREAM,
+				_getContentType("test" + validExtension, false));
+		}
+
+		Assert.assertNull(_getContentType("test.invalid", false));
+	}
 
 	@Test
 	public void testDoc() {

--- a/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/mime/MimeTypesImpl.java
+++ b/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/mime/MimeTypesImpl.java
@@ -170,8 +170,8 @@ public class MimeTypesImpl implements MimeTypes, MimeTypesReaderMetKeys {
 			extensionsMap);
 
 		for (Map.Entry<String, Set<String>> entry : extensionsMap.entrySet()) {
-			for (String mimeType : entry.getValue()) {
-				_contentTypes.put(mimeType, entry.getKey());
+			for (String extension : entry.getValue()) {
+				_contentTypes.put(extension, entry.getKey());
 			}
 		}
 	}

--- a/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/mime/MimeTypesImpl.java
+++ b/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/mime/MimeTypesImpl.java
@@ -113,6 +113,10 @@ public class MimeTypesImpl implements MimeTypes, MimeTypesReaderMetKeys {
 			_log.error(ioException);
 		}
 
+		if (inputStream != null) {
+			return contentType;
+		}
+
 		Set<String> extensions = _extensionsMap.get(
 			ContentTypes.APPLICATION_OCTET_STREAM);
 

--- a/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/mime/MimeTypesImpl.java
+++ b/modules/apps/portal/portal-tika/src/main/java/com/liferay/portal/tika/internal/mime/MimeTypesImpl.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -85,7 +86,9 @@ public class MimeTypesImpl implements MimeTypes, MimeTypesReaderMetKeys {
 
 	@Override
 	public String getContentType(InputStream inputStream, String fileName) {
-		String contentType = _contentTypes.get(_getExtension(fileName));
+		String extension = _getExtension(fileName);
+
+		String contentType = _contentTypes.get(extension);
 
 		if (contentType != null) {
 			return contentType;
@@ -108,6 +111,16 @@ public class MimeTypesImpl implements MimeTypes, MimeTypesReaderMetKeys {
 		}
 		catch (IOException ioException) {
 			_log.error(ioException);
+		}
+
+		Set<String> extensions = _extensionsMap.get(
+			ContentTypes.APPLICATION_OCTET_STREAM);
+
+		if (!extensions.contains(extension) &&
+			Objects.equals(
+				contentType, ContentTypes.APPLICATION_OCTET_STREAM)) {
+
+			return null;
 		}
 
 		return contentType;


### PR DESCRIPTION
- LPS-161990 Satisfy Portlet Specification and Servlet Specification: when detected content type is application/octet-stream, but the extension is not known by Tika, return null
- LPS-161990 Add shortcut, always use Tika result when inputstream is provided
- LPS-161990 SF, rename variable; the key for this map should be file extension name, not mime type
- LPS-161990 Add test
