### PR TITLE
[Rename Classes] LPS-166960 Rename classes in modules info-api、info-impl、layout-admin-web、layout-content-page-editor-web、layout-taglib | part 2

### DIFF
--- a/modules/apps/asset/asset-display-page-api/bnd.bnd
+++ b/modules/apps/asset/asset-display-page-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset Display Page API
 Bundle-SymbolicName: com.liferay.asset.display.page.api
-Bundle-Version: 9.2.2
+Bundle-Version: 10.0.0
 Export-Package:\
 	com.liferay.asset.display.page.configuration,\
 	com.liferay.asset.display.page.constants,\

--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
@@ -33,7 +33,7 @@ import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
@@ -250,7 +250,7 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 	protected InfoItemServiceTracker infoItemServiceTracker;
 
 	@Reference
-	protected InfoSearchClassMapperTracker infoSearchClassMapperTracker;
+	protected InfoSearchClassMapperRegistry infoSearchClassMapperRegistry;
 
 	@Reference
 	protected LayoutDisplayPageProviderTracker layoutDisplayPageProviderTracker;
@@ -270,7 +270,7 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 	private AssetEntry _getAssetEntry(
 		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider) {
 
-		String className = infoSearchClassMapperTracker.getSearchClassName(
+		String className = infoSearchClassMapperRegistry.getSearchClassName(
 			portal.getClassName(
 				layoutDisplayPageObjectProvider.getClassNameId()));
 

--- a/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/portlet/packageinfo
+++ b/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 4.3.0
+version 5.0.0

--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/service/impl/AssetDisplayPageEntryLocalServiceImpl.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/service/impl/AssetDisplayPageEntryLocalServiceImpl.java
@@ -24,7 +24,7 @@ import com.liferay.asset.kernel.model.AssetEntryTable;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.info.item.InfoItemReference;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
@@ -346,7 +346,7 @@ public class AssetDisplayPageEntryLocalServiceImpl
 		).and(
 			() -> {
 				String searchClassName =
-					_infoSearchClassMapperTracker.getSearchClassName(
+					_infoSearchClassMapperRegistry.getSearchClassName(
 						_portal.getClassName(classNameId));
 
 				return AssetEntryTable.INSTANCE.classNameId.eq(
@@ -387,7 +387,7 @@ public class AssetDisplayPageEntryLocalServiceImpl
 	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private LayoutDisplayPageProviderTracker _layoutDisplayPageProviderTracker;

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -40,7 +40,7 @@ import com.liferay.asset.util.comparator.AssetRendererFactoryTypeNameComparator;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.criteria.AssetEntryItemSelectorReturnType;
@@ -120,14 +120,14 @@ public class EditAssetListDisplayContext {
 
 	public EditAssetListDisplayContext(
 		AssetRendererFactoryClassProvider assetRendererFactoryClassProvider,
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker,
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry,
 		ItemSelector itemSelector, PortletRequest portletRequest,
 		PortletResponse portletResponse,
 		SegmentsConfigurationProvider segmentsConfigurationProvider,
 		UnicodeProperties unicodeProperties) {
 
 		_assetRendererFactoryClassProvider = assetRendererFactoryClassProvider;
-		_infoSearchClassMapperTracker = infoSearchClassMapperTracker;
+		_infoSearchClassMapperRegistry = infoSearchClassMapperRegistry;
 		_itemSelector = itemSelector;
 		_portletRequest = portletRequest;
 		_portletResponse = portletResponse;
@@ -1024,7 +1024,7 @@ public class EditAssetListDisplayContext {
 					}
 
 					String className =
-						_infoSearchClassMapperTracker.getSearchClassName(
+						_infoSearchClassMapperRegistry.getSearchClassName(
 							PortalUtil.getClassName(classNameId));
 
 					AssetRendererFactory<?> assetRendererFactory =
@@ -1436,7 +1436,7 @@ public class EditAssetListDisplayContext {
 	private String _ddmStructureFieldName;
 	private String _ddmStructureFieldValue;
 	private final HttpServletRequest _httpServletRequest;
-	private final InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private final InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 	private final ItemSelector _itemSelector;
 	private Boolean _liveGroup;
 	private String _orderByColumn1;

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/AssetListPortlet.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/AssetListPortlet.java
@@ -33,7 +33,7 @@ import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.info.display.url.provider.InfoEditURLProviderTracker;
 import com.liferay.info.item.InfoItemServiceTracker;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.util.Portal;
@@ -102,7 +102,7 @@ public class AssetListPortlet extends MVCPortlet {
 			AssetListWebKeys.EDIT_ASSET_LIST_DISPLAY_CONTEXT,
 			new EditAssetListDisplayContext(
 				_assetRendererFactoryClassProvider,
-				_infoSearchClassMapperTracker, _itemSelector, renderRequest,
+				_infoSearchClassMapperRegistry, _itemSelector, renderRequest,
 				renderResponse, _segmentsConfigurationProvider,
 				_getUnicodeProperties(assetListDisplayContext)));
 		renderRequest.setAttribute(
@@ -120,7 +120,7 @@ public class AssetListPortlet extends MVCPortlet {
 			new ListItemsActionDropdownItems(
 				_assetDisplayPageFriendlyURLProvider, _dlAppService,
 				_infoEditURLProviderTracker, _infoItemServiceTracker,
-				_infoSearchClassMapperTracker,
+				_infoSearchClassMapperRegistry,
 				_portal.getHttpServletRequest(renderRequest)));
 		renderRequest.setAttribute(
 			AssetListWebKeys.SELECT_STRUCTURE_FIELD_DISPLAY_CONTEXT,
@@ -183,7 +183,7 @@ public class AssetListPortlet extends MVCPortlet {
 	private InfoItemServiceTracker _infoItemServiceTracker;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/servlet/taglib/util/ListItemsActionDropdownItems.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/servlet/taglib/util/ListItemsActionDropdownItems.java
@@ -29,7 +29,7 @@ import com.liferay.info.item.InfoItemFieldValues;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -55,7 +55,7 @@ public class ListItemsActionDropdownItems {
 		DLAppService dlAppService,
 		InfoEditURLProviderTracker infoEditURLProviderTracker,
 		InfoItemServiceTracker infoItemServiceTracker,
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker,
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry,
 		HttpServletRequest httpServletRequest) {
 
 		_assetDisplayPageFriendlyURLProvider =
@@ -63,7 +63,7 @@ public class ListItemsActionDropdownItems {
 		_dlAppService = dlAppService;
 		_infoEditURLProviderTracker = infoEditURLProviderTracker;
 		_infoItemServiceTracker = infoItemServiceTracker;
-		_infoSearchClassMapperTracker = infoSearchClassMapperTracker;
+		_infoSearchClassMapperRegistry = infoSearchClassMapperRegistry;
 
 		_httpServletRequest = httpServletRequest;
 
@@ -110,7 +110,7 @@ public class ListItemsActionDropdownItems {
 
 		String viewDisplayPageURL =
 			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
-				_infoSearchClassMapperTracker.getClassName(className), classPK,
+				_infoSearchClassMapperRegistry.getClassName(className), classPK,
 				_themeDisplay);
 
 		return HttpComponentsUtil.setParameter(
@@ -218,7 +218,7 @@ public class ListItemsActionDropdownItems {
 	private final HttpServletRequest _httpServletRequest;
 	private final InfoEditURLProviderTracker _infoEditURLProviderTracker;
 	private final InfoItemServiceTracker _infoItemServiceTracker;
-	private final InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private final InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 	private String _redirect;
 	private final ThemeDisplay _themeDisplay;
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/dao/search/ContentDashboardItemSearchContainerFactory.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/dao/search/ContentDashboardItemSearchContainerFactory.java
@@ -22,7 +22,7 @@ import com.liferay.content.dashboard.web.internal.constants.ContentDashboardPort
 import com.liferay.content.dashboard.web.internal.item.ContentDashboardItemFactoryRegistry;
 import com.liferay.content.dashboard.web.internal.search.request.ContentDashboardSearchContextBuilder;
 import com.liferay.content.dashboard.web.internal.searcher.ContentDashboardSearchRequestBuilderFactory;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -61,7 +61,7 @@ public class ContentDashboardItemSearchContainerFactory {
 		ContentDashboardItemFactoryRegistry contentDashboardItemFactoryRegistry,
 		ContentDashboardSearchRequestBuilderFactory
 			contentDashboardSearchRequestBuilderFactory,
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker,
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry,
 		Portal portal, PortletRequest portletRequest,
 		PortletResponse portletResponse, Searcher searcher) {
 
@@ -69,7 +69,7 @@ public class ContentDashboardItemSearchContainerFactory {
 			assetCategoryLocalService, assetVocabularyLocalService,
 			contentDashboardItemFactoryRegistry,
 			contentDashboardSearchRequestBuilderFactory,
-			infoSearchClassMapperTracker, portal, portletRequest,
+			infoSearchClassMapperRegistry, portal, portletRequest,
 			portletResponse, searcher);
 	}
 
@@ -90,7 +90,7 @@ public class ContentDashboardItemSearchContainerFactory {
 		ContentDashboardItemFactoryRegistry contentDashboardItemFactoryRegistry,
 		ContentDashboardSearchRequestBuilderFactory
 			contentDashboardSearchRequestBuilderFactory,
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker,
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry,
 		Portal portal, PortletRequest portletRequest,
 		PortletResponse portletResponse, Searcher searcher) {
 
@@ -100,7 +100,7 @@ public class ContentDashboardItemSearchContainerFactory {
 			contentDashboardItemFactoryRegistry;
 		_contentDashboardSearchRequestBuilderFactory =
 			contentDashboardSearchRequestBuilderFactory;
-		_infoSearchClassMapperTracker = infoSearchClassMapperTracker;
+		_infoSearchClassMapperRegistry = infoSearchClassMapperRegistry;
 		_portal = portal;
 		_portletRequest = portletRequest;
 		_portletResponse = portletResponse;
@@ -243,7 +243,7 @@ public class ContentDashboardItemSearchContainerFactory {
 	private ContentDashboardItem<?> _toContentDashboardItem(Document document) {
 		ContentDashboardItemFactory<?> contentDashboardItemFactory =
 			_contentDashboardItemFactoryRegistry.getContentDashboardItemFactory(
-				_infoSearchClassMapperTracker.getClassName(
+				_infoSearchClassMapperRegistry.getClassName(
 					document.get(Field.ENTRY_CLASS_NAME)));
 
 		if (contentDashboardItemFactory == null) {
@@ -262,7 +262,7 @@ public class ContentDashboardItemSearchContainerFactory {
 		_contentDashboardItemFactoryRegistry;
 	private final ContentDashboardSearchRequestBuilderFactory
 		_contentDashboardSearchRequestBuilderFactory;
-	private final InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private final InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 	private final Locale _locale;
 	private String _orderByCol;
 	private String _orderByType;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminSharingDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminSharingDisplayContext.java
@@ -18,7 +18,7 @@ import com.liferay.content.dashboard.item.ContentDashboardItem;
 import com.liferay.content.dashboard.item.ContentDashboardItemFactory;
 import com.liferay.content.dashboard.item.action.ContentDashboardItemAction;
 import com.liferay.content.dashboard.web.internal.item.ContentDashboardItemFactoryRegistry;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -38,16 +38,16 @@ public class ContentDashboardAdminSharingDisplayContext {
 	public ContentDashboardAdminSharingDisplayContext(
 		ContentDashboardItemFactoryRegistry contentDashboardItemFactoryRegistry,
 		HttpServletRequest httpServletRequest,
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker) {
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry) {
 
 		_contentDashboardItemFactoryRegistry =
 			contentDashboardItemFactoryRegistry;
 		_httpServletRequest = httpServletRequest;
-		_infoSearchClassMapperTracker = infoSearchClassMapperTracker;
+		_infoSearchClassMapperRegistry = infoSearchClassMapperRegistry;
 	}
 
 	public String getClassName() {
-		return _infoSearchClassMapperTracker.getSearchClassName(
+		return _infoSearchClassMapperRegistry.getSearchClassName(
 			_getClassName());
 	}
 
@@ -164,6 +164,6 @@ public class ContentDashboardAdminSharingDisplayContext {
 	private final ContentDashboardItemFactoryRegistry
 		_contentDashboardItemFactoryRegistry;
 	private final HttpServletRequest _httpServletRequest;
-	private final InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private final InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 }

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/instance/lifecycle/AddDefaultAssetVocabulariesPortalInstanceLifecycleListener.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/instance/lifecycle/AddDefaultAssetVocabulariesPortalInstanceLifecycleListener.java
@@ -20,7 +20,7 @@ import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.content.dashboard.web.internal.constants.ContentDashboardConstants;
 import com.liferay.content.dashboard.web.internal.item.ContentDashboardItemFactoryRegistry;
 import com.liferay.content.dashboard.web.internal.util.AssetVocabularyUtil;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
@@ -64,7 +64,7 @@ public class AddDefaultAssetVocabulariesPortalInstanceLifecycleListener
 
 			searchClassNameIds.add(
 				_portal.getClassNameId(
-					_infoSearchClassMapperTracker.getSearchClassName(
+					_infoSearchClassMapperRegistry.getSearchClassName(
 						className)));
 		}
 
@@ -127,7 +127,7 @@ public class AddDefaultAssetVocabulariesPortalInstanceLifecycleListener
 		_contentDashboardItemFactoryRegistry;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/ContentDashboardItemFactoryRegistry.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/ContentDashboardItemFactoryRegistry.java
@@ -19,7 +19,7 @@ import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.content.dashboard.item.ContentDashboardItemFactory;
 import com.liferay.content.dashboard.web.internal.constants.ContentDashboardConstants;
 import com.liferay.content.dashboard.web.internal.util.AssetVocabularyUtil;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.osgi.service.tracker.collections.map.ServiceReferenceMapperFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
@@ -88,7 +88,7 @@ public class ContentDashboardItemFactoryRegistry {
 	private CompanyLocalService _companyLocalService;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	private volatile ServiceTrackerMap<String, ContentDashboardItemFactory<?>>
 		_serviceTrackerMap;
@@ -111,7 +111,7 @@ public class ContentDashboardItemFactoryRegistry {
 				_bundleContext.getService(serviceReference);
 
 			long classNameId = _classNameLocalService.getClassNameId(
-				_infoSearchClassMapperTracker.getSearchClassName(
+				_infoSearchClassMapperRegistry.getSearchClassName(
 					GenericUtil.getGenericClassName(
 						contentDashboardItemFactory)));
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/selector/ContentDashboardItemSubtypeItemSelectorView.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/selector/ContentDashboardItemSubtypeItemSelectorView.java
@@ -32,7 +32,7 @@ import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
 import com.liferay.info.localized.InfoLocalizedValue;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
@@ -221,7 +221,7 @@ public class ContentDashboardItemSubtypeItemSelectorView
 
 	private String _getIcon(String className) {
 		return Optional.ofNullable(
-			_infoSearchClassMapperTracker.getSearchClassName(className)
+			_infoSearchClassMapperRegistry.getSearchClassName(className)
 		).map(
 			AssetRendererFactoryRegistryUtil::getAssetRendererFactoryByClassName
 		).map(
@@ -424,7 +424,7 @@ public class ContentDashboardItemSubtypeItemSelectorView
 	private InfoItemServiceTracker _infoItemServiceTracker;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/ContentDashboardAdminPortlet.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/ContentDashboardAdminPortlet.java
@@ -33,7 +33,7 @@ import com.liferay.content.dashboard.web.internal.search.request.ContentDashboar
 import com.liferay.content.dashboard.web.internal.searcher.ContentDashboardSearchRequestBuilderFactory;
 import com.liferay.content.dashboard.web.internal.servlet.taglib.util.ContentDashboardDropdownItemsProvider;
 import com.liferay.content.dashboard.web.internal.util.ContentDashboardUtil;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.language.Language;
@@ -122,7 +122,7 @@ public class ContentDashboardAdminPortlet extends MVCPortlet {
 					_assetCategoryLocalService, _assetVocabularyLocalService,
 					_contentDashboardItemFactoryRegistry,
 					_contentDashboardSearchRequestBuilderFactory,
-					_infoSearchClassMapperTracker, _portal, renderRequest,
+					_infoSearchClassMapperRegistry, _portal, renderRequest,
 					renderResponse, _searcher);
 
 		SearchContainer<ContentDashboardItem<?>> searchContainer =
@@ -174,7 +174,7 @@ public class ContentDashboardAdminPortlet extends MVCPortlet {
 			new ContentDashboardAdminSharingDisplayContext(
 				_contentDashboardItemFactoryRegistry,
 				_portal.getHttpServletRequest(liferayPortletRequest),
-				_infoSearchClassMapperTracker));
+				_infoSearchClassMapperRegistry));
 
 		_sharingJavaScriptFactory.requestSharingJavascript();
 
@@ -213,7 +213,7 @@ public class ContentDashboardAdminPortlet extends MVCPortlet {
 	private GroupLocalService _groupLocalService;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
@@ -24,7 +24,7 @@ import com.liferay.content.dashboard.web.internal.constants.ContentDashboardPort
 import com.liferay.content.dashboard.web.internal.item.ContentDashboardItemFactoryRegistry;
 import com.liferay.content.dashboard.web.internal.search.request.ContentDashboardSearchContextBuilder;
 import com.liferay.content.dashboard.web.internal.searcher.ContentDashboardSearchRequestBuilderFactory;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
@@ -308,7 +308,7 @@ public class GetContentDashboardItemsXlsMVCResourceCommand
 	private ContentDashboardItem<?> _toContentDashboardItem(Document document) {
 		ContentDashboardItemFactory<?> contentDashboardItemFactory =
 			_contentDashboardItemFactoryRegistry.getContentDashboardItemFactory(
-				_infoSearchClassMapperTracker.getClassName(
+				_infoSearchClassMapperRegistry.getClassName(
 					document.get(Field.ENTRY_CLASS_NAME)));
 
 		if (contentDashboardItemFactory == null) {
@@ -385,7 +385,7 @@ public class GetContentDashboardItemsXlsMVCResourceCommand
 		_defaultSearchResultPermissionFilterConfiguration;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/searcher/ContentDashboardSearchRequestBuilderFactory.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/searcher/ContentDashboardSearchRequestBuilderFactory.java
@@ -15,7 +15,7 @@
 package com.liferay.content.dashboard.web.internal.searcher;
 
 import com.liferay.content.dashboard.web.internal.item.ContentDashboardItemFactoryRegistry;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -64,7 +64,7 @@ public class ContentDashboardSearchRequestBuilderFactory {
 		Stream<String> stream = classNames.stream();
 
 		return stream.map(
-			_infoSearchClassMapperTracker::getSearchClassName
+			_infoSearchClassMapperRegistry::getSearchClassName
 		).toArray(
 			size -> new String[size]
 		);
@@ -75,7 +75,7 @@ public class ContentDashboardSearchRequestBuilderFactory {
 		_contentDashboardItemFactoryRegistry;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private SearchRequestBuilderFactory _searchRequestBuilderFactory;

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
@@ -27,7 +27,7 @@ import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.info.type.Labeled;
 import com.liferay.info.type.WebImage;
 import com.liferay.petra.string.StringPool;
@@ -170,7 +170,7 @@ public class FragmentEntryProcessorHelperImpl
 
 		InfoItemReference infoItemReference = infoItemReferenceOptional.get();
 
-		String className = _infoSearchClassMapperTracker.getClassName(
+		String className = _infoSearchClassMapperRegistry.getClassName(
 			infoItemReference.getClassName());
 
 		InfoItemFieldValuesProvider<Object> infoItemFieldValuesProvider =
@@ -479,7 +479,7 @@ public class FragmentEntryProcessorHelperImpl
 	private InfoItemServiceTracker _infoItemServiceTracker;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesItemSelectorExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesItemSelectorExportImportContentProcessor.java
@@ -27,7 +27,7 @@ import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
@@ -85,7 +85,7 @@ public class EditableValuesItemSelectorExportImportContentProcessor
 		_exportDDMTemplateReference(
 			portletDataContext, stagedModel, configurationValueJSONObject);
 
-		String className = _infoSearchClassMapperTracker.getSearchClassName(
+		String className = _infoSearchClassMapperRegistry.getSearchClassName(
 			_portal.getClassName(classNameId));
 
 		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
@@ -189,7 +189,7 @@ public class EditableValuesItemSelectorExportImportContentProcessor
 
 		AssetRendererFactory<?> assetRendererFactory =
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
-				_infoSearchClassMapperTracker.getSearchClassName(className));
+				_infoSearchClassMapperRegistry.getSearchClassName(className));
 
 		StagingGroupHelper stagingGroupHelper =
 			StagingGroupHelperUtil.getStagingGroupHelper();
@@ -261,7 +261,7 @@ public class EditableValuesItemSelectorExportImportContentProcessor
 	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesMappingExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesMappingExportImportContentProcessor.java
@@ -27,7 +27,7 @@ import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
@@ -193,7 +193,7 @@ public class EditableValuesMappingExportImportContentProcessor
 		_exportDDMTemplateReference(
 			portletDataContext, stagedModel, editableJSONObject);
 
-		String className = _infoSearchClassMapperTracker.getSearchClassName(
+		String className = _infoSearchClassMapperRegistry.getSearchClassName(
 			_portal.getClassName(classNameId));
 
 		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
@@ -298,7 +298,7 @@ public class EditableValuesMappingExportImportContentProcessor
 
 		AssetRendererFactory<?> assetRendererFactory =
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
-				_infoSearchClassMapperTracker.getSearchClassName(className));
+				_infoSearchClassMapperRegistry.getSearchClassName(className));
 
 		StagingGroupHelper stagingGroupHelper =
 			StagingGroupHelperUtil.getStagingGroupHelper();
@@ -340,7 +340,7 @@ public class EditableValuesMappingExportImportContentProcessor
 	private DDMTemplateLocalService _ddmTemplateLocalService;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 22.1.1
+Bundle-Version: 23.0.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/search/InfoSearchClassMapperRegistry.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/search/InfoSearchClassMapperRegistry.java
@@ -20,7 +20,7 @@ import org.osgi.annotation.versioning.ProviderType;
  * @author Cristina González
  */
 @ProviderType
-public interface InfoSearchClassMapperTracker {
+public interface InfoSearchClassMapperRegistry {
 
 	public String getClassName(String searchClassName);
 

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/search/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/search/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/info/info-collection-provider-item-selector-web/src/main/java/com/liferay/info/collection/provider/item/selector/web/internal/layout/list/retriever/InfoCollectionProviderLayoutListRetriever.java
+++ b/modules/apps/info/info-collection-provider-item-selector-web/src/main/java/com/liferay/info/collection/provider/item/selector/web/internal/layout/list/retriever/InfoCollectionProviderLayoutListRetriever.java
@@ -31,7 +31,7 @@ import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.list.provider.item.selector.criterion.InfoListProviderItemSelectorReturnType;
 import com.liferay.info.pagination.InfoPage;
 import com.liferay.info.pagination.Pagination;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.layout.list.retriever.KeyListObjectReference;
 import com.liferay.layout.list.retriever.LayoutListRetriever;
 import com.liferay.layout.list.retriever.LayoutListRetrieverContext;
@@ -262,7 +262,7 @@ public class InfoCollectionProviderLayoutListRetriever
 		ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
 			(ClassPKInfoItemIdentifier)infoItemIdentifier;
 
-		String className = _infoSearchClassMapperTracker.getSearchClassName(
+		String className = _infoSearchClassMapperRegistry.getSearchClassName(
 			infoItemReference.getClassName());
 
 		return _assetEntryLocalService.fetchEntry(
@@ -286,6 +286,6 @@ public class InfoCollectionProviderLayoutListRetriever
 	private InfoItemServiceTracker _infoItemServiceTracker;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 }

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/search/InfoSearchClassMapperRegistryImpl.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/search/InfoSearchClassMapperRegistryImpl.java
@@ -15,7 +15,7 @@
 package com.liferay.info.internal.search;
 
 import com.liferay.info.search.InfoSearchClassMapper;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.osgi.service.tracker.collections.map.ServiceReferenceMapperFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
@@ -32,9 +32,9 @@ import org.osgi.service.component.annotations.Deactivate;
 /**
  * @author Cristina González
  */
-@Component(service = InfoSearchClassMapperTracker.class)
-public class InfoSearchClassMapperTrackerImpl
-	implements InfoSearchClassMapperTracker {
+@Component(service = InfoSearchClassMapperRegistry.class)
+public class InfoSearchClassMapperRegistryImpl
+	implements InfoSearchClassMapperRegistry {
 
 	@Override
 	public String getClassName(String searchClassName) {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutCollectionDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutCollectionDisplayContext.java
@@ -22,7 +22,7 @@ import com.liferay.info.collection.provider.InfoCollectionProvider;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
-import com.liferay.layout.admin.web.internal.info.search.InfoSearchClassMapperTrackerUtil;
+import com.liferay.layout.admin.web.internal.info.search.InfoSearchClassMapperRegistryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -237,7 +237,8 @@ public class SelectLayoutCollectionDisplayContext {
 					InfoItemFormProvider.class)) {
 
 			infoItemClassNames.add(
-				InfoSearchClassMapperTrackerUtil.getSearchClassName(className));
+				InfoSearchClassMapperRegistryUtil.getSearchClassName(
+					className));
 		}
 
 		return infoItemClassNames;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/search/InfoSearchClassMapperRegistryUtil.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/search/InfoSearchClassMapperRegistryUtil.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Lourdes Fernández Besada
  */
 @Component(immediate = true, service = {})
-public class InfoSearchClassMapperTrackerUtil {
+public class InfoSearchClassMapperRegistryUtil {
 
 	public static String getSearchClassName(String className) {
 		return _infoSearchClassMapperRegistry.getSearchClassName(className);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/search/InfoSearchClassMapperTrackerUtil.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/search/InfoSearchClassMapperTrackerUtil.java
@@ -14,7 +14,7 @@
 
 package com.liferay.layout.admin.web.internal.info.search;
 
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -26,16 +26,16 @@ import org.osgi.service.component.annotations.Reference;
 public class InfoSearchClassMapperTrackerUtil {
 
 	public static String getSearchClassName(String className) {
-		return _infoSearchClassMapperTracker.getSearchClassName(className);
+		return _infoSearchClassMapperRegistry.getSearchClassName(className);
 	}
 
 	@Reference(unbind = "-")
-	protected void setInfoSearchClassMapperTracker(
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker) {
+	protected void setInfoSearchClassMapperRegistry(
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry) {
 
-		_infoSearchClassMapperTracker = infoSearchClassMapperTracker;
+		_infoSearchClassMapperRegistry = infoSearchClassMapperRegistry;
 	}
 
-	private static InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private static InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -29,7 +29,7 @@ import com.liferay.info.collection.provider.item.selector.criterion.InfoCollecti
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.info.list.provider.item.selector.criterion.InfoListProviderItemSelectorReturnType;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.criteria.DownloadFileEntryItemSelectorReturnType;
@@ -173,7 +173,7 @@ public class ContentPageEditorDisplayContext {
 		FrontendTokenDefinitionRegistry frontendTokenDefinitionRegistry,
 		HttpServletRequest httpServletRequest,
 		InfoItemServiceTracker infoItemServiceTracker,
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker,
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry,
 		ItemSelector itemSelector,
 		PageEditorConfiguration pageEditorConfiguration,
 		PortletRequest portletRequest, RenderResponse renderResponse,
@@ -193,7 +193,7 @@ public class ContentPageEditorDisplayContext {
 
 		this.httpServletRequest = httpServletRequest;
 		this.infoItemServiceTracker = infoItemServiceTracker;
-		this.infoSearchClassMapperTracker = infoSearchClassMapperTracker;
+		this.infoSearchClassMapperRegistry = infoSearchClassMapperRegistry;
 		this.portletRequest = portletRequest;
 		this.stagingGroupHelper = stagingGroupHelper;
 
@@ -942,7 +942,7 @@ public class ContentPageEditorDisplayContext {
 
 	protected final HttpServletRequest httpServletRequest;
 	protected final InfoItemServiceTracker infoItemServiceTracker;
-	protected final InfoSearchClassMapperTracker infoSearchClassMapperTracker;
+	protected final InfoSearchClassMapperRegistry infoSearchClassMapperRegistry;
 	protected final PortletRequest portletRequest;
 	protected final StagingGroupHelper stagingGroupHelper;
 	protected final ThemeDisplay themeDisplay;
@@ -1317,7 +1317,7 @@ public class ContentPageEditorDisplayContext {
 
 			infoItemClassNames.add(infoItemClassName);
 			infoItemClassNames.add(
-				infoSearchClassMapperTracker.getSearchClassName(
+				infoSearchClassMapperRegistry.getSearchClassName(
 					infoItemClassName));
 		}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContextProvider.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContextProvider.java
@@ -16,7 +16,7 @@ package com.liferay.layout.content.page.editor.web.internal.display.context;
 
 import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
 import com.liferay.info.item.InfoItemServiceTracker;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorWebKeys;
 import com.liferay.layout.content.page.editor.sidebar.panel.ContentPageEditorSidebarPanel;
@@ -74,7 +74,7 @@ public class ContentPageEditorDisplayContextProvider {
 				_getContentPageEditorSidebarPanels(),
 				_fragmentCollectionManager, _fragmentEntryLinkManager,
 				_frontendTokenDefinitionRegistry, httpServletRequest,
-				_infoItemServiceTracker, _infoSearchClassMapperTracker,
+				_infoItemServiceTracker, _infoSearchClassMapperRegistry,
 				_itemSelector, _pageEditorConfiguration, portletRequest,
 				renderResponse, _segmentsConfigurationProvider,
 				new SegmentsExperienceManager(_segmentsExperienceLocalService),
@@ -101,7 +101,7 @@ public class ContentPageEditorDisplayContextProvider {
 			_getContentPageEditorSidebarPanels(), _fragmentCollectionManager,
 			_fragmentEntryLinkManager, _frontendTokenDefinitionRegistry,
 			httpServletRequest, _infoItemServiceTracker,
-			_infoSearchClassMapperTracker, _itemSelector,
+			_infoSearchClassMapperRegistry, _itemSelector,
 			_pageEditorConfiguration, pageIsDisplayPage, portletRequest,
 			renderResponse, _segmentsConfigurationProvider,
 			new SegmentsExperienceManager(_segmentsExperienceLocalService),
@@ -152,7 +152,7 @@ public class ContentPageEditorDisplayContextProvider {
 	private InfoItemServiceTracker _infoItemServiceTracker;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorLayoutPageTemplateDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorLayoutPageTemplateDisplayContext.java
@@ -28,7 +28,7 @@ import com.liferay.info.item.provider.InfoItemDetailsProvider;
 import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
 import com.liferay.info.list.provider.item.selector.criterion.InfoListProviderItemSelectorReturnType;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.criteria.InfoItemItemSelectorReturnType;
@@ -76,7 +76,7 @@ public class ContentPageEditorLayoutPageTemplateDisplayContext
 		FrontendTokenDefinitionRegistry frontendTokenDefinitionRegistry,
 		HttpServletRequest httpServletRequest,
 		InfoItemServiceTracker infoItemServiceTracker,
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker,
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry,
 		ItemSelector itemSelector,
 		PageEditorConfiguration pageEditorConfiguration,
 		boolean pageIsDisplayPage, PortletRequest portletRequest,
@@ -89,9 +89,10 @@ public class ContentPageEditorLayoutPageTemplateDisplayContext
 			contentPageEditorSidebarPanels, fragmentCollectionManager,
 			fragmentEntryLinkManager, frontendTokenDefinitionRegistry,
 			httpServletRequest, infoItemServiceTracker,
-			infoSearchClassMapperTracker, itemSelector, pageEditorConfiguration,
-			portletRequest, renderResponse, segmentsConfigurationProvider,
-			segmentsExperienceManager, stagingGroupHelper);
+			infoSearchClassMapperRegistry, itemSelector,
+			pageEditorConfiguration, portletRequest, renderResponse,
+			segmentsConfigurationProvider, segmentsExperienceManager,
+			stagingGroupHelper);
 
 		_itemSelector = itemSelector;
 		_pageIsDisplayPage = pageIsDisplayPage;
@@ -169,7 +170,7 @@ public class ContentPageEditorLayoutPageTemplateDisplayContext
 
 		AssetRendererFactory<?> assetRendererFactory =
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
-				infoSearchClassMapperTracker.getSearchClassName(className));
+				infoSearchClassMapperRegistry.getSearchClassName(className));
 
 		if (assetRendererFactory != null) {
 			sourceItemTypes.add(AssetEntry.class.getName());

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
@@ -27,7 +27,7 @@ import com.liferay.info.collection.provider.InfoCollectionProvider;
 import com.liferay.info.collection.provider.SingleFormVariationInfoCollectionProvider;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.list.provider.item.selector.criterion.InfoListProviderItemSelectorReturnType;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.criteria.InfoListItemSelectorReturnType;
 import com.liferay.layout.content.page.editor.sidebar.panel.ContentPageEditorSidebarPanel;
@@ -104,7 +104,7 @@ public class ContentPageLayoutEditorDisplayContext
 		FrontendTokenDefinitionRegistry frontendTokenDefinitionRegistry,
 		HttpServletRequest httpServletRequest,
 		InfoItemServiceTracker infoItemServiceTracker,
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker,
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry,
 		ItemSelector itemSelector,
 		PageEditorConfiguration pageEditorConfiguration,
 		PortletRequest portletRequest, RenderResponse renderResponse,
@@ -116,9 +116,10 @@ public class ContentPageLayoutEditorDisplayContext
 			contentPageEditorSidebarPanels, fragmentCollectionManager,
 			fragmentEntryLinkManager, frontendTokenDefinitionRegistry,
 			httpServletRequest, infoItemServiceTracker,
-			infoSearchClassMapperTracker, itemSelector, pageEditorConfiguration,
-			portletRequest, renderResponse, segmentsConfigurationProvider,
-			segmentsExperienceManager, stagingGroupHelper);
+			infoSearchClassMapperRegistry, itemSelector,
+			pageEditorConfiguration, portletRequest, renderResponse,
+			segmentsConfigurationProvider, segmentsExperienceManager,
+			stagingGroupHelper);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/info/search/InfoSearchClassMapperRegistryUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/info/search/InfoSearchClassMapperRegistryUtil.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Jürgen Kappler
  */
 @Component(service = {})
-public class InfoSearchClassMapperTrackerUtil {
+public class InfoSearchClassMapperRegistryUtil {
 
 	public static String getClassName(String searchClassName) {
 		return _infoSearchClassMapperRegistry.getClassName(searchClassName);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/info/search/InfoSearchClassMapperTrackerUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/info/search/InfoSearchClassMapperTrackerUtil.java
@@ -14,7 +14,7 @@
 
 package com.liferay.layout.content.page.editor.web.internal.info.search;
 
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -26,20 +26,20 @@ import org.osgi.service.component.annotations.Reference;
 public class InfoSearchClassMapperTrackerUtil {
 
 	public static String getClassName(String searchClassName) {
-		return _infoSearchClassMapperTracker.getClassName(searchClassName);
+		return _infoSearchClassMapperRegistry.getClassName(searchClassName);
 	}
 
 	public static String getSearchClassName(String className) {
-		return _infoSearchClassMapperTracker.getSearchClassName(className);
+		return _infoSearchClassMapperRegistry.getSearchClassName(className);
 	}
 
 	@Reference(unbind = "-")
-	protected void setInfoSearchClassMapperTracker(
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker) {
+	protected void setInfoSearchClassMapperRegistry(
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry) {
 
-		_infoSearchClassMapperTracker = infoSearchClassMapperTracker;
+		_infoSearchClassMapperRegistry = infoSearchClassMapperRegistry;
 	}
 
-	private static InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private static InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAvailableListRenderersMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAvailableListRenderersMVCResourceCommand.java
@@ -16,7 +16,7 @@ package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
 import com.liferay.info.list.renderer.InfoListRenderer;
 import com.liferay.info.list.renderer.InfoListRendererTracker;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -58,7 +58,7 @@ public class GetAvailableListRenderersMVCResourceCommand
 
 		List<InfoListRenderer<?>> infoListRenderers =
 			_infoListRendererTracker.getInfoListRenderers(
-				_infoSearchClassMapperTracker.getClassName(
+				_infoSearchClassMapperRegistry.getClassName(
 					ParamUtil.getString(resourceRequest, "className")));
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
@@ -81,7 +81,7 @@ public class GetAvailableListRenderersMVCResourceCommand
 	private InfoListRendererTracker _infoListRendererTracker;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetCollectionFieldMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetCollectionFieldMVCResourceCommand.java
@@ -37,7 +37,7 @@ import com.liferay.info.list.provider.item.selector.criterion.InfoListProviderIt
 import com.liferay.info.list.renderer.DefaultInfoListRendererContext;
 import com.liferay.info.list.renderer.InfoListRenderer;
 import com.liferay.info.list.renderer.InfoListRendererTracker;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.criteria.InfoListItemSelectorReturnType;
 import com.liferay.item.selector.criteria.info.item.criterion.InfoListItemSelectorCriterion;
@@ -257,7 +257,7 @@ public class GetCollectionFieldMVCResourceCommand
 			listObjectReference.getItemType()
 		);
 
-		String itemType = _infoSearchClassMapperTracker.getClassName(
+		String itemType = _infoSearchClassMapperRegistry.getClassName(
 			originalItemType);
 
 		InfoItemFieldValuesProvider<Object> infoItemFieldValuesProvider =
@@ -375,7 +375,7 @@ public class GetCollectionFieldMVCResourceCommand
 
 		sourceItemTypes.add(itemType);
 
-		String className = _infoSearchClassMapperTracker.getSearchClassName(
+		String className = _infoSearchClassMapperRegistry.getSearchClassName(
 			itemType);
 
 		AssetRendererFactory<?> assetRendererFactory =
@@ -487,7 +487,7 @@ public class GetCollectionFieldMVCResourceCommand
 					InfoItemFormProvider.class)) {
 
 			infoItemClassNames.add(
-				_infoSearchClassMapperTracker.getSearchClassName(className));
+				_infoSearchClassMapperRegistry.getSearchClassName(className));
 		}
 
 		return infoItemClassNames;
@@ -512,7 +512,7 @@ public class GetCollectionFieldMVCResourceCommand
 	private InfoListRendererTracker _infoListRendererTracker;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetCollectionMappingFieldsMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetCollectionMappingFieldsMVCResourceCommand.java
@@ -19,7 +19,7 @@ import com.liferay.info.item.InfoItemFormVariation;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.web.internal.util.MappingContentUtil;
 import com.liferay.petra.string.StringPool;
@@ -65,7 +65,7 @@ public class GetCollectionMappingFieldsMVCResourceCommand
 		String itemSubtype = ParamUtil.getString(
 			resourceRequest, "itemSubtype");
 
-		String itemType = _infoSearchClassMapperTracker.getClassName(
+		String itemType = _infoSearchClassMapperRegistry.getClassName(
 			ParamUtil.getString(resourceRequest, "itemType"));
 
 		String itemSubtypeLabel = StringPool.BLANK;
@@ -128,7 +128,7 @@ public class GetCollectionMappingFieldsMVCResourceCommand
 	private InfoItemServiceTracker _infoItemServiceTracker;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
@@ -34,7 +34,7 @@ import com.liferay.info.field.type.TextInfoFieldType;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFormProvider;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.web.internal.util.FragmentEntryLinkManager;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
@@ -304,7 +304,7 @@ public class UpdateFormItemConfigMVCActionCommand extends BaseMVCActionCommand {
 			long groupId)
 		throws Exception {
 
-		String itemClassName = _infoSearchClassMapperTracker.getClassName(
+		String itemClassName = _infoSearchClassMapperRegistry.getClassName(
 			_portal.getClassName(
 				formStyledLayoutStructureItem.getClassNameId()));
 
@@ -565,7 +565,7 @@ public class UpdateFormItemConfigMVCActionCommand extends BaseMVCActionCommand {
 	private InfoItemServiceTracker _infoItemServiceTracker;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/AssetListEntryUsagesUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/AssetListEntryUsagesUtil.java
@@ -34,7 +34,7 @@ import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
 import com.liferay.info.list.provider.item.selector.criterion.InfoListProviderItemSelectorReturnType;
 import com.liferay.item.selector.criteria.InfoListItemSelectorReturnType;
 import com.liferay.layout.content.page.editor.web.internal.info.item.InfoItemServiceTrackerUtil;
-import com.liferay.layout.content.page.editor.web.internal.info.search.InfoSearchClassMapperTrackerUtil;
+import com.liferay.layout.content.page.editor.web.internal.info.search.InfoSearchClassMapperRegistryUtil;
 import com.liferay.layout.content.page.editor.web.internal.security.permission.resource.ModelResourcePermissionUtil;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
 import com.liferay.layout.util.structure.LayoutStructure;
@@ -316,7 +316,8 @@ public class AssetListEntryUsagesUtil {
 
 		return AssetRendererFactoryRegistryUtil.
 			getAssetRendererFactoryByClassName(
-				InfoSearchClassMapperTrackerUtil.getSearchClassName(className));
+				InfoSearchClassMapperRegistryUtil.getSearchClassName(
+					className));
 	}
 
 	private static JSONObject _getInfoCollectionProviderActionsJSONObject(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/ContentUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/ContentUtil.java
@@ -26,7 +26,7 @@ import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.web.internal.info.display.url.provider.InfoEditURLProviderUtil;
-import com.liferay.layout.content.page.editor.web.internal.info.search.InfoSearchClassMapperTrackerUtil;
+import com.liferay.layout.content.page.editor.web.internal.info.search.InfoSearchClassMapperRegistryUtil;
 import com.liferay.layout.content.page.editor.web.internal.layout.display.page.LayoutDisplayPageProviderTrackerUtil;
 import com.liferay.layout.content.page.editor.web.internal.security.permission.resource.ModelResourcePermissionUtil;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
@@ -254,7 +254,8 @@ public class ContentUtil {
 
 		return AssetRendererFactoryRegistryUtil.
 			getAssetRendererFactoryByClassName(
-				InfoSearchClassMapperTrackerUtil.getSearchClassName(className));
+				InfoSearchClassMapperRegistryUtil.getSearchClassName(
+					className));
 	}
 
 	private static Set<LayoutDisplayPageObjectProvider<?>>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/MappingContentUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/MappingContentUtil.java
@@ -21,7 +21,7 @@ import com.liferay.info.field.type.InfoFieldType;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFormProvider;
-import com.liferay.layout.content.page.editor.web.internal.info.search.InfoSearchClassMapperTrackerUtil;
+import com.liferay.layout.content.page.editor.web.internal.info.search.InfoSearchClassMapperRegistryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -86,7 +86,7 @@ public class MappingContentUtil {
 			Locale locale)
 		throws Exception {
 
-		String className = InfoSearchClassMapperTrackerUtil.getClassName(
+		String className = InfoSearchClassMapperRegistryUtil.getClassName(
 			itemClassName);
 
 		InfoItemFormProvider<?> infoItemFormProvider =

--- a/modules/apps/layout/layout-content-page-editor-web/src/test/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContextTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/test/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContextTest.java
@@ -16,7 +16,7 @@ package com.liferay.layout.content.page.editor.web.internal.display.context;
 
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFormProvider;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -67,17 +67,17 @@ public class ContentPageEditorDisplayContextTest {
 			Arrays.asList("className1", "className2")
 		);
 
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker =
-			Mockito.mock(InfoSearchClassMapperTracker.class);
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry =
+			Mockito.mock(InfoSearchClassMapperRegistry.class);
 
 		Mockito.when(
-			infoSearchClassMapperTracker.getSearchClassName("className1")
+			infoSearchClassMapperRegistry.getSearchClassName("className1")
 		).thenReturn(
 			"searchClassName1"
 		);
 
 		Mockito.when(
-			infoSearchClassMapperTracker.getSearchClassName("className2")
+			infoSearchClassMapperRegistry.getSearchClassName("className2")
 		).thenReturn(
 			"className2"
 		);
@@ -85,7 +85,7 @@ public class ContentPageEditorDisplayContextTest {
 		ContentPageEditorDisplayContext contentPageEditorDisplayContext =
 			new ContentPageEditorDisplayContext(
 				null, null, null, null, httpServletRequest,
-				infoItemServiceTracker, infoSearchClassMapperTracker, null,
+				infoItemServiceTracker, infoSearchClassMapperRegistry, null,
 				null, null, null, null, null, null);
 
 		List<String> infoItemClassNames = ReflectionTestUtil.invoke(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/AssetDisplayPageUsagesDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/AssetDisplayPageUsagesDisplayContext.java
@@ -24,7 +24,7 @@ import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.admin.web.internal.util.comparator.AssetDisplayPageEntryModifiedDateComparator;
 import com.liferay.petra.string.StringPool;
@@ -56,14 +56,14 @@ public class AssetDisplayPageUsagesDisplayContext {
 		AssetDisplayPageEntryService assetDisplayPageEntryService,
 		AssetEntryService assetEntryService,
 		HttpServletRequest httpServletRequest,
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker,
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry,
 		InfoItemServiceTracker infoItemServiceTracker, Portal portal,
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
 		_assetDisplayPageEntryService = assetDisplayPageEntryService;
 		_assetEntryService = assetEntryService;
 		_httpServletRequest = httpServletRequest;
-		_infoSearchClassMapperTracker = infoSearchClassMapperTracker;
+		_infoSearchClassMapperRegistry = infoSearchClassMapperRegistry;
 		_infoItemServiceTracker = infoItemServiceTracker;
 		_portal = portal;
 		_renderRequest = renderRequest;
@@ -191,7 +191,7 @@ public class AssetDisplayPageUsagesDisplayContext {
 			AssetDisplayPageEntry assetDisplayPageEntry, Locale locale)
 		throws PortalException {
 
-		String className = _infoSearchClassMapperTracker.getSearchClassName(
+		String className = _infoSearchClassMapperRegistry.getSearchClassName(
 			assetDisplayPageEntry.getClassName());
 
 		try {
@@ -266,7 +266,7 @@ public class AssetDisplayPageUsagesDisplayContext {
 	private Boolean _defaultTemplate;
 	private final HttpServletRequest _httpServletRequest;
 	private final InfoItemServiceTracker _infoItemServiceTracker;
-	private final InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private final InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 	private Long _layoutPageTemplateEntryId;
 	private String _orderByCol;
 	private String _orderByType;

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/BaseLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/BaseLayoutStructureItemImporter.java
@@ -22,7 +22,7 @@ import com.liferay.info.field.InfoField;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.provider.InfoItemFormProvider;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.petra.string.StringBundler;
@@ -480,7 +480,7 @@ public abstract class BaseLayoutStructureItemImporter {
 	protected InfoItemServiceTracker infoItemServiceTracker;
 
 	@Reference
-	protected InfoSearchClassMapperTracker infoSearchClassMapperTracker;
+	protected InfoSearchClassMapperRegistry infoSearchClassMapperRegistry;
 
 	@Reference
 	protected LayoutLocalService layoutLocalService;
@@ -552,7 +552,7 @@ public abstract class BaseLayoutStructureItemImporter {
 		InfoItemFormProvider<Object> infoItemFormProvider =
 			infoItemServiceTracker.getFirstInfoItemService(
 				InfoItemFormProvider.class,
-				infoSearchClassMapperTracker.getClassName(
+				infoSearchClassMapperRegistry.getClassName(
 					portal.getClassName(
 						layoutPageTemplateEntry.getClassNameId())));
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/LayoutPageTemplatesPortlet.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/LayoutPageTemplatesPortlet.java
@@ -18,7 +18,7 @@ import com.liferay.asset.display.page.service.AssetDisplayPageEntryService;
 import com.liferay.asset.kernel.service.AssetEntryService;
 import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.info.item.InfoItemServiceTracker;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.admin.web.internal.configuration.LayoutPageTemplateAdminWebConfiguration;
@@ -153,8 +153,8 @@ public class LayoutPageTemplatesPortlet extends MVCPortlet {
 			new AssetDisplayPageUsagesDisplayContext(
 				_assetDisplayPageEntryService, _assetEntryService,
 				_portal.getHttpServletRequest(renderRequest),
-				_infoSearchClassMapperTracker, _infoItemServiceTracker, _portal,
-				renderRequest, renderResponse));
+				_infoSearchClassMapperRegistry, _infoItemServiceTracker,
+				_portal, renderRequest, renderResponse));
 		renderRequest.setAttribute(
 			LayoutPageTemplateAdminWebConfiguration.class.getName(),
 			_layoutPageTemplateAdminWebConfiguration);
@@ -183,7 +183,7 @@ public class LayoutPageTemplatesPortlet extends MVCPortlet {
 	private InfoItemServiceTracker _infoItemServiceTracker;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderCollectionLayoutStructureItemDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderCollectionLayoutStructureItemDisplayContext.java
@@ -38,7 +38,7 @@ import com.liferay.layout.list.retriever.LayoutListRetrieverRegistry;
 import com.liferay.layout.list.retriever.ListObjectReference;
 import com.liferay.layout.list.retriever.ListObjectReferenceFactory;
 import com.liferay.layout.list.retriever.ListObjectReferenceFactoryRegistry;
-import com.liferay.layout.taglib.internal.info.search.InfoSearchClassMapperTrackerUtil;
+import com.liferay.layout.taglib.internal.info.search.InfoSearchClassMapperRegistryUtil;
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem;
 import com.liferay.petra.string.CharPool;
@@ -202,7 +202,7 @@ public class RenderCollectionLayoutStructureItemDisplayContext {
 
 		return layoutDisplayPageProviderTracker.
 			getLayoutDisplayPageProviderByClassName(
-				InfoSearchClassMapperTrackerUtil.getClassName(
+				InfoSearchClassMapperRegistryUtil.getClassName(
 					listObjectReference.getItemType()));
 	}
 

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -38,7 +38,7 @@ import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.info.type.WebImage;
-import com.liferay.layout.taglib.internal.info.search.InfoSearchClassMapperTrackerUtil;
+import com.liferay.layout.taglib.internal.info.search.InfoSearchClassMapperRegistryUtil;
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
@@ -993,7 +993,7 @@ public class RenderLayoutStructureDisplayContext {
 	private String _getMappedCollectionValue(
 		String collectionFieldId, InfoItemReference infoItemReference) {
 
-		String className = InfoSearchClassMapperTrackerUtil.getClassName(
+		String className = InfoSearchClassMapperRegistryUtil.getClassName(
 			infoItemReference.getClassName());
 
 		InfoItemServiceTracker infoItemServiceTracker =

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/info/search/InfoSearchClassMapperRegistryUtil.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/info/search/InfoSearchClassMapperRegistryUtil.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Jürgen Kappler
  */
 @Component(service = {})
-public class InfoSearchClassMapperTrackerUtil {
+public class InfoSearchClassMapperRegistryUtil {
 
 	public static String getClassName(String searchClassName) {
 		return _infoSearchClassMapperRegistry.getClassName(searchClassName);

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/info/search/InfoSearchClassMapperTrackerUtil.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/info/search/InfoSearchClassMapperTrackerUtil.java
@@ -14,7 +14,7 @@
 
 package com.liferay.layout.taglib.internal.info.search;
 
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -26,16 +26,16 @@ import org.osgi.service.component.annotations.Reference;
 public class InfoSearchClassMapperTrackerUtil {
 
 	public static String getClassName(String searchClassName) {
-		return _infoSearchClassMapperTracker.getClassName(searchClassName);
+		return _infoSearchClassMapperRegistry.getClassName(searchClassName);
 	}
 
 	@Reference(unbind = "-")
-	protected void setInfoSearchClassMapperTracker(
-		InfoSearchClassMapperTracker infoSearchClassMapperTracker) {
+	protected void setInfoSearchClassMapperRegistry(
+		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry) {
 
-		_infoSearchClassMapperTracker = infoSearchClassMapperTracker;
+		_infoSearchClassMapperRegistry = infoSearchClassMapperRegistry;
 	}
 
-	private static InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private static InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 }

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -42,7 +42,7 @@ import com.liferay.layout.page.template.util.LayoutStructureUtil;
 import com.liferay.layout.responsive.ResponsiveLayoutStructureUtil;
 import com.liferay.layout.taglib.internal.display.context.RenderCollectionLayoutStructureItemDisplayContext;
 import com.liferay.layout.taglib.internal.display.context.RenderLayoutStructureDisplayContext;
-import com.liferay.layout.taglib.internal.info.search.InfoSearchClassMapperTrackerUtil;
+import com.liferay.layout.taglib.internal.info.search.InfoSearchClassMapperRegistryUtil;
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.layout.taglib.internal.util.SegmentsExperienceUtil;
 import com.liferay.layout.util.constants.LayoutStructureConstants;
@@ -345,7 +345,7 @@ public class RenderLayoutStructureTag extends IncludeTag {
 				InfoItemDetailsProvider infoItemDetailsProvider =
 					infoItemServiceTracker.getFirstInfoItemService(
 						InfoItemDetailsProvider.class,
-						InfoSearchClassMapperTrackerUtil.getClassName(
+						InfoSearchClassMapperRegistryUtil.getClassName(
 							renderCollectionLayoutStructureItemDisplayContext.
 								getCollectionItemType()));
 

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/display/context/DisplayPageLayoutTypeControllerDisplayContext.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/display/context/DisplayPageLayoutTypeControllerDisplayContext.java
@@ -30,7 +30,7 @@ import com.liferay.info.item.provider.InfoItemDetailsProvider;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.info.item.provider.InfoItemPermissionProvider;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -46,12 +46,12 @@ public class DisplayPageLayoutTypeControllerDisplayContext {
 	public DisplayPageLayoutTypeControllerDisplayContext(
 			HttpServletRequest httpServletRequest,
 			InfoItemServiceTracker infoItemServiceTracker,
-			InfoSearchClassMapperTracker infoSearchClassMapperTracker)
+			InfoSearchClassMapperRegistry infoSearchClassMapperRegistry)
 		throws Exception {
 
 		_httpServletRequest = httpServletRequest;
 		_infoItemServiceTracker = infoItemServiceTracker;
-		_infoSearchClassMapperTracker = infoSearchClassMapperTracker;
+		_infoSearchClassMapperRegistry = infoSearchClassMapperRegistry;
 
 		long assetEntryId = ParamUtil.getLong(
 			_httpServletRequest, "assetEntryId");
@@ -68,7 +68,7 @@ public class DisplayPageLayoutTypeControllerDisplayContext {
 			AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
 				assetEntryId);
 
-			String className = _infoSearchClassMapperTracker.getClassName(
+			String className = _infoSearchClassMapperRegistry.getClassName(
 				assetEntry.getClassName());
 
 			InfoItemObjectProvider<Object> infoItemObjectProvider =
@@ -157,6 +157,6 @@ public class DisplayPageLayoutTypeControllerDisplayContext {
 	private final Object _infoItem;
 	private final InfoItemDetails _infoItemDetails;
 	private final InfoItemServiceTracker _infoItemServiceTracker;
-	private final InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private final InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 }

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
@@ -18,7 +18,7 @@ import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvide
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.info.display.request.attributes.contributor.InfoDisplayRequestAttributesContributor;
 import com.liferay.info.item.InfoItemServiceTracker;
-import com.liferay.info.search.InfoSearchClassMapperTracker;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorWebKeys;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
@@ -150,7 +150,7 @@ public class DisplayPageLayoutTypeController
 			displayPageLayoutTypeControllerDisplayContext =
 				new DisplayPageLayoutTypeControllerDisplayContext(
 					httpServletRequest, _infoItemServiceTracker,
-					_infoSearchClassMapperTracker);
+					_infoSearchClassMapperRegistry);
 
 		httpServletRequest.setAttribute(
 			DisplayPageLayoutTypeControllerWebKeys.
@@ -356,7 +356,7 @@ public class DisplayPageLayoutTypeController
 	private InfoItemServiceTracker _infoItemServiceTracker;
 
 	@Reference
-	private InfoSearchClassMapperTracker _infoSearchClassMapperTracker;
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;


### PR DESCRIPTION
Conflicting classes and commits：

commit: 1f5dadb93c76fdabe3c18fe066d1e4b852de3e26
classes: ContentDashboardItemSearchContainerFactory、ContentDashboardAdminSharingDisplayContext、GetContentDashboardItemsXlsMVCResourceCommand、ContentDashboardSearchRequestBuilderFactory