### PR TITLE
LPS X Stream portal search api

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarSearchPermissionFilterContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarSearchPermissionFilterContributor.java
@@ -18,8 +18,6 @@ import com.liferay.calendar.model.Calendar;
 import com.liferay.calendar.model.CalendarBooking;
 import com.liferay.portal.search.permission.SearchPermissionFilterContributor;
 
-import java.util.Optional;
-
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -30,14 +28,12 @@ public class CalendarSearchPermissionFilterContributor
 	implements SearchPermissionFilterContributor {
 
 	@Override
-	public Optional<String> getParentEntryClassNameOptional(
-		String entryClassName) {
-
+	public String getParentEntryClassName(String entryClassName) {
 		if (entryClassName.equals(CalendarBooking.class.getName())) {
-			return Optional.of(Calendar.class.getName());
+			return Calendar.class.getName();
 		}
 
-		return Optional.empty();
+		return null;
 	}
 
 }

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/SearchCTTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/SearchCTTest.java
@@ -425,8 +425,7 @@ public class SearchCTTest {
 
 			DocumentsAssert.assertValuesIgnoreRelevance(
 				searchResponse.getRequestString(),
-				searchResponse.getDocumentsStream(), Field.UID,
-				Stream.of(uids));
+				searchResponse.getDocuments(), Field.UID, Stream.of(uids));
 		}
 	}
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/search/permission/DDLRecordSearchPermissionFilterContributor.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/search/permission/DDLRecordSearchPermissionFilterContributor.java
@@ -18,8 +18,6 @@ import com.liferay.dynamic.data.lists.model.DDLRecord;
 import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 import com.liferay.portal.search.permission.SearchPermissionFilterContributor;
 
-import java.util.Optional;
-
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -30,14 +28,12 @@ public class DDLRecordSearchPermissionFilterContributor
 	implements SearchPermissionFilterContributor {
 
 	@Override
-	public Optional<String> getParentEntryClassNameOptional(
-		String entryClassName) {
-
+	public String getParentEntryClassName(String entryClassName) {
 		if (entryClassName.equals(DDLRecord.class.getName())) {
-			return Optional.of(DDLRecordSet.class.getName());
+			return DDLRecordSet.class.getName();
 		}
 
-		return Optional.empty();
+		return null;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/permission/DDMFormInstanceRecordSearchPermissionFilterContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/permission/DDMFormInstanceRecordSearchPermissionFilterContributor.java
@@ -18,8 +18,6 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
 import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
 import com.liferay.portal.search.permission.SearchPermissionFilterContributor;
 
-import java.util.Optional;
-
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -30,14 +28,12 @@ public class DDMFormInstanceRecordSearchPermissionFilterContributor
 	implements SearchPermissionFilterContributor {
 
 	@Override
-	public Optional<String> getParentEntryClassNameOptional(
-		String entryClassName) {
-
+	public String getParentEntryClassName(String entryClassName) {
 		if (entryClassName.equals(DDMFormInstanceRecord.class.getName())) {
-			return Optional.of(DDMFormInstance.class.getName());
+			return DDMFormInstance.class.getName();
 		}
 
-		return Optional.empty();
+		return null;
 	}
 
 }

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleExpandoGeolocationSearchTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleExpandoGeolocationSearchTest.java
@@ -290,8 +290,8 @@ public class JournalArticleExpandoGeolocationSearchTest {
 			).build());
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), fieldName, expected);
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			fieldName, expected);
 	}
 
 	@Inject

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleExpandoSearchTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleExpandoSearchTest.java
@@ -171,8 +171,7 @@ public class JournalArticleExpandoSearchTest {
 			).build());
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(),
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
 			"expando__keyword__custom_fields__" + _EXPANDO_COLUMN, expected);
 	}
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
@@ -41,7 +41,6 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
@@ -50,8 +49,6 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -287,18 +284,8 @@ public class JournalArticleIndexVersionsTest {
 
 		Assert.assertEquals(
 			searchResponse.getRequestString() + "->" +
-				_toString(searchResponse.getDocumentsStream()),
+				searchResponse.getDocuments(),
 			expectedCount, searchResponse.getCount());
-	}
-
-	private String _toString(Stream<Document> stream) {
-		return stream.map(
-			Document::getFields
-		).map(
-			String::valueOf
-		).collect(
-			Collectors.joining()
-		);
 	}
 
 	@Inject

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/hits/SearchHitsTranslator.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/hits/SearchHitsTranslator.java
@@ -32,7 +32,6 @@ import com.liferay.portal.search.hits.SearchHitsBuilderFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.TotalHits;
@@ -163,13 +162,15 @@ public class SearchHitsTranslator {
 		org.elasticsearch.search.fetch.subphase.highlight.HighlightField
 			elasticsearchHighlightField) {
 
+		List<String> fragments = new ArrayList<>();
+
+		for (Text text : elasticsearchHighlightField.getFragments()) {
+			fragments.add(text.string());
+		}
+
 		return _highlightFieldBuilderFactory.builder(
 		).fragments(
-			Stream.of(
-				elasticsearchHighlightField.getFragments()
-			).map(
-				Text::string
-			)
+			fragments
 		).name(
 			elasticsearchHighlightField.getName()
 		).build();

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/GeoLocationPointFieldTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/document/GeoLocationPointFieldTest.java
@@ -95,7 +95,7 @@ public class GeoLocationPointFieldTest extends BaseIndexingTestCase {
 				indexingTestHelper.verifyResponse(
 					searchResponse -> DocumentsAssert.assertValues(
 						searchResponse.getRequestString(),
-						searchResponse.getDocumentsStream(), fieldName,
+						searchResponse.getDocuments(), fieldName,
 						"[" + expected + "]"));
 			});
 	}

--- a/modules/apps/portal-search/portal-search-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search API
 Bundle-SymbolicName: com.liferay.portal.search.api
