### PR TITLE
LPS X Commerce Memory

### DIFF
--- a/modules/apps/commerce/commerce-currency-service/src/main/java/com/liferay/commerce/currency/internal/util/CommercePriceFormatterImpl.java
+++ b/modules/apps/commerce/commerce-currency-service/src/main/java/com/liferay/commerce/currency/internal/util/CommercePriceFormatterImpl.java
@@ -31,6 +31,7 @@ import java.text.DecimalFormatSymbols;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -102,7 +103,7 @@ public class CommercePriceFormatterImpl implements CommercePriceFormatter {
 		_roundingTypeConfiguration = null;
 	}
 
-	private DecimalFormat _getDecimalFormat(
+	private DecimalFormat _createDecimalFormat(
 		CommerceCurrency commerceCurrency, Locale locale) {
 
 		String formatPattern = CommerceCurrencyConstants.DECIMAL_FORMAT_PATTERN;
@@ -136,6 +137,25 @@ public class CommercePriceFormatterImpl implements CommercePriceFormatter {
 		return decimalFormat;
 	}
 
+	private DecimalFormat _getDecimalFormat(
+		CommerceCurrency commerceCurrency, Locale locale) {
+
+		long commerceCurrencyId = 0;
+
+		if (commerceCurrency != null) {
+			commerceCurrencyId = commerceCurrency.getCommerceCurrencyId();
+		}
+
+		Map<Locale, DecimalFormat> decimalFormats =
+			_decimalFormatsMap.computeIfAbsent(
+				commerceCurrencyId, key -> new ConcurrentHashMap<>());
+
+		return decimalFormats.computeIfAbsent(
+			locale, key -> _createDecimalFormat(commerceCurrency, key));
+	}
+
+	private final Map<Long, Map<Locale, DecimalFormat>> _decimalFormatsMap =
+		new ConcurrentHashMap<>();
 	private volatile RoundingTypeConfiguration _roundingTypeConfiguration;
 
 }

--- a/modules/apps/commerce/commerce-product-type-virtual-order-service/src/main/java/com/liferay/commerce/product/type/virtual/order/internal/messaging/CommerceOrderStatusMessageListener.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-order-service/src/main/java/com/liferay/commerce/product/type/virtual/order/internal/messaging/CommerceOrderStatusMessageListener.java
@@ -52,8 +52,16 @@ public class CommerceOrderStatusMessageListener extends BaseMessageListener {
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
-		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			String.valueOf(message.getPayload()));
+		Object payload = message.getPayload();
+
+		JSONObject jsonObject = null;
+
+		if (payload instanceof JSONObject) {
+			jsonObject = (JSONObject)payload;
+		}
+		else {
+			jsonObject = _jsonFactory.createJSONObject(String.valueOf(payload));
+		}
 
 		long commerceOrderId = jsonObject.getLong("commerceOrderId");
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/messaging/CommerceOrderStatusMessageListener.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/messaging/CommerceOrderStatusMessageListener.java
@@ -44,8 +44,16 @@ public class CommerceOrderStatusMessageListener extends BaseMessageListener {
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
-		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			String.valueOf(message.getPayload()));
+		Object payload = message.getPayload();
+
+		JSONObject jsonObject = null;
+
+		if (payload instanceof JSONObject) {
+			jsonObject = (JSONObject)payload;
+		}
+		else {
+			jsonObject = _jsonFactory.createJSONObject(String.valueOf(payload));
+		}
 
 		long commerceOrderId = jsonObject.getLong("commerceOrderId");
 


### PR DESCRIPTION
- LPS-X Avoid converting a JSONObject to string and then convert it back to JSONObject. This reduces 20M JSONObject creation per 25 runs.
- LPS-X Incomplete: add a local cache for DecimalFormat of commerce currency. This reduces about 30M DecimalFormat and other garbage creation per 25 runs.