-Bundle-Version: 10.0.1
+Bundle-Version: 11.0.0
 Export-Package:\
 	com.liferay.portal.search.aggregation,\
 	com.liferay.portal.search.aggregation.bucket,\

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/highlight/HighlightFieldBuilder.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/highlight/HighlightFieldBuilder.java
@@ -14,7 +14,7 @@
 
 package com.liferay.portal.search.highlight;
 
-import java.util.stream.Stream;
+import java.util.List;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -29,7 +29,7 @@ public interface HighlightFieldBuilder {
 
 	public HighlightField build();
 
-	public HighlightFieldBuilder fragments(Stream<String> fragmentStream);
+	public HighlightFieldBuilder fragments(List<String> fragmentStream);
 
 	public HighlightFieldBuilder name(String name);
 

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/hits/SearchHitBuilder.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/hits/SearchHitBuilder.java
@@ -19,7 +19,6 @@ import com.liferay.portal.search.highlight.HighlightField;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -33,14 +32,6 @@ public interface SearchHitBuilder {
 
 	public SearchHitBuilder addHighlightFields(
 		Collection<HighlightField> highlightFields);
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #addHighlightFields(Collection)}
-	 */
-	@Deprecated
-	public SearchHitBuilder addHighlightFields(
-		Stream<HighlightField> highlightFieldStream);
 
 	public SearchHitBuilder addSource(String name, Object value);
 

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/hits/SearchHitsBuilder.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/hits/SearchHitsBuilder.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.search.hits;
 
 import java.util.Collection;
-import java.util.stream.Stream;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -28,13 +27,6 @@ public interface SearchHitsBuilder {
 	public SearchHitsBuilder addSearchHit(SearchHit searchHit);
 
 	public SearchHitsBuilder addSearchHits(Collection<SearchHit> searchHits);
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #addSearchHits(Collection)}
-	 */
-	@Deprecated
-	public SearchHitsBuilder addSearchHits(Stream<SearchHit> searchHitStream);
 
 	public SearchHits build();
 

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/indexer/BaseModelRetriever.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/indexer/BaseModelRetriever.java
@@ -16,8 +16,6 @@ package com.liferay.portal.search.indexer;
 
 import com.liferay.portal.kernel.model.BaseModel;
 
-import java.util.Optional;
-
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -26,7 +24,6 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface BaseModelRetriever {
 
-	public Optional<BaseModel<?>> fetchBaseModel(
-		String className, long classPK);
+	public BaseModel<?> fetchBaseModel(String className, long classPK);
 
 }

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/permission/SearchPermissionFilterContributor.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/permission/SearchPermissionFilterContributor.java
@@ -14,14 +14,11 @@
 
 package com.liferay.portal.search.permission;
 
-import java.util.Optional;
-
 /**
  * @author Bryan Engler
  */
 public interface SearchPermissionFilterContributor {
 
-	public Optional<String> getParentEntryClassNameOptional(
-		String entryClassName);
+	public String getParentEntryClassName(String entryClassName);
 
 }

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/searcher/SearchResponse.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/searcher/SearchResponse.java
@@ -22,11 +22,11 @@ import com.liferay.portal.search.groupby.GroupByResponse;
 import com.liferay.portal.search.hits.SearchHits;
 import com.liferay.portal.search.stats.StatsResponse;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -46,15 +46,15 @@ public interface SearchResponse {
 
 	public long getCount();
 
-	public List<com.liferay.portal.kernel.search.Document> getDocuments71();
+	public List<Document> getDocuments();
 
-	public Stream<Document> getDocumentsStream();
+	public List<com.liferay.portal.kernel.search.Document> getDocuments71();
 
 	public String getFederatedSearchKey();
 
 	public SearchResponse getFederatedSearchResponse(String key);
 
-	public Stream<SearchResponse> getFederatedSearchResponsesStream();
+	public Collection<SearchResponse> getFederatedSearchResponses();
 
 	/**
 	 * Returns the map containing the top hits aggregations for each field.

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/highlight/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/highlight/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/hits/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/hits/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/indexer/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/indexer/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 2.0.0

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/permission/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/permission/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/searcher/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/searcher/packageinfo
@@ -1,1 +1,1 @@
-version 1.11.0
+version 2.0.0

--- a/modules/apps/portal-search/portal-search-test-util/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search Test Utilities
 Bundle-SymbolicName: com.liferay.portal.search.test.util
-Bundle-Version: 7.0.1
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.portal.search.test.util,\
 	com.liferay.portal.search.test.util.logging

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/DocumentsAssert.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/DocumentsAssert.java
@@ -68,10 +68,10 @@ public class DocumentsAssert {
 	}
 
 	public static void assertValues(
-		String message, Stream<Document> stream, String fieldName,
+		String message, List<Document> documentList, String fieldName,
 		String expected) {
 
-		Document[] documents = stream.toArray(Document[]::new);
+		Document[] documents = documentList.toArray(new Document[0]);
 
 		List<String> actualValues = _getFieldValueStrings(fieldName, documents);
 
@@ -92,10 +92,10 @@ public class DocumentsAssert {
 	}
 
 	public static void assertValuesIgnoreRelevance(
-		String message, Stream<Document> stream, String fieldName,
+		String message, List<Document> documentList, String fieldName,
 		Stream<?> expectedValues) {
 
-		Document[] documents = stream.toArray(Document[]::new);
+		Document[] documents = documentList.toArray(new Document[0]);
 
 		List<String> actualValues = _getFieldValueStrings(fieldName, documents);
 
@@ -105,10 +105,10 @@ public class DocumentsAssert {
 	}
 
 	public static void assertValuesIgnoreRelevance(
-		String message, Stream<Document> stream, String fieldName,
+		String message, List<Document> documentList, String fieldName,
 		String expected) {
 
-		Document[] documents = stream.toArray(Document[]::new);
+		Document[] documents = documentList.toArray(new Document[0]);
 
 		List<String> actualValues = _getFieldValueStrings(fieldName, documents);
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FieldValuesAssert.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FieldValuesAssert.java
@@ -64,9 +64,7 @@ public class FieldValuesAssert {
 		Map<String, String> expectedFieldValuesMap = _toStringValuesMap(
 			expected);
 
-		Stream<Document> stream = searchResponse.getDocumentsStream();
-
-		List<Document> documents = stream.collect(Collectors.toList());
+		List<Document> documents = searchResponse.getDocuments();
 
 		if (documents.size() == 1) {
 			Map<String, String> actualFieldValuesMap = _toFieldValuesMap(

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/filter/groupid/BaseGroupIdQueryPreFilterContributorTestCase.java
@@ -162,7 +162,7 @@ public abstract class BaseGroupIdQueryPreFilterContributorTestCase
 					searchResponse ->
 						DocumentsAssert.assertValuesIgnoreRelevance(
 							searchResponse.getRequestString(),
-							searchResponse.getDocumentsStream(), Field.GROUP_ID,
+							searchResponse.getDocuments(), Field.GROUP_ID,
 							expected));
 			});
 	}

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseLiferayFieldQueryFactoryTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseLiferayFieldQueryFactoryTestCase.java
@@ -291,7 +291,7 @@ public abstract class BaseLiferayFieldQueryFactoryTestCase
 				indexingTestHelper.verifyResponse(
 					searchResponse -> DocumentsAssert.assertValues(
 						searchResponse.getRequestString(),
-						searchResponse.getDocumentsStream(), _fieldName,
+						searchResponse.getDocuments(), _fieldName,
 						StringPool.OPEN_BRACKET + getExpected(hit) +
 							StringPool.CLOSE_BRACKET));
 			});

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseNestedFieldsTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseNestedFieldsTestCase.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.FieldArray;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.engine.adapter.index.GetFieldMappingIndexRequest;
@@ -266,9 +267,11 @@ public abstract class BaseNestedFieldsTestCase extends BaseIndexingTestCase {
 					searchResponse -> {
 						assertOneResult(searchResponse);
 
-						Document document = searchResponse.getDocumentsStream(
-						).findAny(
-						).get();
+						List<Document> documents =
+							searchResponse.getDocuments();
+
+						Document document = documents.get(
+							RandomTestUtil.randomInt(0, documents.size() - 1));
 
 						List<?> values = document.getValues("ddmFieldArray");
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseIdsQueryTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseIdsQueryTestCase.java
@@ -30,9 +30,9 @@ import com.liferay.portal.search.sort.SortOrder;
 import com.liferay.portal.search.test.util.DocumentsAssert;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 
 import org.junit.Test;
 
@@ -110,20 +110,20 @@ public abstract class BaseIdsQueryTestCase extends BaseIndexingTestCase {
 		SearchSearchResponse searchSearchResponse = searchEngineAdapter.execute(
 			searchSearchRequest);
 
-		Stream<Document> stream = getDocumentsStream(
-			searchSearchResponse.getSearchHits());
-
 		DocumentsAssert.assertValues(
-			searchSearchResponse.getSearchRequestString(), stream,
+			searchSearchResponse.getSearchRequestString(),
+			getDocumentsStream(searchSearchResponse.getSearchHits()),
 			Field.USER_NAME, expected);
 	}
 
-	protected Stream<Document> getDocumentsStream(SearchHits searchHits) {
-		List<SearchHit> list = searchHits.getSearchHits();
+	protected List<Document> getDocumentsStream(SearchHits searchHits) {
+		List<Document> documents = new ArrayList<>();
 
-		Stream<SearchHit> stream = list.stream();
+		for (SearchHit searchHit : searchHits.getSearchHits()) {
+			documents.add(searchHit.getDocument());
+		}
 
-		return stream.map(SearchHit::getDocument);
+		return documents;
 	}
 
 	protected SearchSearchRequest getSearchSearchRequest(Query query) {

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseMatchAllQueryTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseMatchAllQueryTestCase.java
@@ -73,7 +73,7 @@ public abstract class BaseMatchAllQueryTestCase extends BaseIndexingTestCase {
 
 						DocumentsAssert.assertValues(
 							searchResponse.getRequestString(),
-							searchResponse.getDocumentsStream(), Field.PRIORITY,
+							searchResponse.getDocuments(), Field.PRIORITY,
 							String.valueOf(list));
 					});
 			});
@@ -112,7 +112,7 @@ public abstract class BaseMatchAllQueryTestCase extends BaseIndexingTestCase {
 
 						DocumentsAssert.assertValues(
 							searchResponse.getRequestString(),
-							searchResponse.getDocumentsStream(), Field.PRIORITY,
+							searchResponse.getDocuments(), Field.PRIORITY,
 							"[]");
 					});
 			});

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseTermsQueryTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseTermsQueryTestCase.java
@@ -66,8 +66,8 @@ public abstract class BaseTermsQueryTestCase extends BaseIndexingTestCase {
 					searchResponse -> {
 						DocumentsAssert.assertValues(
 							searchResponse.getRequestString(),
-							searchResponse.getDocumentsStream(),
-							Field.USER_NAME, expected);
+							searchResponse.getDocuments(), Field.USER_NAME,
+							expected);
 
 						SearchHits searchHits = searchResponse.getSearchHits();
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseTermsSetQueryTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseTermsSetQueryTestCase.java
@@ -93,8 +93,8 @@ public abstract class BaseTermsSetQueryTestCase extends BaseIndexingTestCase {
 					searchResponse ->
 						DocumentsAssert.assertValuesIgnoreRelevance(
 							searchResponse.getRequestString(),
-							searchResponse.getDocumentsStream(),
-							Field.USER_NAME, expected));
+							searchResponse.getDocuments(), Field.USER_NAME,
+							expected));
 			});
 	}
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseNestedFieldsSortTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseNestedFieldsSortTestCase.java
@@ -22,10 +22,10 @@ import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
 import com.liferay.portal.search.test.util.mappings.NestedDDMFieldArrayUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.Assert;
@@ -110,13 +110,13 @@ public abstract class BaseNestedFieldsSortTestCase
 	protected List<?> getDDMFieldValues(
 		String fieldName, SearchResponse searchResponse) {
 
-		Stream<Document> stream = searchResponse.getDocumentsStream();
+		List<Object> ddmFieldValues = new ArrayList<>();
 
-		return stream.map(
-			document -> getDDMFieldValue(fieldName, document)
-		).collect(
-			Collectors.toList()
-		);
+		for (Document document : searchResponse.getDocuments()) {
+			ddmFieldValues.add(getDDMFieldValue(fieldName, document));
+		}
+
+		return ddmFieldValues;
 	}
 
 }

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseSortUnmappedFieldsTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/sort/BaseSortUnmappedFieldsTestCase.java
@@ -184,8 +184,7 @@ public abstract class BaseSortUnmappedFieldsTestCase
 				indexingTestHelper.verifyResponse(
 					searchResponse -> DocumentsAssert.assertValues(
 						searchResponse.getRequestString(),
-						searchResponse.getDocumentsStream(), fieldName,
-						expected));
+						searchResponse.getDocuments(), fieldName, expected));
 			});
 	}
 

--- a/modules/apps/portal-search/portal-search-test-util/src/main/resources/com/liferay/portal/search/test/util/packageinfo
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/resources/com/liferay/portal/search/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FacetPermissionCharacteristicTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FacetPermissionCharacteristicTest.java
@@ -275,8 +275,8 @@ public class FacetPermissionCharacteristicTest {
 			).build());
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), "title_en_US", expected);
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			"title_en_US", expected);
 	}
 
 	private String _getName(Object object) {

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clause/contributors/test/IndexerClauseContributorsTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clause/contributors/test/IndexerClauseContributorsTest.java
@@ -350,8 +350,8 @@ public class IndexerClauseContributorsTest {
 			).build());
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), _TITLE_EN_US, expected);
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			_TITLE_EN_US, expected);
 	}
 
 	protected Consumer<SearchRequestBuilder> withExcludes(String... excludes) {

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clauses/test/IndexerClausesChangeTrackingTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clauses/test/IndexerClausesChangeTrackingTest.java
@@ -293,8 +293,8 @@ public class IndexerClausesChangeTrackingTest {
 		}
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), _TITLE_EN_US, expected);
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			_TITLE_EN_US, expected);
 	}
 
 	protected void updateJournalArticle(

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clauses/test/IndexerClausesComplexQueryPartTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clauses/test/IndexerClausesComplexQueryPartTest.java
@@ -291,7 +291,7 @@ public class IndexerClausesComplexQueryPartTest {
 		}
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			requestString, searchResponse.getDocumentsStream(), _TITLE_EN_US,
+			requestString, searchResponse.getDocuments(), _TITLE_EN_US,
 			expected);
 	}
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clauses/test/IndexerClausesExpandoTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clauses/test/IndexerClausesExpandoTest.java
@@ -169,8 +169,7 @@ public class IndexerClausesExpandoTest {
 			).build());
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(),
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
 			"expando__keyword__custom_fields__" + _EXPANDO_COLUMN, expected);
 	}
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clauses/test/IndexerClausesPermissionTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clauses/test/IndexerClausesPermissionTest.java
@@ -297,7 +297,7 @@ public class IndexerClausesPermissionTest {
 		}
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			requestString, searchResponse.getDocumentsStream(), _TITLE_EN_US,
+			requestString, searchResponse.getDocuments(), _TITLE_EN_US,
 			expected);
 	}
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clauses/test/IndexerClausesTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/clauses/test/IndexerClausesTest.java
@@ -228,8 +228,8 @@ public class IndexerClausesTest {
 			).build());
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), _TITLE_EN_US, expected);
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			_TITLE_EN_US, expected);
 	}
 
 	protected Consumer<SearchRequestBuilder> withoutIndexerClauses() {

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/scores/test/IndexerScoreDistortionTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/indexer/scores/test/IndexerScoreDistortionTest.java
@@ -140,11 +140,11 @@ public class IndexerScoreDistortionTest {
 			Field.ENTRY_CLASS_NAME,
 			getClassNamesAsString(
 				BlogsEntry.class, MBMessage.class, WikiPage.class),
-			_limit(searchResponse1.getDocumentsStream(), 3), searchResponse1);
+			_limit(searchResponse1.getDocuments(), 3), searchResponse1);
 		assertValuesIgnoreRelevance(
 			Field.ENTRY_CLASS_NAME,
 			getClassNamesAsString(DLFileEntry.class, JournalArticle.class),
-			_skip(searchResponse1.getDocumentsStream(), 3), searchResponse1);
+			_skip(searchResponse1.getDocuments(), 3), searchResponse1);
 
 		SearchResponse searchResponse2 = search(
 			title, locale, classes,
@@ -255,15 +255,16 @@ public class IndexerScoreDistortionTest {
 
 		DocumentsAssert.assertValues(
 			getMessage(fieldName, searchResponse),
-			searchResponse.getDocumentsStream(), fieldName, expected);
+			searchResponse.getDocuments(), fieldName, expected);
 	}
 
 	protected void assertValuesIgnoreRelevance(
-		String fieldName, String expected, Stream<Document> stream,
+		String fieldName, String expected, List<Document> documents,
 		SearchResponse searchResponse) {
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			getMessage(fieldName, searchResponse), stream, fieldName, expected);
+			getMessage(fieldName, searchResponse), documents, fieldName,
+			expected);
 	}
 
 	protected String getClassNamesAsString(Class... classes) {
@@ -344,12 +345,12 @@ public class IndexerScoreDistortionTest {
 			_group.getGroupId(), _user.getUserId());
 	}
 
-	private Stream<Document> _limit(Stream<Document> stream, long maxSize) {
-		return stream.limit(maxSize);
+	private List<Document> _limit(List<Document> documents, int maxSize) {
+		return documents.subList(0, maxSize);
 	}
 
-	private Stream<Document> _skip(Stream<Document> stream, long n) {
-		return stream.skip(n);
+	private List<Document> _skip(List<Document> documents, int n) {
+		return documents.subList(n, documents.size());
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/SearchRequestBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/searcher/test/SearchRequestBuilderTest.java
@@ -385,8 +385,8 @@ public class SearchRequestBuilderTest {
 			searchRequestBuilder.build());
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), fieldName, expected);
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			fieldName, expected);
 	}
 
 	private void _assertSearch(
@@ -417,8 +417,8 @@ public class SearchRequestBuilderTest {
 			searchRequestBuilder.build());
 
 		DocumentsAssert.assertValues(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), fieldName, expected);
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			fieldName, expected);
 	}
 
 	private void _assertSearch(
@@ -437,8 +437,8 @@ public class SearchRequestBuilderTest {
 			).build());
 
 		DocumentsAssert.assertValues(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), fieldName, expected);
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			fieldName, expected);
 	}
 
 	private Rescore _buildRescore(String fieldName, String value) {

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/highlight/HighlightFieldImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/highlight/HighlightFieldImpl.java
@@ -20,8 +20,6 @@ import com.liferay.portal.search.highlight.HighlightFieldBuilder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Michael C. Han
@@ -62,9 +60,8 @@ public class HighlightFieldImpl implements HighlightField {
 		}
 
 		@Override
-		public HighlightFieldBuilder fragments(Stream<String> fragmentStream) {
-			_highlightFieldImpl._fragments = fragmentStream.collect(
-				Collectors.toList());
+		public HighlightFieldBuilder fragments(List<String> fragments) {
+			_highlightFieldImpl._fragments = fragments;
 
 			return this;
 		}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/hits/SearchHitImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/hits/SearchHitImpl.java
@@ -25,8 +25,6 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Michael C. Han
@@ -120,21 +118,6 @@ public class SearchHitImpl implements SearchHit, Serializable {
 			Collection<HighlightField> highlightFields) {
 
 			_searchHitImpl.addHighlightFields(highlightFields);
-
-			return this;
-		}
-
-		/**
-		 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-		 *             #addHighlightFields(Collection)}
-		 */
-		@Deprecated
-		@Override
-		public SearchHitBuilder addHighlightFields(
-			Stream<HighlightField> highlightFieldStream) {
-
-			_searchHitImpl.addHighlightFields(
-				highlightFieldStream.collect(Collectors.toList()));
 
 			return this;
 		}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/hits/SearchHitsImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/hits/SearchHitsImpl.java
@@ -23,8 +23,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Michael C. Han
@@ -84,21 +82,6 @@ public class SearchHitsImpl implements SearchHits, Serializable {
 			Collection<SearchHit> searchHits) {
 
 			_searchHitsImpl.addSearchHits(searchHits);
-
-			return this;
-		}
-
-		/**
-		 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-		 *             #addSearchHits(Collection)}
-		 */
-		@Deprecated
-		@Override
-		public SearchHitsBuilder addSearchHits(
-			Stream<SearchHit> searchHitStream) {
-
-			_searchHitsImpl.addSearchHits(
-				searchHitStream.collect(Collectors.toList()));
 
 			return this;
 		}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java
@@ -25,8 +25,6 @@ import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.search.indexer.BaseModelRetriever;
 
-import java.util.Optional;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -37,13 +35,11 @@ import org.osgi.service.component.annotations.Reference;
 public class BaseModelRetrieverImpl implements BaseModelRetriever {
 
 	@Override
-	public Optional<BaseModel<?>> fetchBaseModel(
-		String className, long classPK) {
-
+	public BaseModel<?> fetchBaseModel(String className, long classPK) {
 		PersistedModel persistModel = _getPersistedModel(className, classPK);
 
 		if (persistModel == null) {
-			return Optional.empty();
+			return null;
 		}
 
 		if (!(persistModel instanceof BaseModel)) {
@@ -51,10 +47,10 @@ public class BaseModelRetrieverImpl implements BaseModelRetriever {
 				_log.warn(persistModel + " is not a base model");
 			}
 
-			return Optional.empty();
+			return null;
 		}
 
-		return Optional.ofNullable((BaseModel<?>)persistModel);
+		return (BaseModel<?>)persistModel;
 	}
 
 	private PersistedModel _getPersistedModel(String className, long classPK) {

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
@@ -43,7 +43,6 @@ import com.liferay.portal.search.spi.model.index.contributor.helper.IndexerWrite
 import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
 
 import java.util.Collection;
-import java.util.Optional;
 
 /**
  * @author Michael C. Han
@@ -154,11 +153,14 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 			return;
 		}
 
-		Optional<BaseModel<?>> baseModelOptional =
-			_baseModelRetriever.fetchBaseModel(
-				_modelSearchSettings.getClassName(), classPK);
+		BaseModel<?> baseModel = _baseModelRetriever.fetchBaseModel(
+			_modelSearchSettings.getClassName(), classPK);
 
-		baseModelOptional.ifPresent(baseModel -> reindex((T)baseModel));
+		if (baseModel == null) {
+			return;
+		}
+
+		reindex((T)baseModel);
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/helper/PreFilterContributorHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/helper/PreFilterContributorHelperImpl.java
@@ -176,17 +176,9 @@ public class PreFilterContributorHelperImpl
 			return;
 		}
 
-		String permissionedEntryClassName = entryClassName;
-
-		String parentEntryClassName = _getParentEntryClassName(entryClassName);
-
-		if (parentEntryClassName != null) {
-			permissionedEntryClassName = parentEntryClassName;
-		}
-
 		searchPermissionChecker.getPermissionBooleanFilter(
 			searchContext.getCompanyId(), searchContext.getGroupIds(),
-			searchContext.getUserId(), permissionedEntryClassName,
+			searchContext.getUserId(), _getParentEntryClassName(entryClassName),
 			booleanFilter, searchContext);
 	}
 
@@ -249,7 +241,7 @@ public class PreFilterContributorHelperImpl
 			}
 		}
 
-		return null;
+		return entryClassName;
 	}
 
 	private ServiceTrackerList<SearchPermissionFilterContributor>

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/helper/PreFilterContributorHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/helper/PreFilterContributorHelperImpl.java
@@ -176,10 +176,13 @@ public class PreFilterContributorHelperImpl
 			return;
 		}
 
-		Optional<String> optional = _getParentEntryClassNameOptional(
-			entryClassName);
+		String permissionedEntryClassName = entryClassName;
 
-		String permissionedEntryClassName = optional.orElse(entryClassName);
+		String parentEntryClassName = _getParentEntryClassName(entryClassName);
+
+		if (parentEntryClassName != null) {
+			permissionedEntryClassName = parentEntryClassName;
+		}
 
 		searchPermissionChecker.getPermissionBooleanFilter(
 			searchContext.getCompanyId(), searchContext.getGroupIds(),
@@ -232,25 +235,21 @@ public class PreFilterContributorHelperImpl
 		return modelSearchSettingsImpl;
 	}
 
-	private Optional<String> _getParentEntryClassNameOptional(
-		String entryClassName) {
-
+	private String _getParentEntryClassName(String entryClassName) {
 		for (SearchPermissionFilterContributor
 				searchPermissionFilterContributor :
 					_serviceTrackerList.toList()) {
 
-			Optional<String> parentEntryClassNameOptional =
-				searchPermissionFilterContributor.
-					getParentEntryClassNameOptional(entryClassName);
+			String parentEntryClassName =
+				searchPermissionFilterContributor.getParentEntryClassName(
+					entryClassName);
 
-			if ((parentEntryClassNameOptional != null) &&
-				parentEntryClassNameOptional.isPresent()) {
-
-				return parentEntryClassNameOptional;
+			if (parentEntryClassName != null) {
+				return parentEntryClassName;
 			}
 		}
 
-		return Optional.empty();
+		return null;
 	}
 
 	private ServiceTrackerList<SearchPermissionFilterContributor>

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearchResponseImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearchResponseImpl.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 /**
  * @author André de Oliveira
@@ -79,26 +78,27 @@ public class SearchResponseImpl implements SearchResponse, Serializable {
 	}
 
 	@Override
+	public List<Document> getDocuments() {
+		if (_searchHits == null) {
+			return Collections.emptyList();
+		}
+
+		List<Document> documents = new ArrayList<>();
+
+		for (SearchHit searchHit : _searchHits.getSearchHits()) {
+			documents.add(searchHit.getDocument());
+		}
+
+		return documents;
+	}
+
+	@Override
 	public List<com.liferay.portal.kernel.search.Document> getDocuments71() {
 		if (_hits == null) {
 			return Collections.emptyList();
 		}
 
 		return Arrays.asList(_hits.getDocs());
-	}
-
-	@Override
-	public Stream<Document> getDocumentsStream() {
-		if (_searchHits == null) {
-			return Stream.empty();
-		}
-
-		List<SearchHit> list = _searchHits.getSearchHits();
-
-		return list.stream(
-		).map(
-			SearchHit::getDocument
-		);
 	}
 
 	@Override
@@ -116,11 +116,8 @@ public class SearchResponseImpl implements SearchResponse, Serializable {
 	}
 
 	@Override
-	public Stream<SearchResponse> getFederatedSearchResponsesStream() {
-		Collection<SearchResponse> searchResponses =
-			_federatedSearchResponsesMap.values();
-
-		return searchResponses.stream();
+	public Collection<SearchResponse> getFederatedSearchResponses() {
+		return _federatedSearchResponsesMap.values();
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/SearchResponseImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/SearchResponseImplTest.java
@@ -23,8 +23,6 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -50,13 +48,14 @@ public class SearchResponseImplTest {
 		_assertIs(searchResponse.getAggregationResultsMap(), _emptyMap());
 		_assertIs(searchResponse.getCount(), _zeroLong());
 		_assertIs(searchResponse.getDocuments71(), emptyList());
-		_assertIs(searchResponse.getDocumentsStream(), _emptyStream());
+		_assertIs(searchResponse.getDocuments(), emptyList());
 		_assertIs(searchResponse.getFederatedSearchKey(), _blank());
 		_assertIs(
 			searchResponse.getFederatedSearchResponse(null),
 			same(searchResponse));
 		_assertIs(
-			searchResponse.getFederatedSearchResponsesStream(), _emptyStream());
+			searchResponse.getFederatedSearchResponses(),
+			values -> Assert.assertTrue(values.isEmpty()));
 		_assertIs(searchResponse.getGroupByResponses(), emptyList());
 		_assertIs(searchResponse.getRequest(), _nullValue());
 		_assertIs(searchResponse.getRequestString(), _blank());
@@ -85,17 +84,6 @@ public class SearchResponseImplTest {
 
 	private Consumer<Map<String, ?>> _emptyMap() {
 		return map -> Assert.assertEquals("{}", String.valueOf(map));
-	}
-
-	private Consumer<Stream<?>> _emptyStream() {
-		return stream -> Assert.assertEquals(
-			"[]",
-			String.valueOf(
-				stream.map(
-					String::valueOf
-				).collect(
-					Collectors.toList()
-				)));
 	}
 
 	private Consumer<Object> _instanceOf(Class<?> clazz) {

--- a/modules/apps/user-groups-admin/user-groups-admin-web-test/src/testIntegration/java/com/liferay/user/groups/admin/web/internal/search/test/UserGroupIndexerTest.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web-test/src/testIntegration/java/com/liferay/user/groups/admin/web/internal/search/test/UserGroupIndexerTest.java
@@ -117,9 +117,8 @@ public class UserGroupIndexerTest {
 		Stream<UserGroup> stream = userGroups.stream();
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse1.getRequestString(),
-			searchResponse1.getDocumentsStream(), Field.NAME,
-			stream.map(UserGroup::getName));
+			searchResponse1.getRequestString(), searchResponse1.getDocuments(),
+			Field.NAME, stream.map(UserGroup::getName));
 
 		SearchRequestBuilder searchRequestBuilder2 = _getSearchRequestBuilder(
 			companyId);

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/OrganizationIndexerTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/OrganizationIndexerTest.java
@@ -37,8 +37,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -143,11 +141,9 @@ public class OrganizationIndexerTest {
 	protected void assertHits(String keywords, int length) throws Exception {
 		SearchResponse searchResponse = search(keywords);
 
-		Stream<Document> stream = searchResponse.getDocumentsStream();
-
 		AssertUtils.assertEquals(
 			() -> StringBundler.concat(
-				keywords, "->", stream.collect(Collectors.toList())),
+				keywords, "->", searchResponse.getDocuments()),
 			length, searchResponse.getTotalHits());
 	}
 
@@ -160,13 +156,13 @@ public class OrganizationIndexerTest {
 	protected List<String> getNames(String keywords) throws Exception {
 		SearchResponse searchResponse = search(keywords);
 
-		Stream<Document> stream = searchResponse.getDocumentsStream();
+		List<String> names = new ArrayList<>();
 
-		return stream.map(
-			document -> document.getString(Field.NAME)
-		).collect(
-			Collectors.toList()
-		);
+		for (Document document : searchResponse.getDocuments()) {
+			names.add(document.getString(Field.NAME));
+		}
+
+		return names;
 	}
 
 	protected SearchResponse search(String keywords) throws Exception {

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserGroupCascadeReindexUsersTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserGroupCascadeReindexUsersTest.java
@@ -168,9 +168,8 @@ public class UserGroupCascadeReindexUsersTest {
 		SearchResponse searchResponse = searchUsersInUserGroup(userGroup);
 
 		DocumentsAssert.assertValues(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), "userGroupIds",
-			_repeat(String.valueOf(userGroupId), users.size()));
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			"userGroupIds", _repeat(String.valueOf(userGroupId), users.size()));
 
 		List<Group> groups = addGroups(_groupCount);
 
@@ -182,8 +181,8 @@ public class UserGroupCascadeReindexUsersTest {
 		searchResponse = searchUsersInGroup(groups.get(0));
 
 		DocumentsAssert.assertValues(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), Field.GROUP_ID,
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			Field.GROUP_ID,
 			_repeat(_getAllGroupIdsString(groups), users.size()));
 	}
 

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsByAssociationTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsByAssociationTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -257,10 +258,10 @@ public class UserIndexerIndexedFieldsByAssociationTest {
 				_queries.term(Field.USER_ID, TestPropsValues.getUserId())
 			).build());
 
-		Stream<Document> stream = searchResponse1.getDocumentsStream();
+		List<Document> documents = searchResponse1.getDocuments();
 
-		Document document = stream.findAny(
-		).get();
+		Document document = documents.get(
+			RandomTestUtil.randomInt(0, documents.size() - 1));
 
 		List<Long> groupIds = document.getLongs(Field.GROUP_ID);
 
@@ -268,8 +269,7 @@ public class UserIndexerIndexedFieldsByAssociationTest {
 
 		if (!groupIds.contains(groupId)) {
 			DocumentsAssert.assertValuesIgnoreRelevance(
-				searchResponse1.getRequestString(),
-				searchResponse1.getDocumentsStream(), Field.GROUP_ID,
+				searchResponse1.getRequestString(), documents, Field.GROUP_ID,
 				_toSingletonListString(_toSortedListString(groupIds.stream())));
 		}
 
@@ -279,8 +279,8 @@ public class UserIndexerIndexedFieldsByAssociationTest {
 			).build());
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse2.getRequestString(),
-			searchResponse2.getDocumentsStream(), Field.GROUP_ID,
+			searchResponse2.getRequestString(), searchResponse2.getDocuments(),
+			Field.GROUP_ID,
 			_toSingletonListString(_toSortedListString(groupIds.stream())));
 	}
 
@@ -324,10 +324,9 @@ public class UserIndexerIndexedFieldsByAssociationTest {
 				_queries.term(Field.ENTRY_CLASS_PK, user.getPrimaryKeyObj())
 			).build());
 
-		Stream<Document> stream = searchResponse.getDocumentsStream();
+		List<Document> documents = searchResponse.getDocuments();
 
-		Document document = stream.findFirst(
-		).get();
+		Document document = documents.get(0);
 
 		return indexedFieldsFixture.postProcessDocument(document);
 	}

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserReindexerPerformanceOfLargeUserGroupInManySitesTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserReindexerPerformanceOfLargeUserGroupInManySitesTest.java
@@ -259,9 +259,8 @@ public class UserReindexerPerformanceOfLargeUserGroupInManySitesTest {
 			groups, getTestUserId());
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), Field.USER_ID,
-			_getUserIdsStream(users));
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			Field.USER_ID, _getUserIdsStream(users));
 	}
 
 	protected SearchRequestBuilder getSearchRequestBuilder(long companyId) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetSearchResultsBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetSearchResultsBuilder.java
@@ -30,9 +30,6 @@ import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.search.tuning.rankings.web.internal.util.RankingResultUtil;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
 
@@ -98,11 +95,11 @@ public class RankingGetSearchResultsBuilder {
 	}
 
 	protected JSONArray buildDocuments(SearchResponse searchResponse) {
-		List<JSONObject> jsonObjects = _getElements(searchResponse);
-
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		jsonObjects.forEach(jsonArray::put);
+		for (Document document : searchResponse.getDocuments()) {
+			jsonArray.put(translate(document));
+		}
 
 		return jsonArray;
 	}
@@ -137,16 +134,6 @@ public class RankingGetSearchResultsBuilder {
 		).viewURL(
 			_getViewURL(document)
 		).build();
-	}
-
-	private List<JSONObject> _getElements(SearchResponse searchResponse) {
-		List<JSONObject> jsonObjects = new ArrayList<>();
-
-		for (Document document : searchResponse.getDocuments()) {
-			jsonObjects.add(translate(document));
-		}
-
-		return jsonObjects;
 	}
 
 	private String _getViewURL(Document document) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetSearchResultsBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetSearchResultsBuilder.java
@@ -30,7 +30,8 @@ import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.search.tuning.rankings.web.internal.util.RankingResultUtil;
 
-import java.util.stream.Stream;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
@@ -97,11 +98,11 @@ public class RankingGetSearchResultsBuilder {
 	}
 
 	protected JSONArray buildDocuments(SearchResponse searchResponse) {
-		Stream<JSONObject> stream = _getElements(searchResponse);
+		List<JSONObject> jsonObjects = _getElements(searchResponse);
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		stream.forEach(jsonArray::put);
+		jsonObjects.forEach(jsonArray::put);
 
 		return jsonArray;
 	}
@@ -138,10 +139,14 @@ public class RankingGetSearchResultsBuilder {
 		).build();
 	}
 
-	private Stream<JSONObject> _getElements(SearchResponse searchResponse) {
-		Stream<Document> stream = searchResponse.getDocumentsStream();
+	private List<JSONObject> _getElements(SearchResponse searchResponse) {
+		List<JSONObject> jsonObjects = new ArrayList<>();
 
-		return stream.map(this::translate);
+		for (Document document : searchResponse.getDocuments()) {
+			jsonObjects.add(translate(document));
+		}
+
+		return jsonObjects;
 	}
 
 	private String _getViewURL(Document document) {

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetVisibleResultsBuilder.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/results/builder/RankingGetVisibleResultsBuilder.java
@@ -38,7 +38,6 @@ import com.liferay.portal.search.tuning.rankings.web.internal.searcher.helper.Ra
 import com.liferay.portal.search.tuning.rankings.web.internal.util.RankingResultUtil;
 
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
@@ -130,14 +129,11 @@ public class RankingGetVisibleResultsBuilder {
 	protected JSONArray buildDocuments(
 		Ranking ranking, SearchResponse searchResponse) {
 
-		Stream<Document> documentsStream = searchResponse.getDocumentsStream();
-
-		Stream<JSONObject> jsonObjectStream = documentsStream.map(
-			document -> translate(document, ranking));
-
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		jsonObjectStream.forEach(jsonArray::put);
+		for (Document document : searchResponse.getDocuments()) {
+			jsonArray.put(translate(document, ranking));
+		}
 
 		return jsonArray;
 	}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/BaseRankingsWebTestCase.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/BaseRankingsWebTestCase.java
@@ -738,7 +738,7 @@ public abstract class BaseRankingsWebTestCase {
 			Stream.of(document)
 		).when(
 			searchResponse
-		).getDocumentsStream();
+		).getDocuments();
 
 		Mockito.doReturn(
 			1

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/BaseRankingsWebTestCase.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/BaseRankingsWebTestCase.java
@@ -64,6 +64,7 @@ import com.liferay.portal.search.web.interpreter.SearchResultInterpreterProvider
 
 import java.text.SimpleDateFormat;
 
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.function.Consumer;
@@ -735,7 +736,7 @@ public abstract class BaseRankingsWebTestCase {
 		SearchResponse searchResponse = Mockito.mock(SearchResponse.class);
 
 		Mockito.doReturn(
-			Stream.of(document)
+			Collections.singletonList(document)
 		).when(
 			searchResponse
 		).getDocuments();

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/search/spi/searcher/test/SXPBlueprintSearchRequestContributorTest.java
@@ -200,9 +200,8 @@ public class SXPBlueprintSearchRequestContributorTest {
 				).build()));
 
 		DocumentsAssert.assertValues(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), "localized_title_en_US",
-			expected);
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			"localized_title_en_US", expected);
 	}
 
 	private ConfigurationTemporarySwapper _getConfigurationTemporarySwapper(

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
@@ -2231,8 +2231,7 @@ public class SXPBlueprintSearchResultTest {
 			_getScore(searchResponse) + searchResponse.getRequestString();
 
 		DocumentsAssert.assertValues(
-			message, searchResponse.getDocumentsStream(), "title_en_US",
-			expected);
+			message, searchResponse.getDocuments(), "title_en_US", expected);
 
 		if (!Objects.equals("{}", _sxpBlueprint.getElementInstancesJSON())) {
 			searchResponse = _getSearchResponsePreview(
@@ -2242,7 +2241,7 @@ public class SXPBlueprintSearchResultTest {
 				_getScore(searchResponse) + searchResponse.getRequestString();
 
 			DocumentsAssert.assertValues(
-				message, searchResponse.getDocumentsStream(), "title_en_US",
+				message, searchResponse.getDocuments(), "title_en_US",
 				expected);
 		}
 	}
@@ -2256,8 +2255,8 @@ public class SXPBlueprintSearchResultTest {
 			searchRequestBuilderConsumer);
 
 		DocumentsAssert.assertValuesIgnoreRelevance(
-			searchResponse.getRequestString(),
-			searchResponse.getDocumentsStream(), "title_en_US", expected);
+			searchResponse.getRequestString(), searchResponse.getDocuments(),
+			"title_en_US", expected);
 
 		if (!Objects.equals("{}", _sxpBlueprint.getElementInstancesJSON())) {
 			searchResponse = _getSearchResponsePreview(
@@ -2265,7 +2264,7 @@ public class SXPBlueprintSearchResultTest {
 
 			DocumentsAssert.assertValuesIgnoreRelevance(
 				searchResponse.getRequestString(),
-				searchResponse.getDocumentsStream(), "title_en_US", expected);
+				searchResponse.getDocuments(), "title_en_US", expected);
 		}
 	}
 


### PR DESCRIPTION
- LPS-X Remove Optional usage from BaseModelRetriever
- LPS-X Apply
- LPS-X Remove Stream usage from SearchResponse
- LPS-X Apply
- LPS-X SF, simplify
- LPS-X Fix tests
- LPS-171292 Remove Optional from SearchPermissionFilterContributor and its implementations
- LPS-171292 SF
- LPS-X Remove Stream usages from HighlightFieldBuilder and apply
- LPS-X Remove Stream usages from SearchHitBuilder and SearchHitsBuilder by removing the deprecated methods
- LPS-X Sem Ver
