### PR TITLE
LPD 5187 Equinox 2024 1 26

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/HttpServletEndpointControllerImpl.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/HttpServletEndpointControllerImpl.java
@@ -170,7 +170,7 @@ public class HttpServletEndpointControllerImpl
 
 	@Override
 	public void log(String message, Throwable throwable) {
-		_log.error(message, throwable);
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayContextController.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayContextController.java
@@ -13,6 +13,10 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.osgi.web.http.servlet.internal.context.customizer.EventListenerServiceTrackerCustomizer;
+import com.liferay.portal.osgi.web.http.servlet.internal.context.customizer.FilterServiceTrackerCustomizer;
+import com.liferay.portal.osgi.web.http.servlet.internal.context.customizer.ResourceServiceTrackerCustomizer;
+import com.liferay.portal.osgi.web.http.servlet.internal.context.customizer.ServletServiceTrackerCustomizer;
 import com.liferay.portal.osgi.web.http.servlet.internal.servlet.ServletContextWrapper;
 
 import java.net.URI;
@@ -58,10 +62,6 @@ import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
 import org.eclipse.equinox.http.servlet.internal.context.ContextController;
 import org.eclipse.equinox.http.servlet.internal.context.DispatchTargets;
 import org.eclipse.equinox.http.servlet.internal.context.ServletContextHelperDataContext;
-import org.eclipse.equinox.http.servlet.internal.customizer.ContextFilterTrackerCustomizer;
-import org.eclipse.equinox.http.servlet.internal.customizer.ContextListenerTrackerCustomizer;
-import org.eclipse.equinox.http.servlet.internal.customizer.ContextResourceTrackerCustomizer;
-import org.eclipse.equinox.http.servlet.internal.customizer.ContextServletTrackerCustomizer;
 import org.eclipse.equinox.http.servlet.internal.error.IllegalContextNameException;
 import org.eclipse.equinox.http.servlet.internal.error.IllegalContextPathException;
 import org.eclipse.equinox.http.servlet.internal.error.RegisteredFilterException;
@@ -145,35 +145,35 @@ public class LiferayContextController extends ContextController {
 
 		_filterServiceTracker = new ServiceTracker<>(
 			bundleContext, Filter.class,
-			new ContextFilterTrackerCustomizer(
+			new FilterServiceTrackerCustomizer(
 				bundleContext, httpServletEndpointController, this));
 
 		_filterServiceTracker.open(true);
 
 		_httpSessionAttributeListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, HttpSessionAttributeListener.class.getName(),
-			new ContextListenerTrackerCustomizer(
+			new EventListenerServiceTrackerCustomizer(
 				bundleContext, httpServletEndpointController, this));
 
 		_httpSessionAttributeListenerServiceTracker.open(true);
 
 		_httpSessionListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, HttpSessionListener.class.getName(),
-			new ContextListenerTrackerCustomizer(
+			new EventListenerServiceTrackerCustomizer(
 				bundleContext, httpServletEndpointController, this));
 
 		_httpSessionListenerServiceTracker.open(true);
 
 		_resourceServiceTracker = new ServiceTracker<>(
 			bundleContext, Object.class,
-			new ContextResourceTrackerCustomizer(
+			new ResourceServiceTrackerCustomizer(
 				bundleContext, httpServletEndpointController, this));
 
 		_resourceServiceTracker.open(true);
 
 		_servletContextAttributeListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, ServletContextAttributeListener.class.getName(),
-			new ContextListenerTrackerCustomizer(
+			new EventListenerServiceTrackerCustomizer(
 				bundleContext, httpServletEndpointController, this));
 
 		_servletContextAttributeListenerServiceTracker.open(true);
@@ -187,28 +187,28 @@ public class LiferayContextController extends ContextController {
 
 		_servletContextListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, ServletContextListener.class.getName(),
-			new ContextListenerTrackerCustomizer(
+			new EventListenerServiceTrackerCustomizer(
 				bundleContext, httpServletEndpointController, this));
 
 		_servletContextListenerServiceTracker.open(true);
 
 		_servletRequestAttributeListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, ServletRequestAttributeListener.class.getName(),
-			new ContextListenerTrackerCustomizer(
+			new EventListenerServiceTrackerCustomizer(
 				bundleContext, httpServletEndpointController, this));
 
 		_servletRequestAttributeListenerServiceTracker.open(true);
 
 		_servletRequestListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, ServletRequestListener.class.getName(),
-			new ContextListenerTrackerCustomizer(
+			new EventListenerServiceTrackerCustomizer(
 				bundleContext, httpServletEndpointController, this));
 
 		_servletRequestListenerServiceTracker.open(true);
 
 		_servletServiceTracker = new ServiceTracker<>(
 			bundleContext, Servlet.class,
-			new ContextServletTrackerCustomizer(
+			new ServletServiceTrackerCustomizer(
 				bundleContext, httpServletEndpointController, this));
 
 		_servletServiceTracker.open(true);

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayContextController.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayContextController.java
@@ -5,33 +5,21 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.context;
 
-import com.liferay.osgi.util.StringPlus;
-import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.customizer.EventListenerServiceTrackerCustomizer;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.customizer.FilterServiceTrackerCustomizer;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.customizer.ResourceServiceTrackerCustomizer;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.customizer.ServletServiceTrackerCustomizer;
-import com.liferay.portal.osgi.web.http.servlet.internal.servlet.ServletContextWrapper;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import java.security.AccessController;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.EventListener;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -42,14 +30,11 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextAttributeListener;
-import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
-import javax.servlet.ServletException;
 import javax.servlet.ServletRequestAttributeListener;
 import javax.servlet.ServletRequestListener;
 import javax.servlet.http.HttpSession;
@@ -63,17 +48,13 @@ import org.eclipse.equinox.http.servlet.internal.context.DispatchTargets;
 import org.eclipse.equinox.http.servlet.internal.context.ServletContextHelperDataContext;
 import org.eclipse.equinox.http.servlet.internal.error.IllegalContextNameException;
 import org.eclipse.equinox.http.servlet.internal.error.IllegalContextPathException;
-import org.eclipse.equinox.http.servlet.internal.error.RegisteredFilterException;
 import org.eclipse.equinox.http.servlet.internal.registration.EndpointRegistration;
 import org.eclipse.equinox.http.servlet.internal.registration.FilterRegistration;
 import org.eclipse.equinox.http.servlet.internal.registration.ListenerRegistration;
 import org.eclipse.equinox.http.servlet.internal.registration.ResourceRegistration;
 import org.eclipse.equinox.http.servlet.internal.registration.ServletRegistration;
-import org.eclipse.equinox.http.servlet.internal.servlet.FilterConfigImpl;
 import org.eclipse.equinox.http.servlet.internal.servlet.HttpSessionAdaptor;
 import org.eclipse.equinox.http.servlet.internal.servlet.Match;
-import org.eclipse.equinox.http.servlet.internal.servlet.ResourceServlet;
-import org.eclipse.equinox.http.servlet.internal.servlet.ServletConfigImpl;
 import org.eclipse.equinox.http.servlet.internal.util.Const;
 import org.eclipse.equinox.http.servlet.internal.util.EventListeners;
 import org.eclipse.equinox.http.servlet.internal.util.Path;
@@ -87,11 +68,6 @@ import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.http.context.ServletContextHelper;
 import org.osgi.service.http.runtime.dto.DTOConstants;
-import org.osgi.service.http.runtime.dto.ErrorPageDTO;
-import org.osgi.service.http.runtime.dto.FilterDTO;
-import org.osgi.service.http.runtime.dto.ListenerDTO;
-import org.osgi.service.http.runtime.dto.ResourceDTO;
-import org.osgi.service.http.runtime.dto.ServletDTO;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -130,7 +106,6 @@ public class LiferayContextController extends ContextController {
 			throw illegalContextPathException;
 		}
 
-		_bundleContext = bundleContext;
 		_serviceReference = serviceReference;
 		_servletContextHelperDataContext = servletContextHelperDataContext;
 		_httpServletEndpointController = httpServletEndpointController;
@@ -142,43 +117,54 @@ public class LiferayContextController extends ContextController {
 
 		_contextPath = contextPath;
 
+		long servletContextHelperServiceId = (long)serviceReference.getProperty(
+			Constants.SERVICE_ID);
+
 		_filterServiceTracker = new ServiceTracker<>(
 			bundleContext, Filter.class,
 			new FilterServiceTrackerCustomizer(
-				bundleContext, httpServletEndpointController, this));
+				bundleContext, httpServletEndpointController, this,
+				_servletContextHelperDataContext,
+				servletContextHelperServiceId));
 
 		_filterServiceTracker.open(true);
 
 		_httpSessionAttributeListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, HttpSessionAttributeListener.class.getName(),
 			new EventListenerServiceTrackerCustomizer(
-				bundleContext, httpServletEndpointController, this));
+				bundleContext, httpServletEndpointController, this,
+				_servletContextHelperDataContext,
+				servletContextHelperServiceId));
 
 		_httpSessionAttributeListenerServiceTracker.open(true);
 
 		_httpSessionListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, HttpSessionListener.class.getName(),
 			new EventListenerServiceTrackerCustomizer(
-				bundleContext, httpServletEndpointController, this));
+				bundleContext, httpServletEndpointController, this,
+				_servletContextHelperDataContext,
+				servletContextHelperServiceId));
 
 		_httpSessionListenerServiceTracker.open(true);
 
 		_resourceServiceTracker = new ServiceTracker<>(
 			bundleContext, Object.class,
 			new ResourceServiceTrackerCustomizer(
-				bundleContext, httpServletEndpointController, this));
+				bundleContext, httpServletEndpointController, this,
+				_servletContextHelperDataContext,
+				servletContextHelperServiceId));
 
 		_resourceServiceTracker.open(true);
 
 		_servletContextAttributeListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, ServletContextAttributeListener.class.getName(),
 			new EventListenerServiceTrackerCustomizer(
-				bundleContext, httpServletEndpointController, this));
+				bundleContext, httpServletEndpointController, this,
+				_servletContextHelperDataContext,
+				servletContextHelperServiceId));
 
 		_servletContextAttributeListenerServiceTracker.open(true);
 
-		_servletContextHelperServiceId = (long)serviceReference.getProperty(
-			Constants.SERVICE_ID);
 		_servletContextInitParams = ServiceProperties.parseInitParams(
 			serviceReference,
 			HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX,
@@ -187,309 +173,72 @@ public class LiferayContextController extends ContextController {
 		_servletContextListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, ServletContextListener.class.getName(),
 			new EventListenerServiceTrackerCustomizer(
-				bundleContext, httpServletEndpointController, this));
+				bundleContext, httpServletEndpointController, this,
+				_servletContextHelperDataContext,
+				servletContextHelperServiceId));
 
 		_servletContextListenerServiceTracker.open(true);
 
 		_servletRequestAttributeListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, ServletRequestAttributeListener.class.getName(),
 			new EventListenerServiceTrackerCustomizer(
-				bundleContext, httpServletEndpointController, this));
+				bundleContext, httpServletEndpointController, this,
+				_servletContextHelperDataContext,
+				servletContextHelperServiceId));
 
 		_servletRequestAttributeListenerServiceTracker.open(true);
 
 		_servletRequestListenerServiceTracker = new ServiceTracker<>(
 			bundleContext, ServletRequestListener.class.getName(),
 			new EventListenerServiceTrackerCustomizer(
-				bundleContext, httpServletEndpointController, this));
+				bundleContext, httpServletEndpointController, this,
+				_servletContextHelperDataContext,
+				servletContextHelperServiceId));
 
 		_servletRequestListenerServiceTracker.open(true);
 
 		_servletServiceTracker = new ServiceTracker<>(
 			bundleContext, Servlet.class,
 			new ServletServiceTrackerCustomizer(
-				bundleContext, httpServletEndpointController, this));
+				bundleContext, httpServletEndpointController, this,
+				_servletContextHelperDataContext,
+				servletContextHelperServiceId));
 
 		_servletServiceTracker.open(true);
 	}
 
 	@Override
 	public FilterRegistration addFilterRegistration(
-			ServiceReference<Filter> serviceReference)
-		throws ServletException {
+		ServiceReference<Filter> serviceReference) {
 
-		_checkShutdown();
-
-		ContextController.ServiceHolder<Filter> serviceHolder =
-			new ContextController.ServiceHolder<>(
-				_bundleContext.getServiceObjects(serviceReference));
-
-		Filter filter = serviceHolder.get();
-
-		FilterRegistration filterRegistration = null;
-
-		boolean addedRegisteredObject = false;
-
-		Set<Object> registeredObjects =
-			_httpServletEndpointController.getRegisteredObjects();
-
-		try {
-			if (filter == null) {
-				throw new IllegalArgumentException("Filter is null");
-			}
-
-			addedRegisteredObject = registeredObjects.add(filter);
-
-			if (addedRegisteredObject) {
-				for (FilterRegistration curFilterRegistration :
-						_filterRegistrations) {
-
-					if (Objects.equals(curFilterRegistration.getT(), filter)) {
-						throw new RegisteredFilterException(filter);
-					}
-				}
-
-				FilterDTO filterDTO = _createFilterDTO(
-					serviceReference, filter);
-
-				filterRegistration = new FilterRegistration(
-					serviceHolder, filterDTO,
-					GetterUtil.getInteger(
-						serviceReference.getProperty(
-							Constants.SERVICE_RANKING)),
-					this, null);
-
-				filterRegistration.init(
-					new FilterConfigImpl(
-						filterDTO.name, filterDTO.initParams,
-						new ServletContextWrapper(
-							serviceHolder.getBundle(), this,
-							_getServletContextHelper(serviceHolder.getBundle()),
-							_servletContextHelperDataContext)));
-
-				_filterRegistrations.add(filterRegistration);
-			}
-		}
-		finally {
-			if (filterRegistration == null) {
-				serviceHolder.release();
-
-				if (addedRegisteredObject) {
-					registeredObjects.remove(filter);
-				}
-			}
-		}
-
-		return filterRegistration;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public ListenerRegistration addListenerRegistration(
 		ServiceReference<EventListener> serviceReference) {
 
-		_checkShutdown();
-
-		ContextController.ServiceHolder<EventListener> serviceHolder =
-			new ContextController.ServiceHolder<>(
-				_bundleContext.getServiceObjects(serviceReference));
-
-		EventListener eventListener = serviceHolder.get();
-
-		ListenerRegistration listenerRegistration = null;
-
-		try {
-			if (eventListener == null) {
-				throw new IllegalArgumentException("Event listener is null");
-			}
-
-			List<Class<? extends EventListener>> eventListenerClasses =
-				_getEventListenerClasses(serviceReference);
-
-			if (eventListenerClasses.isEmpty()) {
-				throw new IllegalArgumentException(
-					"Event listener does not implement a supported interface");
-			}
-
-			for (ListenerRegistration curListenerRegistration :
-					_listenerRegistrations) {
-
-				if (Objects.equals(
-						curListenerRegistration.getT(), eventListener)) {
-
-					return null;
-				}
-			}
-
-			ServletContext servletContext = new ServletContextWrapper(
-				serviceHolder.getBundle(), this,
-				_getServletContextHelper(serviceHolder.getBundle()),
-				_servletContextHelperDataContext);
-
-			listenerRegistration = new ListenerRegistration(
-				serviceHolder, eventListenerClasses,
-				_createListenerDTO(serviceReference, eventListenerClasses),
-				servletContext, this);
-
-			if (eventListenerClasses.contains(ServletContextListener.class)) {
-				ServletContextListener servletContextListener =
-					(ServletContextListener)listenerRegistration.getT();
-
-				servletContextListener.contextInitialized(
-					new ServletContextEvent(servletContext));
-			}
-
-			_listenerRegistrations.add(listenerRegistration);
-
-			_eventListeners.put(eventListenerClasses, listenerRegistration);
-		}
-		finally {
-			if (listenerRegistration == null) {
-				serviceHolder.release();
-			}
-		}
-
-		return listenerRegistration;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public ResourceRegistration addResourceRegistration(
 		ServiceReference<?> serviceReference) {
 
-		_checkShutdown();
-
-		String resourcePrefix = (String)serviceReference.getProperty(
-			HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PREFIX);
-
-		if (resourcePrefix == null) {
-			throw new IllegalArgumentException("Prefix is null");
-		}
-
-		if (resourcePrefix.endsWith(Const.SLASH) &&
-			!resourcePrefix.equals(Const.SLASH)) {
-
-			throw new IllegalArgumentException(
-				"Invalid prefix \"" + resourcePrefix + "\"");
-		}
-
-		String[] resourcePatterns = ArrayUtil.toStringArray(
-			StringPlus.asList(
-				serviceReference.getProperty(
-					HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PATTERN)));
-
-		if (resourcePatterns.length < 1) {
-			throw new IllegalArgumentException("Patterns must contain a value");
-		}
-
-		for (String resourcePattern : resourcePatterns) {
-			ContextController.checkPattern(resourcePattern);
-		}
-
-		Bundle bundle = serviceReference.getBundle();
-
-		ResourceDTO resourceDTO = new ResourceDTO();
-
-		resourceDTO.patterns = _sort(resourcePatterns);
-		resourceDTO.prefix = resourcePrefix;
-		resourceDTO.serviceId = (long)serviceReference.getProperty(
-			Constants.SERVICE_ID);
-		resourceDTO.servletContextId = _servletContextHelperServiceId;
-
-		ServletContextHelper servletContextHelper = _getServletContextHelper(
-			bundle);
-
-		ResourceRegistration resourceRegistration = new ResourceRegistration(
-			new ContextController.ServiceHolder<>(
-				new ResourceServlet(
-					resourcePrefix, servletContextHelper,
-					AccessController.getContext()),
-				bundle, resourceDTO.serviceId,
-				GetterUtil.getInteger(
-					serviceReference.getProperty(Constants.SERVICE_RANKING))),
-			resourceDTO, servletContextHelper, this, null);
-
-		try {
-			resourceRegistration.init(
-				new ServletConfigImpl(
-					resourceRegistration.getName(), new HashMap<>(),
-					new ServletContextWrapper(
-						bundle, this, servletContextHelper,
-						_servletContextHelperDataContext)));
-		}
-		catch (ServletException servletException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(servletException);
-			}
-
-			return null;
-		}
-
-		_endpointRegistrations.add(resourceRegistration);
-
-		return resourceRegistration;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public ServletRegistration addServletRegistration(
-			ServiceReference<Servlet> serviceReference)
-		throws ServletException {
+		ServiceReference<Servlet> serviceReference) {
 
-		_checkShutdown();
+		throw new UnsupportedOperationException();
+	}
 
-		ContextController.ServiceHolder<Servlet> serviceHolder =
-			new ContextController.ServiceHolder<>(
-				_bundleContext.getServiceObjects(serviceReference));
-
-		Servlet servlet = serviceHolder.get();
-
-		ServletRegistration servletRegistration = null;
-
-		boolean addedRegisteredObject = false;
-
-		Set<Object> registeredObjects =
-			_httpServletEndpointController.getRegisteredObjects();
-
-		try {
-			if (servlet == null) {
-				throw new IllegalArgumentException("Servlet is null");
-			}
-
-			addedRegisteredObject = registeredObjects.add(servlet);
-
-			if (addedRegisteredObject) {
-				ObjectValuePair<ServletDTO, ErrorPageDTO> objectValuePair =
-					_createServletDTOs(serviceReference, servlet);
-
-				ServletDTO servletDTO = objectValuePair.getKey();
-
-				ServletContextHelper servletContextHelper =
-					_getServletContextHelper(serviceHolder.getBundle());
-
-				servletRegistration = new ServletRegistration(
-					serviceHolder, servletDTO, objectValuePair.getValue(),
-					servletContextHelper, this, null);
-
-				servletRegistration.init(
-					new ServletConfigImpl(
-						servletDTO.name, servletDTO.initParams,
-						new ServletContextWrapper(
-							serviceHolder.getBundle(), this,
-							servletContextHelper,
-							_servletContextHelperDataContext)));
-
-				_endpointRegistrations.add(servletRegistration);
-			}
+	public void checkShutdown() {
+		if (_shutdown) {
+			throw new IllegalStateException("Context is shutdown");
 		}
-		finally {
-			if (servletRegistration == null) {
-				serviceHolder.release();
-
-				if (addedRegisteredObject) {
-					registeredObjects.remove(servlet);
-				}
-			}
-		}
-
-		return servletRegistration;
 	}
 
 	@Override
@@ -574,7 +323,7 @@ public class LiferayContextController extends ContextController {
 		String servletName, String requestURI, String servletPath,
 		String pathInfo, String extension, String queryString, Match match) {
 
-		_checkShutdown();
+		checkShutdown();
 
 		EndpointRegistration<?> endpointRegistration = null;
 
@@ -686,6 +435,12 @@ public class LiferayContextController extends ContextController {
 		return _listenerRegistrations;
 	}
 
+	public ServletContextHelper getServletContextHelper(Bundle bundle) {
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		return bundleContext.getService(_serviceReference);
+	}
+
 	@Override
 	public HttpSessionAdaptor getSessionAdaptor(
 		HttpSession httpSession, ServletContext servletContext) {
@@ -783,201 +538,6 @@ public class LiferayContextController extends ContextController {
 		}
 	}
 
-	private void _checkShutdown() {
-		if (_shutdown) {
-			throw new IllegalStateException("Context is shutdown");
-		}
-	}
-
-	private FilterDTO _createFilterDTO(
-		ServiceReference<Filter> filterServiceReference, Filter filter) {
-
-		String[] filterPatterns = ArrayUtil.toStringArray(
-			StringPlus.asList(
-				filterServiceReference.getProperty(
-					HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_PATTERN)));
-		String[] filterRegexes = ArrayUtil.toStringArray(
-			StringPlus.asList(
-				filterServiceReference.getProperty(
-					HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_REGEX)));
-		String[] filterServletNames = ArrayUtil.toStringArray(
-			StringPlus.asList(
-				filterServiceReference.getProperty(
-					HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET)));
-
-		if ((filterPatterns.length == 0) && (filterRegexes.length == 0) &&
-			(filterServletNames.length == 0)) {
-
-			throw new IllegalArgumentException(
-				"Patterns, regex, and servlet names must contain a value");
-		}
-
-		for (String filterPattern : filterPatterns) {
-			ContextController.checkPattern(filterPattern);
-		}
-
-		String[] filterDispatcherTypes = ArrayUtil.toStringArray(
-			StringPlus.asList(
-				filterServiceReference.getProperty(
-					HttpWhiteboardConstants.
-						HTTP_WHITEBOARD_FILTER_DISPATCHER)));
-
-		if (filterDispatcherTypes.length == 0) {
-			filterDispatcherTypes = _DISPATCHER_TYPES;
-		}
-
-		for (String filterDispatcherType : filterDispatcherTypes) {
-			try {
-				DispatcherType.valueOf(filterDispatcherType);
-			}
-			catch (IllegalArgumentException illegalArgumentException) {
-				throw new IllegalArgumentException(
-					"Invalid dispatcher \"" + filterDispatcherType + "\"",
-					illegalArgumentException);
-			}
-		}
-
-		FilterDTO filterDTO = new FilterDTO();
-
-		filterDTO.asyncSupported = ServiceProperties.parseBoolean(
-			filterServiceReference,
-			HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_ASYNC_SUPPORTED);
-		filterDTO.dispatcher = _sort(filterDispatcherTypes);
-		filterDTO.initParams = ServiceProperties.parseInitParams(
-			filterServiceReference,
-			HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_INIT_PARAM_PREFIX);
-
-		Class<?> filterClass = filter.getClass();
-
-		filterDTO.name = GetterUtil.getString(
-			ServiceProperties.parseName(
-				filterServiceReference.getProperty(
-					HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_NAME),
-				filter),
-			filterClass.getName());
-
-		filterDTO.patterns = _sort(filterPatterns);
-		filterDTO.regexs = filterRegexes;
-		filterDTO.serviceId = (long)filterServiceReference.getProperty(
-			Constants.SERVICE_ID);
-		filterDTO.servletContextId = _servletContextHelperServiceId;
-		filterDTO.servletNames = _sort(filterServletNames);
-
-		return filterDTO;
-	}
-
-	private ListenerDTO _createListenerDTO(
-		ServiceReference<EventListener> serviceReference,
-		List<Class<? extends EventListener>> eventListenerClasses) {
-
-		ListenerDTO listenerDTO = new ListenerDTO();
-
-		listenerDTO.serviceId = (long)serviceReference.getProperty(
-			Constants.SERVICE_ID);
-		listenerDTO.servletContextId = _servletContextHelperServiceId;
-		listenerDTO.types = TransformUtil.transformToArray(
-			eventListenerClasses, Class::getName, String.class);
-
-		return listenerDTO;
-	}
-
-	private ObjectValuePair<ServletDTO, ErrorPageDTO> _createServletDTOs(
-		ServiceReference<Servlet> serviceReference, Servlet servlet) {
-
-		String[] servletErrorPages = ArrayUtil.toStringArray(
-			StringPlus.asList(
-				serviceReference.getProperty(
-					HttpWhiteboardConstants.
-						HTTP_WHITEBOARD_SERVLET_ERROR_PAGE)));
-		String servletName = (String)serviceReference.getProperty(
-			HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME);
-		String[] servletPatterns = ArrayUtil.toStringArray(
-			StringPlus.asList(
-				serviceReference.getProperty(
-					HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN)));
-
-		if ((servletErrorPages.length == 0) && (servletName == null) &&
-			(servletPatterns.length == 0)) {
-
-			throw new IllegalArgumentException(
-				StringBundler.concat(
-					"One of the service properties ",
-					HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_ERROR_PAGE,
-					", ", HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME,
-					", and ",
-					HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN,
-					" must contain a value"));
-		}
-
-		for (String servletPattern : servletPatterns) {
-			ContextController.checkPattern(servletPattern);
-		}
-
-		ServletDTO servletDTO = new ServletDTO();
-
-		servletDTO.asyncSupported = ServiceProperties.parseBoolean(
-			serviceReference,
-			HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_ASYNC_SUPPORTED);
-		servletDTO.initParams = ServiceProperties.parseInitParams(
-			serviceReference,
-			HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_INIT_PARAM_PREFIX);
-		servletDTO.name = ServiceProperties.parseName(servletName, servlet);
-		servletDTO.patterns = _sort(servletPatterns);
-		servletDTO.serviceId = (long)serviceReference.getProperty(
-			Constants.SERVICE_ID);
-		servletDTO.servletContextId = _servletContextHelperServiceId;
-		servletDTO.servletInfo = servlet.getServletInfo();
-
-		ErrorPageDTO errorPageDTO = null;
-
-		if (servletErrorPages.length > 0) {
-			errorPageDTO = new ErrorPageDTO();
-
-			errorPageDTO.asyncSupported = servletDTO.asyncSupported;
-
-			Set<Long> httpErrorCodes = new LinkedHashSet<>();
-
-			List<String> exceptionErrorPages = new ArrayList<>();
-
-			for (String servletErrorPage : servletErrorPages) {
-				try {
-					if (Objects.equals(servletErrorPage, "4xx")) {
-						for (long code = 400; code < 500; code++) {
-							httpErrorCodes.add(code);
-						}
-					}
-					else if (Objects.equals(servletErrorPage, "5xx")) {
-						for (long code = 500; code < 600; code++) {
-							httpErrorCodes.add(code);
-						}
-					}
-					else {
-						httpErrorCodes.add(Long.parseLong(servletErrorPage));
-					}
-				}
-				catch (NumberFormatException numberFormatException) {
-					if (_log.isDebugEnabled()) {
-						_log.debug(numberFormatException);
-					}
-
-					exceptionErrorPages.add(servletErrorPage);
-				}
-			}
-
-			errorPageDTO.errorCodes = TransformUtil.transformToLongArray(
-				httpErrorCodes, errorCode -> errorCode);
-			errorPageDTO.exceptions = exceptionErrorPages.toArray(
-				new String[0]);
-			errorPageDTO.initParams = servletDTO.initParams;
-			errorPageDTO.name = servletDTO.name;
-			errorPageDTO.serviceId = servletDTO.serviceId;
-			errorPageDTO.servletContextId = _servletContextHelperServiceId;
-			errorPageDTO.servletInfo = servlet.getServletInfo();
-		}
-
-		return new ObjectValuePair<>(servletDTO, errorPageDTO);
-	}
-
 	private DispatchTargets _getDispatchTargets(
 		String requestURI, String extension, String queryString, Match match) {
 
@@ -1015,68 +575,6 @@ public class LiferayContextController extends ContextController {
 		return null;
 	}
 
-	private List<Class<? extends EventListener>> _getEventListenerClasses(
-		ServiceReference<EventListener> serviceReference) {
-
-		List<Class<? extends EventListener>> eventListenerClasses =
-			new ArrayList<>();
-
-		List<String> objectClasses = StringPlus.asList(
-			serviceReference.getProperty(Constants.OBJECTCLASS));
-
-		if (objectClasses.contains(
-				HttpSessionAttributeListener.class.getName())) {
-
-			eventListenerClasses.add(HttpSessionAttributeListener.class);
-		}
-
-		if (objectClasses.contains(HttpSessionListener.class.getName())) {
-			eventListenerClasses.add(HttpSessionListener.class);
-		}
-
-		if (objectClasses.contains(
-				ServletContextAttributeListener.class.getName())) {
-
-			eventListenerClasses.add(ServletContextAttributeListener.class);
-		}
-
-		if (objectClasses.contains(ServletContextListener.class.getName())) {
-			eventListenerClasses.add(ServletContextListener.class);
-		}
-
-		if (objectClasses.contains(
-				ServletRequestAttributeListener.class.getName())) {
-
-			eventListenerClasses.add(ServletRequestAttributeListener.class);
-		}
-
-		if (objectClasses.contains(ServletRequestListener.class.getName())) {
-			eventListenerClasses.add(ServletRequestListener.class);
-		}
-
-		return eventListenerClasses;
-	}
-
-	private ServletContextHelper _getServletContextHelper(Bundle bundle) {
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		return bundleContext.getService(_serviceReference);
-	}
-
-	private String[] _sort(String[] values) {
-		if (values == null) {
-			return null;
-		}
-
-		Arrays.sort(values);
-
-		return values;
-	}
-
-	private static final String[] _DISPATCHER_TYPES = {
-		DispatcherType.REQUEST.toString()
-	};
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		LiferayContextController.class.getName());
 
@@ -1085,7 +583,6 @@ public class LiferayContextController extends ContextController {
 
 	private final ConcurrentMap<String, HttpSessionAdaptor>
 		_activeHttpSessionAdaptors = new ConcurrentHashMap<>();
-	private final BundleContext _bundleContext;
 	private final String _contextName;
 	private final String _contextPath;
 	private final Set<EndpointRegistration<?>> _endpointRegistrations =
@@ -1109,7 +606,6 @@ public class LiferayContextController extends ContextController {
 		_servletContextAttributeListenerServiceTracker;
 	private final ServletContextHelperDataContext
 		_servletContextHelperDataContext;
-	private final long _servletContextHelperServiceId;
 	private final Map<String, String> _servletContextInitParams;
 	private final ServiceTracker<EventListener, ListenerRegistration>
 		_servletContextListenerServiceTracker;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayContextController.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayContextController.java
@@ -352,7 +352,7 @@ public class LiferayContextController extends ContextController {
 		}
 
 		if (_filterRegistrations.isEmpty()) {
-			return new DispatchTargets(
+			return new LiferayDispatchTargets(
 				this, endpointRegistration, servletName, requestURI,
 				servletPath, pathInfo, queryString);
 		}
@@ -381,7 +381,7 @@ public class LiferayContextController extends ContextController {
 			}
 		}
 
-		return new DispatchTargets(
+		return new LiferayDispatchTargets(
 			this, endpointRegistration, matchingFilterRegistrations,
 			servletName, requestURI, servletPath, pathInfo, queryString);
 	}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayContextController.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayContextController.java
@@ -39,7 +39,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -1094,37 +1093,31 @@ public class LiferayContextController extends ContextController {
 	private final EventListeners _eventListeners = new EventListeners();
 	private final Set<FilterRegistration> _filterRegistrations =
 		new ConcurrentSkipListSet<>();
-	private final ServiceTracker<Filter, AtomicReference<FilterRegistration>>
+	private final ServiceTracker<Filter, FilterRegistration>
 		_filterServiceTracker;
 	private final HttpServletEndpointController _httpServletEndpointController;
-	private final ServiceTracker
-		<EventListener, AtomicReference<ListenerRegistration>>
-			_httpSessionAttributeListenerServiceTracker;
-	private final ServiceTracker
-		<EventListener, AtomicReference<ListenerRegistration>>
-			_httpSessionListenerServiceTracker;
+	private final ServiceTracker<EventListener, ListenerRegistration>
+		_httpSessionAttributeListenerServiceTracker;
+	private final ServiceTracker<EventListener, ListenerRegistration>
+		_httpSessionListenerServiceTracker;
 	private final Set<ListenerRegistration> _listenerRegistrations =
 		new HashSet<>();
-	private final ServiceTracker<Object, AtomicReference<ResourceRegistration>>
+	private final ServiceTracker<Object, ResourceRegistration>
 		_resourceServiceTracker;
 	private final ServiceReference<ServletContextHelper> _serviceReference;
-	private final ServiceTracker
-		<EventListener, AtomicReference<ListenerRegistration>>
-			_servletContextAttributeListenerServiceTracker;
+	private final ServiceTracker<EventListener, ListenerRegistration>
+		_servletContextAttributeListenerServiceTracker;
 	private final ServletContextHelperDataContext
 		_servletContextHelperDataContext;
 	private final long _servletContextHelperServiceId;
 	private final Map<String, String> _servletContextInitParams;
-	private final ServiceTracker
-		<EventListener, AtomicReference<ListenerRegistration>>
-			_servletContextListenerServiceTracker;
-	private final ServiceTracker
-		<EventListener, AtomicReference<ListenerRegistration>>
-			_servletRequestAttributeListenerServiceTracker;
-	private final ServiceTracker
-		<EventListener, AtomicReference<ListenerRegistration>>
-			_servletRequestListenerServiceTracker;
-	private final ServiceTracker<Servlet, AtomicReference<ServletRegistration>>
+	private final ServiceTracker<EventListener, ListenerRegistration>
+		_servletContextListenerServiceTracker;
+	private final ServiceTracker<EventListener, ListenerRegistration>
+		_servletRequestAttributeListenerServiceTracker;
+	private final ServiceTracker<EventListener, ListenerRegistration>
+		_servletRequestListenerServiceTracker;
+	private final ServiceTracker<Servlet, ServletRegistration>
 		_servletServiceTracker;
 	private boolean _shutdown;
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayContextController.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayContextController.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.osgi.web.http.servlet.internal.servlet.ServletContextWrapper;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -74,7 +75,6 @@ import org.eclipse.equinox.http.servlet.internal.servlet.HttpSessionAdaptor;
 import org.eclipse.equinox.http.servlet.internal.servlet.Match;
 import org.eclipse.equinox.http.servlet.internal.servlet.ResourceServlet;
 import org.eclipse.equinox.http.servlet.internal.servlet.ServletConfigImpl;
-import org.eclipse.equinox.http.servlet.internal.servlet.ServletContextAdaptor;
 import org.eclipse.equinox.http.servlet.internal.util.Const;
 import org.eclipse.equinox.http.servlet.internal.util.EventListeners;
 import org.eclipse.equinox.http.servlet.internal.util.Path;
@@ -263,10 +263,10 @@ public class LiferayContextController extends ContextController {
 				filterRegistration.init(
 					new FilterConfigImpl(
 						filterDTO.name, filterDTO.initParams,
-						_createServletContextAdaptor(
-							serviceHolder.getBundle(),
-							_getServletContextHelper(
-								serviceHolder.getBundle()))));
+						new ServletContextWrapper(
+							serviceHolder.getBundle(), this,
+							_getServletContextHelper(serviceHolder.getBundle()),
+							_servletContextHelperDataContext)));
 
 				_filterRegistrations.add(filterRegistration);
 			}
@@ -321,9 +321,10 @@ public class LiferayContextController extends ContextController {
 				}
 			}
 
-			ServletContext servletContext = _createServletContextAdaptor(
-				serviceHolder.getBundle(),
-				_getServletContextHelper(serviceHolder.getBundle()));
+			ServletContext servletContext = new ServletContextWrapper(
+				serviceHolder.getBundle(), this,
+				_getServletContextHelper(serviceHolder.getBundle()),
+				_servletContextHelperDataContext);
 
 			listenerRegistration = new ListenerRegistration(
 				serviceHolder, eventListenerClasses,
@@ -411,8 +412,9 @@ public class LiferayContextController extends ContextController {
 			resourceRegistration.init(
 				new ServletConfigImpl(
 					resourceRegistration.getName(), new HashMap<>(),
-					_createServletContextAdaptor(
-						bundle, servletContextHelper)));
+					new ServletContextWrapper(
+						bundle, this, servletContextHelper,
+						_servletContextHelperDataContext)));
 		}
 		catch (ServletException servletException) {
 			if (_log.isDebugEnabled()) {
@@ -460,19 +462,20 @@ public class LiferayContextController extends ContextController {
 
 				ServletDTO servletDTO = objectValuePair.getKey();
 
-				ServletContextHelper curServletContextHelper =
+				ServletContextHelper servletContextHelper =
 					_getServletContextHelper(serviceHolder.getBundle());
 
 				servletRegistration = new ServletRegistration(
 					serviceHolder, servletDTO, objectValuePair.getValue(),
-					curServletContextHelper, this, null);
+					servletContextHelper, this, null);
 
 				servletRegistration.init(
 					new ServletConfigImpl(
 						servletDTO.name, servletDTO.initParams,
-						_createServletContextAdaptor(
-							serviceHolder.getBundle(),
-							curServletContextHelper)));
+						new ServletContextWrapper(
+							serviceHolder.getBundle(), this,
+							servletContextHelper,
+							_servletContextHelperDataContext)));
 
 				_endpointRegistrations.add(servletRegistration);
 			}
@@ -877,17 +880,6 @@ public class LiferayContextController extends ContextController {
 			eventListenerClasses, Class::getName, String.class);
 
 		return listenerDTO;
-	}
-
-	private ServletContext _createServletContextAdaptor(
-		Bundle bundle, ServletContextHelper servletContextHelper) {
-
-		ServletContextAdaptor servletContextAdaptor = new ServletContextAdaptor(
-			this, bundle, servletContextHelper,
-			_servletContextHelperDataContext, _eventListeners,
-			AccessController.getContext());
-
-		return servletContextAdaptor.createServletContext();
 	}
 
 	private ObjectValuePair<ServletDTO, ErrorPageDTO> _createServletDTOs(

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayDispatchTargets.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayDispatchTargets.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.osgi.web.http.servlet.internal.servlet.LiferayResponseStateHandler;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -174,7 +175,7 @@ public class LiferayDispatchTargets extends DispatchTargets {
 			httpServletRequestWrapperImpl.push(this);
 
 			ResponseStateHandler responseStateHandler =
-				new ResponseStateHandler(
+				new LiferayResponseStateHandler(
 					httpServletRequest, httpServletResponse, this);
 
 			responseStateHandler.processRequest();

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayDispatchTargets.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayDispatchTargets.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.osgi.web.http.servlet.internal.context;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.equinox.http.servlet.internal.context.DispatchTargets;
+import org.eclipse.equinox.http.servlet.internal.registration.EndpointRegistration;
+import org.eclipse.equinox.http.servlet.internal.registration.FilterRegistration;
+import org.eclipse.equinox.http.servlet.internal.util.Const;
+
+/**
+ * @author Dante Wang
+ */
+public class LiferayDispatchTargets extends DispatchTargets {
+
+	public LiferayDispatchTargets(
+		LiferayContextController liferayContextController,
+		EndpointRegistration<?> endpointRegistration,
+		List<FilterRegistration> filterRegistrations, String servletName,
+		String requestURI, String servletPath, String pathInfo,
+		String queryString) {
+
+		super(
+			liferayContextController, endpointRegistration, filterRegistrations,
+			servletName, requestURI, servletPath, pathInfo, queryString);
+
+		_liferayContextController = liferayContextController;
+		_endpointRegistration = endpointRegistration;
+		_filterRegistrations = filterRegistrations;
+		_servletName = servletName;
+		_requestURI = requestURI;
+		_servletPath = (servletPath == null) ? Const.BLANK : servletPath;
+		_pathInfo = pathInfo;
+		_queryString = queryString;
+	}
+
+	public LiferayDispatchTargets(
+		LiferayContextController liferayContextController,
+		EndpointRegistration<?> endpointRegistration, String servletName,
+		String requestURI, String servletPath, String pathInfo,
+		String queryString) {
+
+		this(
+			liferayContextController, endpointRegistration,
+			Collections.emptyList(), servletName, requestURI, servletPath,
+			pathInfo, queryString);
+	}
+
+	private final EndpointRegistration<?> _endpointRegistration;
+	private final List<FilterRegistration> _filterRegistrations;
+	private final LiferayContextController _liferayContextController;
+	private final String _pathInfo;
+	private final String _queryString;
+	private final String _requestURI;
+	private final String _servletName;
+	private final String _servletPath;
+
+}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayDispatchTargets.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayDispatchTargets.java
@@ -5,15 +5,17 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.context;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.URLCodec;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.io.Writer;
-
-import java.net.URLDecoder;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,7 +39,6 @@ import org.eclipse.equinox.http.servlet.internal.registration.FilterRegistration
 import org.eclipse.equinox.http.servlet.internal.servlet.HttpServletRequestWrapperImpl;
 import org.eclipse.equinox.http.servlet.internal.servlet.HttpServletResponseWrapperImpl;
 import org.eclipse.equinox.http.servlet.internal.servlet.ResponseStateHandler;
-import org.eclipse.equinox.http.servlet.internal.util.Const;
 import org.eclipse.equinox.http.servlet.internal.util.Params;
 
 /**
@@ -60,7 +61,7 @@ public class LiferayDispatchTargets extends DispatchTargets {
 		_endpointRegistration = endpointRegistration;
 		_servletName = servletName;
 		_requestURI = requestURI;
-		_servletPath = (servletPath == null) ? Const.BLANK : servletPath;
+		_servletPath = GetterUtil.getString(servletPath);
 		_pathInfo = pathInfo;
 		_queryString = queryString;
 
@@ -282,48 +283,42 @@ public class LiferayDispatchTargets extends DispatchTargets {
 	}
 
 	private Map<String, String[]> _parseParameterMap(String queryString) {
-		if ((queryString == null) || (queryString.length() == 0)) {
+		if (Validator.isBlank(queryString)) {
 			return new HashMap<>();
 		}
 
-		try {
-			Map<String, String[]> parameterMap = new LinkedHashMap<>();
+		Map<String, String[]> parameterMap = new LinkedHashMap<>();
 
-			String[] parameters = queryString.split(Const.AMP);
+		String[] parameters = StringUtil.split(
+			queryString, StringPool.AMPERSAND);
 
-			for (String parameter : parameters) {
-				int index = parameter.indexOf('=');
+		for (String parameter : parameters) {
+			int index = parameter.indexOf('=');
 
-				String name = parameter;
+			String name = parameter;
 
-				if (index > 0) {
-					name = URLDecoder.decode(
-						parameter.substring(0, index), Const.UTF8);
-				}
-
-				String[] values = parameterMap.get(name);
-
-				if (values == null) {
-					values = new String[0];
-				}
-
-				String value = null;
-
-				if ((index > 0) && (parameter.length() > (index + 1))) {
-					value = URLDecoder.decode(
-						parameter.substring(index + 1), Const.UTF8);
-				}
-
-				values = Params.append(values, value);
-
-				parameterMap.put(name, values);
+			if (index > 0) {
+				name = URLCodec.decodeURL(parameter.substring(0, index));
 			}
 
-			return parameterMap;
+			String[] values = parameterMap.get(name);
+
+			if (values == null) {
+				values = new String[0];
+			}
+
+			String value = null;
+
+			if ((index > 0) && (parameter.length() > (index + 1))) {
+				value = URLCodec.decodeURL(parameter.substring(index + 1));
+			}
+
+			values = Params.append(values, value);
+
+			parameterMap.put(name, values);
 		}
-		catch (UnsupportedEncodingException unsupportedEncodingException) {
-			throw new RuntimeException(unsupportedEncodingException);
-		}
+
+		return parameterMap;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayDispatchTargets.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/LiferayDispatchTargets.java
@@ -5,13 +5,40 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.context;
 
-import java.util.Collections;
-import java.util.List;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+
+import java.net.URLDecoder;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
 import org.eclipse.equinox.http.servlet.internal.context.DispatchTargets;
 import org.eclipse.equinox.http.servlet.internal.registration.EndpointRegistration;
 import org.eclipse.equinox.http.servlet.internal.registration.FilterRegistration;
+import org.eclipse.equinox.http.servlet.internal.servlet.HttpServletRequestWrapperImpl;
+import org.eclipse.equinox.http.servlet.internal.servlet.HttpServletResponseWrapperImpl;
+import org.eclipse.equinox.http.servlet.internal.servlet.ResponseStateHandler;
 import org.eclipse.equinox.http.servlet.internal.util.Const;
+import org.eclipse.equinox.http.servlet.internal.util.Params;
 
 /**
  * @author Dante Wang
@@ -31,12 +58,13 @@ public class LiferayDispatchTargets extends DispatchTargets {
 
 		_liferayContextController = liferayContextController;
 		_endpointRegistration = endpointRegistration;
-		_filterRegistrations = filterRegistrations;
 		_servletName = servletName;
 		_requestURI = requestURI;
 		_servletPath = (servletPath == null) ? Const.BLANK : servletPath;
 		_pathInfo = pathInfo;
 		_queryString = queryString;
+
+		_matchingFilterRegistrations = filterRegistrations;
 	}
 
 	public LiferayDispatchTargets(
@@ -51,13 +79,299 @@ public class LiferayDispatchTargets extends DispatchTargets {
 			pathInfo, queryString);
 	}
 
+	@Override
+	public void addRequestParameters(HttpServletRequest httpServletRequest) {
+		if (_queryString == null) {
+			_parameterMap = httpServletRequest.getParameterMap();
+			_queryString = httpServletRequest.getQueryString();
+
+			return;
+		}
+
+		Map<String, String[]> parameterMap = _parseParameterMap(_queryString);
+
+		Map<String, String[]> requestParameterMap =
+			httpServletRequest.getParameterMap();
+
+		for (Map.Entry<String, String[]> entry :
+				requestParameterMap.entrySet()) {
+
+			String[] values = parameterMap.get(entry.getKey());
+
+			values = Params.append(values, entry.getValue());
+
+			parameterMap.put(entry.getKey(), values);
+		}
+
+		_parameterMap = Collections.unmodifiableMap(parameterMap);
+	}
+
+	@Override
+	public boolean doDispatch(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String path,
+			DispatcherType dispatcherType)
+		throws IOException, ServletException {
+
+		setDispatcherType(dispatcherType);
+
+		RequestAttributeSetter requestAttributeSetter =
+			new RequestAttributeSetter(httpServletRequest);
+
+		if (_dispatcherType == DispatcherType.INCLUDE) {
+			requestAttributeSetter.setAttribute(
+				RequestDispatcher.INCLUDE_CONTEXT_PATH,
+				_liferayContextController.getFullContextPath());
+			requestAttributeSetter.setAttribute(
+				RequestDispatcher.INCLUDE_PATH_INFO, getPathInfo());
+			requestAttributeSetter.setAttribute(
+				RequestDispatcher.INCLUDE_QUERY_STRING, getQueryString());
+			requestAttributeSetter.setAttribute(
+				RequestDispatcher.INCLUDE_REQUEST_URI, getRequestURI());
+			requestAttributeSetter.setAttribute(
+				RequestDispatcher.INCLUDE_SERVLET_PATH, getServletPath());
+		}
+		else if (_dispatcherType == DispatcherType.FORWARD) {
+			if (!httpServletRequest.isAsyncStarted() &&
+				!httpServletResponse.isCommitted()) {
+
+				httpServletResponse.resetBuffer();
+			}
+
+			requestAttributeSetter.setAttribute(
+				RequestDispatcher.FORWARD_CONTEXT_PATH,
+				httpServletRequest.getContextPath());
+			requestAttributeSetter.setAttribute(
+				RequestDispatcher.FORWARD_PATH_INFO,
+				httpServletRequest.getPathInfo());
+			requestAttributeSetter.setAttribute(
+				RequestDispatcher.FORWARD_QUERY_STRING,
+				httpServletRequest.getQueryString());
+			requestAttributeSetter.setAttribute(
+				RequestDispatcher.FORWARD_REQUEST_URI,
+				httpServletRequest.getRequestURI());
+			requestAttributeSetter.setAttribute(
+				RequestDispatcher.FORWARD_SERVLET_PATH,
+				httpServletRequest.getServletPath());
+		}
+
+		HttpServletRequestWrapperImpl httpServletRequestWrapperImpl =
+			HttpServletRequestWrapperImpl.findHttpRuntimeRequest(
+				httpServletRequest);
+
+		if (httpServletRequestWrapperImpl == null) {
+			httpServletRequestWrapperImpl = new HttpServletRequestWrapperImpl(
+				httpServletRequest);
+
+			httpServletRequest = httpServletRequestWrapperImpl;
+
+			httpServletResponse = new HttpServletResponseWrapperImpl(
+				httpServletResponse);
+		}
+
+		try {
+			httpServletRequestWrapperImpl.push(this);
+
+			ResponseStateHandler responseStateHandler =
+				new ResponseStateHandler(
+					httpServletRequest, httpServletResponse, this);
+
+			responseStateHandler.processRequest();
+
+			if ((_dispatcherType == DispatcherType.FORWARD) &&
+				!httpServletResponse.isCommitted() &&
+				!httpServletRequest.isAsyncStarted()) {
+
+				try {
+					httpServletResponse.flushBuffer();
+
+					Writer writer = httpServletResponse.getWriter();
+
+					writer.close();
+				}
+				catch (IllegalStateException illegalStateException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(illegalStateException);
+					}
+
+					try {
+						ServletOutputStream servletOutputStream =
+							httpServletResponse.getOutputStream();
+
+						servletOutputStream.close();
+					}
+					catch (IllegalStateException | IOException exception) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(exception);
+						}
+					}
+				}
+			}
+
+			return true;
+		}
+		finally {
+			httpServletRequestWrapperImpl.pop();
+
+			requestAttributeSetter.close();
+		}
+	}
+
+	@Override
+	public ContextController getContextController() {
+		return _liferayContextController;
+	}
+
+	@Override
+	public DispatcherType getDispatcherType() {
+		return _dispatcherType;
+	}
+
+	@Override
+	public List<FilterRegistration> getMatchingFilterRegistrations() {
+		return _matchingFilterRegistrations;
+	}
+
+	@Override
+	public Map<String, String[]> getParameterMap() {
+		return _parameterMap;
+	}
+
+	@Override
+	public String getPathInfo() {
+		return _pathInfo;
+	}
+
+	@Override
+	public String getQueryString() {
+		return _queryString;
+	}
+
+	@Override
+	public String getRequestURI() {
+		if (_requestURI == null) {
+			return null;
+		}
+
+		return _liferayContextController.getFullContextPath() + _requestURI;
+	}
+
+	@Override
+	public String getServletName() {
+		return _servletName;
+	}
+
+	@Override
+	public String getServletPath() {
+		return _servletPath;
+	}
+
+	@Override
+	public EndpointRegistration<?> getServletRegistration() {
+		return _endpointRegistration;
+	}
+
+	@Override
+	public Map<String, Object> getSpecialOverides() {
+		return _specialOverrides;
+	}
+
+	@Override
+	public void setDispatcherType(DispatcherType dispatcherType) {
+		_dispatcherType = dispatcherType;
+	}
+
+	private Map<String, String[]> _parseParameterMap(String queryString) {
+		if ((queryString == null) || (queryString.length() == 0)) {
+			return new HashMap<>();
+		}
+
+		try {
+			Map<String, String[]> parameterMap = new LinkedHashMap<>();
+
+			String[] parameters = queryString.split(Const.AMP);
+
+			for (String parameter : parameters) {
+				int index = parameter.indexOf('=');
+
+				String name = parameter;
+
+				if (index > 0) {
+					name = URLDecoder.decode(
+						parameter.substring(0, index), Const.UTF8);
+				}
+
+				String[] values = parameterMap.get(name);
+
+				if (values == null) {
+					values = new String[0];
+				}
+
+				String value = null;
+
+				if ((index > 0) && (parameter.length() > (index + 1))) {
+					value = URLDecoder.decode(
+						parameter.substring(index + 1), Const.UTF8);
+				}
+
+				values = Params.append(values, value);
+
+				parameterMap.put(name, values);
+			}
+
+			return parameterMap;
+		}
+		catch (UnsupportedEncodingException unsupportedEncodingException) {
+			throw new RuntimeException(unsupportedEncodingException);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LiferayDispatchTargets.class.getName());
+
+	private DispatcherType _dispatcherType;
 	private final EndpointRegistration<?> _endpointRegistration;
-	private final List<FilterRegistration> _filterRegistrations;
 	private final LiferayContextController _liferayContextController;
+	private final List<FilterRegistration> _matchingFilterRegistrations;
+	private Map<String, String[]> _parameterMap;
 	private final String _pathInfo;
-	private final String _queryString;
+	private String _queryString;
 	private final String _requestURI;
 	private final String _servletName;
 	private final String _servletPath;
+	private final Map<String, Object> _specialOverrides =
+		new ConcurrentHashMap<>();
+
+	private static class RequestAttributeSetter implements Closeable {
+
+		public RequestAttributeSetter(ServletRequest servletRequest) {
+			_servletRequest = servletRequest;
+		}
+
+		@Override
+		public void close() {
+			for (Map.Entry<String, Object> oldValue :
+					_oldValuesMap.entrySet()) {
+
+				if (oldValue.getValue() == null) {
+					_servletRequest.removeAttribute(oldValue.getKey());
+				}
+				else {
+					_servletRequest.setAttribute(
+						oldValue.getKey(), oldValue.getValue());
+				}
+			}
+		}
+
+		public void setAttribute(String name, Object value) {
+			_oldValuesMap.put(name, _servletRequest.getAttribute(name));
+
+			_servletRequest.setAttribute(name, value);
+		}
+
+		private final Map<String, Object> _oldValuesMap = new HashMap<>();
+		private final ServletRequest _servletRequest;
+
+	}
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/BaseServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/BaseServiceTrackerCustomizer.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/BaseServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/BaseServiceTrackerCustomizer.java
@@ -5,8 +5,9 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
+import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
+
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
-import org.eclipse.equinox.http.servlet.internal.context.ContextController;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
@@ -18,16 +19,17 @@ public abstract class BaseServiceTrackerCustomizer<S, T>
 	implements ServiceTrackerCustomizer<S, T> {
 
 	public BaseServiceTrackerCustomizer(
-		BundleContext bundleContext, ContextController contextController,
-		HttpServletEndpointController httpServletEndpointController) {
+		BundleContext bundleContext,
+		HttpServletEndpointController httpServletEndpointController,
+		LiferayContextController liferayContextController) {
 
 		this.bundleContext = bundleContext;
-		this.contextController = contextController;
 		this.httpServletEndpointController = httpServletEndpointController;
+		this.liferayContextController = liferayContextController;
 	}
 
 	protected BundleContext bundleContext;
-	protected ContextController contextController;
 	protected HttpServletEndpointController httpServletEndpointController;
+	protected LiferayContextController liferayContextController;
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/BaseServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/BaseServiceTrackerCustomizer.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
+
+import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * @author Dante Wang
+ */
+public abstract class BaseServiceTrackerCustomizer<S, T>
+	implements ServiceTrackerCustomizer<S, T> {
+
+	public BaseServiceTrackerCustomizer(
+		BundleContext bundleContext, ContextController contextController,
+		HttpServletEndpointController httpServletEndpointController) {
+
+		this.bundleContext = bundleContext;
+		this.contextController = contextController;
+		this.httpServletEndpointController = httpServletEndpointController;
+	}
+
+	protected BundleContext bundleContext;
+	protected ContextController contextController;
+	protected HttpServletEndpointController httpServletEndpointController;
+
+}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/BaseServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/BaseServiceTrackerCustomizer.java
@@ -7,7 +7,10 @@ package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
 
+import java.util.Arrays;
+
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
+import org.eclipse.equinox.http.servlet.internal.context.ServletContextHelperDataContext;
 import org.eclipse.equinox.http.servlet.internal.registration.Registration;
 
 import org.osgi.dto.DTO;
@@ -25,11 +28,15 @@ public abstract class BaseServiceTrackerCustomizer
 	public BaseServiceTrackerCustomizer(
 		BundleContext bundleContext,
 		HttpServletEndpointController httpServletEndpointController,
-		LiferayContextController liferayContextController) {
+		LiferayContextController liferayContextController,
+		ServletContextHelperDataContext servletContextHelperDataContext,
+		long servletContextHelperServiceId) {
 
 		this.bundleContext = bundleContext;
 		this.httpServletEndpointController = httpServletEndpointController;
 		this.liferayContextController = liferayContextController;
+		this.servletContextHelperDataContext = servletContextHelperDataContext;
+		this.servletContextHelperServiceId = servletContextHelperServiceId;
 	}
 
 	@Override
@@ -44,8 +51,20 @@ public abstract class BaseServiceTrackerCustomizer
 		registration.destroy();
 	}
 
+	protected String[] sort(String[] values) {
+		if (values == null) {
+			return null;
+		}
+
+		Arrays.sort(values);
+
+		return values;
+	}
+
 	protected BundleContext bundleContext;
 	protected HttpServletEndpointController httpServletEndpointController;
 	protected LiferayContextController liferayContextController;
+	protected ServletContextHelperDataContext servletContextHelperDataContext;
+	protected long servletContextHelperServiceId;
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/BaseServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/BaseServiceTrackerCustomizer.java
@@ -8,15 +8,19 @@ package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
 
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
+import org.eclipse.equinox.http.servlet.internal.registration.Registration;
 
+import org.osgi.dto.DTO;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 /**
  * @author Dante Wang
  */
-public abstract class BaseServiceTrackerCustomizer<S, T>
-	implements ServiceTrackerCustomizer<S, T> {
+public abstract class BaseServiceTrackerCustomizer
+	<S, T extends Registration<?, ? extends DTO>>
+		implements ServiceTrackerCustomizer<S, T> {
 
 	public BaseServiceTrackerCustomizer(
 		BundleContext bundleContext,
@@ -26,6 +30,18 @@ public abstract class BaseServiceTrackerCustomizer<S, T>
 		this.bundleContext = bundleContext;
 		this.httpServletEndpointController = httpServletEndpointController;
 		this.liferayContextController = liferayContextController;
+	}
+
+	@Override
+	public void modifiedService(
+		ServiceReference<S> serviceReference, T registration) {
+	}
+
+	@Override
+	public void removedService(
+		ServiceReference<S> serviceReference, T registration) {
+
+		registration.destroy();
 	}
 
 	protected BundleContext bundleContext;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
 
 import java.util.EventListener;
@@ -64,16 +65,7 @@ public class EventListenerServiceTrackerCustomizer
 					DTOConstants.FAILURE_REASON_VALIDATION_FAILED);
 			}
 
-			boolean listener = false;
-
-			if (listenerObject instanceof Boolean) {
-				listener = (boolean)listenerObject;
-			}
-			else {
-				listener = Boolean.parseBoolean((String)listenerObject);
-			}
-
-			if (!listener) {
+			if (!GetterUtil.getBoolean(listenerObject)) {
 				return result;
 			}
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.util.EventListener;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
+import org.eclipse.equinox.http.servlet.internal.error.HttpWhiteboardFailureException;
+import org.eclipse.equinox.http.servlet.internal.registration.ListenerRegistration;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.http.runtime.dto.DTOConstants;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+
+/**
+ * @author Dante Wang
+ */
+public class EventListenerServiceTrackerCustomizer
+	extends BaseServiceTrackerCustomizer
+		<EventListener, AtomicReference<ListenerRegistration>> {
+
+	public EventListenerServiceTrackerCustomizer(
+		BundleContext bundleContext, ContextController contextController,
+		HttpServletEndpointController httpServletEndpointController) {
+
+		super(bundleContext, contextController, httpServletEndpointController);
+	}
+
+	@Override
+	public AtomicReference<ListenerRegistration> addingService(
+		ServiceReference<EventListener> serviceReference) {
+
+		Object listenerObject = serviceReference.getProperty(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_LISTENER);
+
+		if ((listenerObject == null) ||
+			!contextController.matches(serviceReference) ||
+			!httpServletEndpointController.matches(serviceReference)) {
+
+			return null;
+		}
+
+		AtomicReference<ListenerRegistration> result = new AtomicReference<>();
+
+		try {
+			if (!(listenerObject instanceof Boolean) &&
+				!(listenerObject instanceof String)) {
+
+				throw new HttpWhiteboardFailureException(
+					StringBundler.concat(
+						HttpWhiteboardConstants.HTTP_WHITEBOARD_LISTENER, "=",
+						listenerObject, " is not valid"),
+					DTOConstants.FAILURE_REASON_VALIDATION_FAILED);
+			}
+
+			boolean listener = false;
+
+			if (listenerObject instanceof Boolean) {
+				listener = (boolean)listenerObject;
+			}
+			else {
+				listener = Boolean.parseBoolean((String)listenerObject);
+			}
+
+			if (!listener) {
+				return result;
+			}
+
+			result.set(
+				contextController.addListenerRegistration(serviceReference));
+		}
+		catch (Exception exception) {
+			httpServletEndpointController.log(
+				exception.getMessage(), exception);
+		}
+
+		return result;
+	}
+
+	@Override
+	public void modifiedService(
+		ServiceReference<EventListener> serviceReference,
+		AtomicReference<ListenerRegistration> listenerRegistration) {
+
+		removedService(serviceReference, listenerRegistration);
+
+		addingService(serviceReference);
+	}
+
+	@Override
+	public void removedService(
+		ServiceReference<EventListener> serviceReference,
+		AtomicReference<ListenerRegistration> listenerReference) {
+
+		ListenerRegistration listenerRegistration = listenerReference.get();
+
+		if (listenerRegistration != null) {
+			listenerRegistration.destroy();
+		}
+	}
+
+}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
@@ -6,12 +6,12 @@
 package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
 
 import java.util.EventListener;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
-import org.eclipse.equinox.http.servlet.internal.context.ContextController;
 import org.eclipse.equinox.http.servlet.internal.error.HttpWhiteboardFailureException;
 import org.eclipse.equinox.http.servlet.internal.registration.ListenerRegistration;
 
@@ -28,10 +28,13 @@ public class EventListenerServiceTrackerCustomizer
 		<EventListener, AtomicReference<ListenerRegistration>> {
 
 	public EventListenerServiceTrackerCustomizer(
-		BundleContext bundleContext, ContextController contextController,
-		HttpServletEndpointController httpServletEndpointController) {
+		BundleContext bundleContext,
+		HttpServletEndpointController httpServletEndpointController,
+		LiferayContextController liferayContextController) {
 
-		super(bundleContext, contextController, httpServletEndpointController);
+		super(
+			bundleContext, httpServletEndpointController,
+			liferayContextController);
 	}
 
 	@Override
@@ -42,7 +45,7 @@ public class EventListenerServiceTrackerCustomizer
 			HttpWhiteboardConstants.HTTP_WHITEBOARD_LISTENER);
 
 		if ((listenerObject == null) ||
-			!contextController.matches(serviceReference) ||
+			!liferayContextController.matches(serviceReference) ||
 			!httpServletEndpointController.matches(serviceReference)) {
 
 			return null;
@@ -75,7 +78,8 @@ public class EventListenerServiceTrackerCustomizer
 			}
 
 			result.set(
-				contextController.addListenerRegistration(serviceReference));
+				liferayContextController.addListenerRegistration(
+					serviceReference));
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
@@ -5,19 +5,40 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
+import com.liferay.osgi.util.StringPlus;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
+import com.liferay.portal.osgi.web.http.servlet.internal.servlet.ServletContextWrapper;
 
+import java.util.ArrayList;
 import java.util.EventListener;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextAttributeListener;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletRequestAttributeListener;
+import javax.servlet.ServletRequestListener;
+import javax.servlet.http.HttpSessionAttributeListener;
+import javax.servlet.http.HttpSessionListener;
 
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
+import org.eclipse.equinox.http.servlet.internal.context.ServletContextHelperDataContext;
 import org.eclipse.equinox.http.servlet.internal.error.HttpWhiteboardFailureException;
 import org.eclipse.equinox.http.servlet.internal.registration.ListenerRegistration;
+import org.eclipse.equinox.http.servlet.internal.util.EventListeners;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.http.runtime.dto.DTOConstants;
+import org.osgi.service.http.runtime.dto.ListenerDTO;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 
 /**
@@ -29,11 +50,14 @@ public class EventListenerServiceTrackerCustomizer
 	public EventListenerServiceTrackerCustomizer(
 		BundleContext bundleContext,
 		HttpServletEndpointController httpServletEndpointController,
-		LiferayContextController liferayContextController) {
+		LiferayContextController liferayContextController,
+		ServletContextHelperDataContext servletContextHelperDataContext,
+		long servletContextHelperServiceId) {
 
 		super(
 			bundleContext, httpServletEndpointController,
-			liferayContextController);
+			liferayContextController, servletContextHelperDataContext,
+			servletContextHelperServiceId);
 	}
 
 	@Override
@@ -65,8 +89,79 @@ public class EventListenerServiceTrackerCustomizer
 				return null;
 			}
 
-			return liferayContextController.addListenerRegistration(
-				serviceReference);
+			liferayContextController.checkShutdown();
+
+			ContextController.ServiceHolder<EventListener> serviceHolder =
+				new ContextController.ServiceHolder<>(
+					bundleContext.getServiceObjects(serviceReference));
+
+			EventListener eventListener = serviceHolder.get();
+
+			ListenerRegistration listenerRegistration = null;
+
+			try {
+				if (eventListener == null) {
+					throw new IllegalArgumentException(
+						"Event listener is null");
+				}
+
+				List<Class<? extends EventListener>> eventListenerClasses =
+					_getEventListenerClasses(serviceReference);
+
+				if (eventListenerClasses.isEmpty()) {
+					throw new IllegalArgumentException(
+						"Event listener does not implement a supported " +
+							"interface");
+				}
+
+				Set<ListenerRegistration> listenerRegistrations =
+					liferayContextController.getListenerRegistrations();
+
+				for (ListenerRegistration curListenerRegistration :
+						listenerRegistrations) {
+
+					if (Objects.equals(
+							curListenerRegistration.getT(), eventListener)) {
+
+						return null;
+					}
+				}
+
+				ServletContext servletContext = new ServletContextWrapper(
+					serviceHolder.getBundle(), liferayContextController,
+					liferayContextController.getServletContextHelper(
+						serviceHolder.getBundle()),
+					servletContextHelperDataContext);
+
+				listenerRegistration = new ListenerRegistration(
+					serviceHolder, eventListenerClasses,
+					_createListenerDTO(serviceReference, eventListenerClasses),
+					servletContext, liferayContextController);
+
+				if (eventListenerClasses.contains(
+						ServletContextListener.class)) {
+
+					ServletContextListener servletContextListener =
+						(ServletContextListener)listenerRegistration.getT();
+
+					servletContextListener.contextInitialized(
+						new ServletContextEvent(servletContext));
+				}
+
+				listenerRegistrations.add(listenerRegistration);
+
+				EventListeners eventListeners =
+					liferayContextController.getEventListeners();
+
+				eventListeners.put(eventListenerClasses, listenerRegistration);
+			}
+			finally {
+				if (listenerRegistration == null) {
+					serviceHolder.release();
+				}
+			}
+
+			return listenerRegistration;
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(
@@ -74,6 +169,63 @@ public class EventListenerServiceTrackerCustomizer
 		}
 
 		return null;
+	}
+
+	private ListenerDTO _createListenerDTO(
+		ServiceReference<EventListener> serviceReference,
+		List<Class<? extends EventListener>> eventListenerClasses) {
+
+		ListenerDTO listenerDTO = new ListenerDTO();
+
+		listenerDTO.serviceId = (long)serviceReference.getProperty(
+			Constants.SERVICE_ID);
+		listenerDTO.servletContextId = servletContextHelperServiceId;
+		listenerDTO.types = TransformUtil.transformToArray(
+			eventListenerClasses, Class::getName, String.class);
+
+		return listenerDTO;
+	}
+
+	private List<Class<? extends EventListener>> _getEventListenerClasses(
+		ServiceReference<EventListener> serviceReference) {
+
+		List<Class<? extends EventListener>> eventListenerClasses =
+			new ArrayList<>();
+
+		List<String> objectClasses = StringPlus.asList(
+			serviceReference.getProperty(Constants.OBJECTCLASS));
+
+		if (objectClasses.contains(
+				HttpSessionAttributeListener.class.getName())) {
+
+			eventListenerClasses.add(HttpSessionAttributeListener.class);
+		}
+
+		if (objectClasses.contains(HttpSessionListener.class.getName())) {
+			eventListenerClasses.add(HttpSessionListener.class);
+		}
+
+		if (objectClasses.contains(
+				ServletContextAttributeListener.class.getName())) {
+
+			eventListenerClasses.add(ServletContextAttributeListener.class);
+		}
+
+		if (objectClasses.contains(ServletContextListener.class.getName())) {
+			eventListenerClasses.add(ServletContextListener.class);
+		}
+
+		if (objectClasses.contains(
+				ServletRequestAttributeListener.class.getName())) {
+
+			eventListenerClasses.add(ServletRequestAttributeListener.class);
+		}
+
+		if (objectClasses.contains(ServletRequestListener.class.getName())) {
+			eventListenerClasses.add(ServletRequestListener.class);
+		}
+
+		return eventListenerClasses;
 	}
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
@@ -10,7 +10,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
 
 import java.util.EventListener;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
 import org.eclipse.equinox.http.servlet.internal.error.HttpWhiteboardFailureException;
@@ -25,8 +24,7 @@ import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
  * @author Dante Wang
  */
 public class EventListenerServiceTrackerCustomizer
-	extends BaseServiceTrackerCustomizer
-		<EventListener, AtomicReference<ListenerRegistration>> {
+	extends BaseServiceTrackerCustomizer<EventListener, ListenerRegistration> {
 
 	public EventListenerServiceTrackerCustomizer(
 		BundleContext bundleContext,
@@ -39,7 +37,7 @@ public class EventListenerServiceTrackerCustomizer
 	}
 
 	@Override
-	public AtomicReference<ListenerRegistration> addingService(
+	public ListenerRegistration addingService(
 		ServiceReference<EventListener> serviceReference) {
 
 		Object listenerObject = serviceReference.getProperty(
@@ -51,8 +49,6 @@ public class EventListenerServiceTrackerCustomizer
 
 			return null;
 		}
-
-		AtomicReference<ListenerRegistration> result = new AtomicReference<>();
 
 		try {
 			if (!(listenerObject instanceof Boolean) &&
@@ -66,41 +62,32 @@ public class EventListenerServiceTrackerCustomizer
 			}
 
 			if (!GetterUtil.getBoolean(listenerObject)) {
-				return result;
+				return null;
 			}
 
-			result.set(
-				liferayContextController.addListenerRegistration(
-					serviceReference));
+			return liferayContextController.addListenerRegistration(
+				serviceReference);
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(
 				exception.getMessage(), exception);
 		}
 
-		return result;
+		return null;
 	}
 
 	@Override
 	public void modifiedService(
 		ServiceReference<EventListener> serviceReference,
-		AtomicReference<ListenerRegistration> listenerRegistration) {
-
-		removedService(serviceReference, listenerRegistration);
-
-		addingService(serviceReference);
+		ListenerRegistration listenerRegistration) {
 	}
 
 	@Override
 	public void removedService(
 		ServiceReference<EventListener> serviceReference,
-		AtomicReference<ListenerRegistration> listenerReference) {
+		ListenerRegistration listenerRegistration) {
 
-		ListenerRegistration listenerRegistration = listenerReference.get();
-
-		if (listenerRegistration != null) {
-			listenerRegistration.destroy();
-		}
+		listenerRegistration.destroy();
 	}
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
@@ -8,6 +8,8 @@ package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 import com.liferay.osgi.util.StringPlus;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
 import com.liferay.portal.osgi.web.http.servlet.internal.servlet.ServletContextWrapper;
@@ -164,8 +166,7 @@ public class EventListenerServiceTrackerCustomizer
 			return listenerRegistration;
 		}
 		catch (Exception exception) {
-			httpServletEndpointController.log(
-				exception.getMessage(), exception);
+			_log.error(exception);
 		}
 
 		return null;
@@ -227,5 +228,8 @@ public class EventListenerServiceTrackerCustomizer
 
 		return eventListenerClasses;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		EventListenerServiceTrackerCustomizer.class.getName());
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/EventListenerServiceTrackerCustomizer.java
@@ -76,18 +76,4 @@ public class EventListenerServiceTrackerCustomizer
 		return null;
 	}
 
-	@Override
-	public void modifiedService(
-		ServiceReference<EventListener> serviceReference,
-		ListenerRegistration listenerRegistration) {
-	}
-
-	@Override
-	public void removedService(
-		ServiceReference<EventListener> serviceReference,
-		ListenerRegistration listenerRegistration) {
-
-		listenerRegistration.destroy();
-	}
-
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
@@ -8,7 +8,6 @@ package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.Filter;
 
@@ -23,8 +22,7 @@ import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
  * @author Raymond Augé
  */
 public class FilterServiceTrackerCustomizer
-	extends BaseServiceTrackerCustomizer
-		<Filter, AtomicReference<FilterRegistration>> {
+	extends BaseServiceTrackerCustomizer<Filter, FilterRegistration> {
 
 	public FilterServiceTrackerCustomizer(
 		BundleContext bundleContext,
@@ -37,7 +35,7 @@ public class FilterServiceTrackerCustomizer
 	}
 
 	@Override
-	public AtomicReference<FilterRegistration> addingService(
+	public FilterRegistration addingService(
 		ServiceReference<Filter> serviceReference) {
 
 		if (Objects.isNull(
@@ -59,44 +57,30 @@ public class FilterServiceTrackerCustomizer
 			return null;
 		}
 
-		AtomicReference<FilterRegistration> result = new AtomicReference<>();
-
 		try {
-			result.set(
-				liferayContextController.addFilterRegistration(
-					serviceReference));
+			return liferayContextController.addFilterRegistration(
+				serviceReference);
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(
 				exception.getMessage(), exception);
 		}
 
-		return result;
+		return null;
 	}
 
 	@Override
 	public void modifiedService(
 		ServiceReference<Filter> serviceReference,
-		AtomicReference<FilterRegistration> filterReference) {
-
-		removedService(serviceReference, filterReference);
-
-		AtomicReference<FilterRegistration> added = addingService(
-			serviceReference);
-
-		filterReference.set(added.get());
+		FilterRegistration filterRegistration) {
 	}
 
 	@Override
 	public void removedService(
 		ServiceReference<Filter> serviceReference,
-		AtomicReference<FilterRegistration> filterReference) {
+		FilterRegistration filterRegistration) {
 
-		FilterRegistration filterRegistration = filterReference.get();
-
-		if (filterRegistration != null) {
-			filterRegistration.destroy();
-		}
+		filterRegistration.destroy();
 	}
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
@@ -5,17 +5,30 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
+import com.liferay.osgi.util.StringPlus;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
+import com.liferay.portal.osgi.web.http.servlet.internal.servlet.ServletContextWrapper;
 
 import java.util.Objects;
+import java.util.Set;
 
+import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
+import org.eclipse.equinox.http.servlet.internal.context.ServletContextHelperDataContext;
+import org.eclipse.equinox.http.servlet.internal.error.RegisteredFilterException;
 import org.eclipse.equinox.http.servlet.internal.registration.FilterRegistration;
+import org.eclipse.equinox.http.servlet.internal.servlet.FilterConfigImpl;
+import org.eclipse.equinox.http.servlet.internal.util.ServiceProperties;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.http.runtime.dto.FilterDTO;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 
 /**
@@ -27,11 +40,14 @@ public class FilterServiceTrackerCustomizer
 	public FilterServiceTrackerCustomizer(
 		BundleContext bundleContext,
 		HttpServletEndpointController httpServletEndpointController,
-		LiferayContextController liferayContextController) {
+		LiferayContextController liferayContextController,
+		ServletContextHelperDataContext servletContextHelperDataContext,
+		long servletContextHelperServiceId) {
 
 		super(
 			bundleContext, httpServletEndpointController,
-			liferayContextController);
+			liferayContextController, servletContextHelperDataContext,
+			servletContextHelperServiceId);
 	}
 
 	@Override
@@ -58,8 +74,77 @@ public class FilterServiceTrackerCustomizer
 		}
 
 		try {
-			return liferayContextController.addFilterRegistration(
-				serviceReference);
+			liferayContextController.checkShutdown();
+
+			ContextController.ServiceHolder<Filter> serviceHolder =
+				new ContextController.ServiceHolder<>(
+					bundleContext.getServiceObjects(serviceReference));
+
+			Filter filter = serviceHolder.get();
+
+			FilterRegistration filterRegistration = null;
+
+			boolean addedRegisteredObject = false;
+
+			Set<Object> registeredObjects =
+				httpServletEndpointController.getRegisteredObjects();
+
+			try {
+				if (filter == null) {
+					throw new IllegalArgumentException("Filter is null");
+				}
+
+				addedRegisteredObject = registeredObjects.add(filter);
+
+				if (addedRegisteredObject) {
+					Set<FilterRegistration> filterRegistrations =
+						liferayContextController.getFilterRegistrations();
+
+					for (FilterRegistration curFilterRegistration :
+							filterRegistrations) {
+
+						if (Objects.equals(
+								curFilterRegistration.getT(), filter)) {
+
+							throw new RegisteredFilterException(filter);
+						}
+					}
+
+					FilterDTO filterDTO = _createFilterDTO(
+						serviceReference, filter);
+
+					filterRegistration = new FilterRegistration(
+						serviceHolder, filterDTO,
+						GetterUtil.getInteger(
+							serviceReference.getProperty(
+								Constants.SERVICE_RANKING)),
+						liferayContextController, null);
+
+					filterRegistration.init(
+						new FilterConfigImpl(
+							filterDTO.name, filterDTO.initParams,
+							new ServletContextWrapper(
+								serviceHolder.getBundle(),
+								liferayContextController,
+								liferayContextController.
+									getServletContextHelper(
+										serviceHolder.getBundle()),
+								servletContextHelperDataContext)));
+
+					filterRegistrations.add(filterRegistration);
+				}
+			}
+			finally {
+				if (filterRegistration == null) {
+					serviceHolder.release();
+
+					if (addedRegisteredObject) {
+						registeredObjects.remove(filter);
+					}
+				}
+			}
+
+			return filterRegistration;
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(
@@ -68,5 +153,86 @@ public class FilterServiceTrackerCustomizer
 
 		return null;
 	}
+
+	private FilterDTO _createFilterDTO(
+		ServiceReference<Filter> filterServiceReference, Filter filter) {
+
+		String[] filterPatterns = ArrayUtil.toStringArray(
+			StringPlus.asList(
+				filterServiceReference.getProperty(
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_PATTERN)));
+		String[] filterRegexes = ArrayUtil.toStringArray(
+			StringPlus.asList(
+				filterServiceReference.getProperty(
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_REGEX)));
+		String[] filterServletNames = ArrayUtil.toStringArray(
+			StringPlus.asList(
+				filterServiceReference.getProperty(
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET)));
+
+		if ((filterPatterns.length == 0) && (filterRegexes.length == 0) &&
+			(filterServletNames.length == 0)) {
+
+			throw new IllegalArgumentException(
+				"Patterns, regex, and servlet names must contain a value");
+		}
+
+		for (String filterPattern : filterPatterns) {
+			ContextController.checkPattern(filterPattern);
+		}
+
+		String[] filterDispatcherTypes = ArrayUtil.toStringArray(
+			StringPlus.asList(
+				filterServiceReference.getProperty(
+					HttpWhiteboardConstants.
+						HTTP_WHITEBOARD_FILTER_DISPATCHER)));
+
+		if (filterDispatcherTypes.length == 0) {
+			filterDispatcherTypes = _DISPATCHER_TYPES;
+		}
+
+		for (String filterDispatcherType : filterDispatcherTypes) {
+			try {
+				DispatcherType.valueOf(filterDispatcherType);
+			}
+			catch (IllegalArgumentException illegalArgumentException) {
+				throw new IllegalArgumentException(
+					"Invalid dispatcher \"" + filterDispatcherType + "\"",
+					illegalArgumentException);
+			}
+		}
+
+		FilterDTO filterDTO = new FilterDTO();
+
+		filterDTO.asyncSupported = ServiceProperties.parseBoolean(
+			filterServiceReference,
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_ASYNC_SUPPORTED);
+		filterDTO.dispatcher = sort(filterDispatcherTypes);
+		filterDTO.initParams = ServiceProperties.parseInitParams(
+			filterServiceReference,
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_INIT_PARAM_PREFIX);
+
+		Class<?> filterClass = filter.getClass();
+
+		filterDTO.name = GetterUtil.getString(
+			ServiceProperties.parseName(
+				filterServiceReference.getProperty(
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_NAME),
+				filter),
+			filterClass.getName());
+
+		filterDTO.patterns = sort(filterPatterns);
+		filterDTO.regexs = filterRegexes;
+		filterDTO.serviceId = (long)filterServiceReference.getProperty(
+			Constants.SERVICE_ID);
+		filterDTO.servletContextId = servletContextHelperServiceId;
+		filterDTO.servletNames = sort(filterServletNames);
+
+		return filterDTO;
+	}
+
+	private static final String[] _DISPATCHER_TYPES = {
+		DispatcherType.REQUEST.toString()
+	};
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
@@ -5,13 +5,14 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
+import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
+
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.Filter;
 
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
-import org.eclipse.equinox.http.servlet.internal.context.ContextController;
 import org.eclipse.equinox.http.servlet.internal.registration.FilterRegistration;
 
 import org.osgi.framework.BundleContext;
@@ -28,9 +29,11 @@ public class FilterServiceTrackerCustomizer
 	public FilterServiceTrackerCustomizer(
 		BundleContext bundleContext,
 		HttpServletEndpointController httpServletEndpointController,
-		ContextController contextController) {
+		LiferayContextController liferayContextController) {
 
-		super(bundleContext, contextController, httpServletEndpointController);
+		super(
+			bundleContext, httpServletEndpointController,
+			liferayContextController);
 	}
 
 	@Override
@@ -50,7 +53,7 @@ public class FilterServiceTrackerCustomizer
 			return null;
 		}
 
-		if (!contextController.matches(serviceReference) ||
+		if (!liferayContextController.matches(serviceReference) ||
 			!httpServletEndpointController.matches(serviceReference)) {
 
 			return null;
@@ -60,7 +63,8 @@ public class FilterServiceTrackerCustomizer
 
 		try {
 			result.set(
-				contextController.addFilterRegistration(serviceReference));
+				liferayContextController.addFilterRegistration(
+					serviceReference));
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
@@ -6,6 +6,8 @@
 package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
 import com.liferay.osgi.util.StringPlus;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
@@ -147,8 +149,7 @@ public class FilterServiceTrackerCustomizer
 			return filterRegistration;
 		}
 		catch (Exception exception) {
-			httpServletEndpointController.log(
-				exception.getMessage(), exception);
+			_log.error(exception);
 		}
 
 		return null;
@@ -234,5 +235,8 @@ public class FilterServiceTrackerCustomizer
 	private static final String[] _DISPATCHER_TYPES = {
 		DispatcherType.REQUEST.toString()
 	};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FilterServiceTrackerCustomizer.class.getName());
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
@@ -1,0 +1,98 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.servlet.Filter;
+
+import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
+import org.eclipse.equinox.http.servlet.internal.registration.FilterRegistration;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+
+/**
+ * @author Raymond Augé
+ */
+public class FilterServiceTrackerCustomizer
+	extends BaseServiceTrackerCustomizer
+		<Filter, AtomicReference<FilterRegistration>> {
+
+	public FilterServiceTrackerCustomizer(
+		BundleContext bundleContext,
+		HttpServletEndpointController httpServletEndpointController,
+		ContextController contextController) {
+
+		super(bundleContext, contextController, httpServletEndpointController);
+	}
+
+	@Override
+	public AtomicReference<FilterRegistration> addingService(
+		ServiceReference<Filter> serviceReference) {
+
+		if (Objects.isNull(
+				serviceReference.getProperty(
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_PATTERN)) &&
+			Objects.isNull(
+				serviceReference.getProperty(
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_REGEX)) &&
+			Objects.isNull(
+				serviceReference.getProperty(
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_SERVLET))) {
+
+			return null;
+		}
+
+		if (!contextController.matches(serviceReference) ||
+			!httpServletEndpointController.matches(serviceReference)) {
+
+			return null;
+		}
+
+		AtomicReference<FilterRegistration> result = new AtomicReference<>();
+
+		try {
+			result.set(
+				contextController.addFilterRegistration(serviceReference));
+		}
+		catch (Exception exception) {
+			httpServletEndpointController.log(
+				exception.getMessage(), exception);
+		}
+
+		return result;
+	}
+
+	@Override
+	public void modifiedService(
+		ServiceReference<Filter> serviceReference,
+		AtomicReference<FilterRegistration> filterReference) {
+
+		removedService(serviceReference, filterReference);
+
+		AtomicReference<FilterRegistration> added = addingService(
+			serviceReference);
+
+		filterReference.set(added.get());
+	}
+
+	@Override
+	public void removedService(
+		ServiceReference<Filter> serviceReference,
+		AtomicReference<FilterRegistration> filterReference) {
+
+		FilterRegistration filterRegistration = filterReference.get();
+
+		if (filterRegistration != null) {
+			filterRegistration.destroy();
+		}
+	}
+
+}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/FilterServiceTrackerCustomizer.java
@@ -69,18 +69,4 @@ public class FilterServiceTrackerCustomizer
 		return null;
 	}
 
-	@Override
-	public void modifiedService(
-		ServiceReference<Filter> serviceReference,
-		FilterRegistration filterRegistration) {
-	}
-
-	@Override
-	public void removedService(
-		ServiceReference<Filter> serviceReference,
-		FilterRegistration filterRegistration) {
-
-		filterRegistration.destroy();
-	}
-
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
@@ -5,11 +5,12 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
+import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
+
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
-import org.eclipse.equinox.http.servlet.internal.context.ContextController;
 import org.eclipse.equinox.http.servlet.internal.registration.ResourceRegistration;
 
 import org.osgi.framework.BundleContext;
@@ -26,9 +27,11 @@ public class ResourceServiceTrackerCustomizer
 	public ResourceServiceTrackerCustomizer(
 		BundleContext bundleContext,
 		HttpServletEndpointController httpServletEndpointController,
-		ContextController contextController) {
+		LiferayContextController liferayContextController) {
 
-		super(bundleContext, contextController, httpServletEndpointController);
+		super(
+			bundleContext, httpServletEndpointController,
+			liferayContextController);
 	}
 
 	@Override
@@ -46,7 +49,7 @@ public class ResourceServiceTrackerCustomizer
 			return null;
 		}
 
-		if (!contextController.matches(serviceReference) ||
+		if (!liferayContextController.matches(serviceReference) ||
 			!httpServletEndpointController.matches(serviceReference)) {
 
 			return null;
@@ -56,7 +59,8 @@ public class ResourceServiceTrackerCustomizer
 
 		try {
 			result.set(
-				contextController.addResourceRegistration(serviceReference));
+				liferayContextController.addResourceRegistration(
+					serviceReference));
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
+import org.eclipse.equinox.http.servlet.internal.registration.ResourceRegistration;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+
+/**
+ * @author Dante Wang
+ */
+public class ResourceServiceTrackerCustomizer
+	extends BaseServiceTrackerCustomizer
+		<Object, AtomicReference<ResourceRegistration>> {
+
+	public ResourceServiceTrackerCustomizer(
+		BundleContext bundleContext,
+		HttpServletEndpointController httpServletEndpointController,
+		ContextController contextController) {
+
+		super(bundleContext, contextController, httpServletEndpointController);
+	}
+
+	@Override
+	public AtomicReference<ResourceRegistration> addingService(
+		ServiceReference<Object> serviceReference) {
+
+		if (Objects.isNull(
+				serviceReference.getProperty(
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PREFIX)) &&
+			Objects.isNull(
+				serviceReference.getProperty(
+					HttpWhiteboardConstants.
+						HTTP_WHITEBOARD_RESOURCE_PATTERN))) {
+
+			return null;
+		}
+
+		if (!contextController.matches(serviceReference) ||
+			!httpServletEndpointController.matches(serviceReference)) {
+
+			return null;
+		}
+
+		AtomicReference<ResourceRegistration> result = new AtomicReference<>();
+
+		try {
+			result.set(
+				contextController.addResourceRegistration(serviceReference));
+		}
+		catch (Exception exception) {
+			httpServletEndpointController.log(
+				exception.getMessage(), exception);
+		}
+
+		return result;
+	}
+
+	@Override
+	public void modifiedService(
+		ServiceReference<Object> serviceReference,
+		AtomicReference<ResourceRegistration> resourceReference) {
+
+		removedService(serviceReference, resourceReference);
+
+		AtomicReference<ResourceRegistration> added = addingService(
+			serviceReference);
+
+		resourceReference.set(added.get());
+	}
+
+	@Override
+	public void removedService(
+		ServiceReference<Object> serviceReference,
+		AtomicReference<ResourceRegistration> resourceReference) {
+
+		ResourceRegistration registration = resourceReference.get();
+
+		if (registration != null) {
+			registration.destroy();
+		}
+	}
+
+}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
@@ -65,18 +65,4 @@ public class ResourceServiceTrackerCustomizer
 		return null;
 	}
 
-	@Override
-	public void modifiedService(
-		ServiceReference<Object> serviceReference,
-		ResourceRegistration resourceRegistration) {
-	}
-
-	@Override
-	public void removedService(
-		ServiceReference<Object> serviceReference,
-		ResourceRegistration resourceRegistration) {
-
-		resourceRegistration.destroy();
-	}
-
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
@@ -136,22 +136,12 @@ public class ResourceServiceTrackerCustomizer
 					resourceDTO, servletContextHelper, liferayContextController,
 					null);
 
-			try {
-				resourceRegistration.init(
-					new ServletConfigImpl(
-						resourceRegistration.getName(), new HashMap<>(),
-						new ServletContextWrapper(
-							bundle, liferayContextController,
-							servletContextHelper,
-							servletContextHelperDataContext)));
-			}
-			catch (ServletException servletException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(servletException);
-				}
-
-				return null;
-			}
+			resourceRegistration.init(
+				new ServletConfigImpl(
+					resourceRegistration.getName(), new HashMap<>(),
+					new ServletContextWrapper(
+						bundle, liferayContextController, servletContextHelper,
+						servletContextHelperDataContext)));
 
 			Set<EndpointRegistration<?>> endpointRegistrations =
 				liferayContextController.getEndpointRegistrations();
@@ -159,6 +149,11 @@ public class ResourceServiceTrackerCustomizer
 			endpointRegistrations.add(resourceRegistration);
 
 			return resourceRegistration;
+		}
+		catch (ServletException servletException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(servletException);
+			}
 		}
 		catch (Exception exception) {
 			_log.error(exception);

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
@@ -161,14 +161,13 @@ public class ResourceServiceTrackerCustomizer
 			return resourceRegistration;
 		}
 		catch (Exception exception) {
-			httpServletEndpointController.log(
-				exception.getMessage(), exception);
+			_log.error(exception);
 		}
 
 		return null;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		ResourceServiceTrackerCustomizer.class);
+		EventListenerServiceTrackerCustomizer.class.getName());
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
@@ -5,15 +5,37 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
+import com.liferay.osgi.util.StringPlus;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
+import com.liferay.portal.osgi.web.http.servlet.internal.servlet.ServletContextWrapper;
 
+import java.security.AccessController;
+
+import java.util.HashMap;
 import java.util.Objects;
+import java.util.Set;
+
+import javax.servlet.ServletException;
 
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
+import org.eclipse.equinox.http.servlet.internal.context.ServletContextHelperDataContext;
+import org.eclipse.equinox.http.servlet.internal.registration.EndpointRegistration;
 import org.eclipse.equinox.http.servlet.internal.registration.ResourceRegistration;
+import org.eclipse.equinox.http.servlet.internal.servlet.ResourceServlet;
+import org.eclipse.equinox.http.servlet.internal.servlet.ServletConfigImpl;
+import org.eclipse.equinox.http.servlet.internal.util.Const;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.http.context.ServletContextHelper;
+import org.osgi.service.http.runtime.dto.ResourceDTO;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 
 /**
@@ -25,11 +47,14 @@ public class ResourceServiceTrackerCustomizer
 	public ResourceServiceTrackerCustomizer(
 		BundleContext bundleContext,
 		HttpServletEndpointController httpServletEndpointController,
-		LiferayContextController liferayContextController) {
+		LiferayContextController liferayContextController,
+		ServletContextHelperDataContext servletContextHelperDataContext,
+		long servletContextHelperServiceId) {
 
 		super(
 			bundleContext, httpServletEndpointController,
-			liferayContextController);
+			liferayContextController, servletContextHelperDataContext,
+			servletContextHelperServiceId);
 	}
 
 	@Override
@@ -54,8 +79,86 @@ public class ResourceServiceTrackerCustomizer
 		}
 
 		try {
-			return liferayContextController.addResourceRegistration(
-				serviceReference);
+			liferayContextController.checkShutdown();
+
+			String resourcePrefix = (String)serviceReference.getProperty(
+				HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PREFIX);
+
+			if (resourcePrefix == null) {
+				throw new IllegalArgumentException("Prefix is null");
+			}
+
+			if (resourcePrefix.endsWith(Const.SLASH) &&
+				!resourcePrefix.equals(Const.SLASH)) {
+
+				throw new IllegalArgumentException(
+					"Invalid prefix \"" + resourcePrefix + "\"");
+			}
+
+			String[] resourcePatterns = ArrayUtil.toStringArray(
+				StringPlus.asList(
+					serviceReference.getProperty(
+						HttpWhiteboardConstants.
+							HTTP_WHITEBOARD_RESOURCE_PATTERN)));
+
+			if (resourcePatterns.length < 1) {
+				throw new IllegalArgumentException(
+					"Patterns must contain a value");
+			}
+
+			for (String resourcePattern : resourcePatterns) {
+				ContextController.checkPattern(resourcePattern);
+			}
+
+			Bundle bundle = serviceReference.getBundle();
+
+			ResourceDTO resourceDTO = new ResourceDTO();
+
+			resourceDTO.patterns = sort(resourcePatterns);
+			resourceDTO.prefix = resourcePrefix;
+			resourceDTO.serviceId = (long)serviceReference.getProperty(
+				Constants.SERVICE_ID);
+			resourceDTO.servletContextId = servletContextHelperServiceId;
+
+			ServletContextHelper servletContextHelper =
+				liferayContextController.getServletContextHelper(bundle);
+
+			ResourceRegistration resourceRegistration =
+				new ResourceRegistration(
+					new ContextController.ServiceHolder<>(
+						new ResourceServlet(
+							resourcePrefix, servletContextHelper,
+							AccessController.getContext()),
+						bundle, resourceDTO.serviceId,
+						GetterUtil.getInteger(
+							serviceReference.getProperty(
+								Constants.SERVICE_RANKING))),
+					resourceDTO, servletContextHelper, liferayContextController,
+					null);
+
+			try {
+				resourceRegistration.init(
+					new ServletConfigImpl(
+						resourceRegistration.getName(), new HashMap<>(),
+						new ServletContextWrapper(
+							bundle, liferayContextController,
+							servletContextHelper,
+							servletContextHelperDataContext)));
+			}
+			catch (ServletException servletException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(servletException);
+				}
+
+				return null;
+			}
+
+			Set<EndpointRegistration<?>> endpointRegistrations =
+				liferayContextController.getEndpointRegistrations();
+
+			endpointRegistrations.add(resourceRegistration);
+
+			return resourceRegistration;
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(
@@ -64,5 +167,8 @@ public class ResourceServiceTrackerCustomizer
 
 		return null;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ResourceServiceTrackerCustomizer.class);
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ResourceServiceTrackerCustomizer.java
@@ -8,7 +8,6 @@ package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
 import org.eclipse.equinox.http.servlet.internal.registration.ResourceRegistration;
@@ -21,8 +20,7 @@ import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
  * @author Dante Wang
  */
 public class ResourceServiceTrackerCustomizer
-	extends BaseServiceTrackerCustomizer
-		<Object, AtomicReference<ResourceRegistration>> {
+	extends BaseServiceTrackerCustomizer<Object, ResourceRegistration> {
 
 	public ResourceServiceTrackerCustomizer(
 		BundleContext bundleContext,
@@ -35,7 +33,7 @@ public class ResourceServiceTrackerCustomizer
 	}
 
 	@Override
-	public AtomicReference<ResourceRegistration> addingService(
+	public ResourceRegistration addingService(
 		ServiceReference<Object> serviceReference) {
 
 		if (Objects.isNull(
@@ -55,44 +53,30 @@ public class ResourceServiceTrackerCustomizer
 			return null;
 		}
 
-		AtomicReference<ResourceRegistration> result = new AtomicReference<>();
-
 		try {
-			result.set(
-				liferayContextController.addResourceRegistration(
-					serviceReference));
+			return liferayContextController.addResourceRegistration(
+				serviceReference);
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(
 				exception.getMessage(), exception);
 		}
 
-		return result;
+		return null;
 	}
 
 	@Override
 	public void modifiedService(
 		ServiceReference<Object> serviceReference,
-		AtomicReference<ResourceRegistration> resourceReference) {
-
-		removedService(serviceReference, resourceReference);
-
-		AtomicReference<ResourceRegistration> added = addingService(
-			serviceReference);
-
-		resourceReference.set(added.get());
+		ResourceRegistration resourceRegistration) {
 	}
 
 	@Override
 	public void removedService(
 		ServiceReference<Object> serviceReference,
-		AtomicReference<ResourceRegistration> resourceReference) {
+		ResourceRegistration resourceRegistration) {
 
-		ResourceRegistration registration = resourceReference.get();
-
-		if (registration != null) {
-			registration.destroy();
-		}
+		resourceRegistration.destroy();
 	}
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.servlet.Servlet;
+
+import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
+import org.eclipse.equinox.http.servlet.internal.registration.ServletRegistration;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+
+/**
+ * @author Dante Wang
+ */
+public class ServletServiceTrackerCustomizer
+	extends BaseServiceTrackerCustomizer
+		<Servlet, AtomicReference<ServletRegistration>> {
+
+	public ServletServiceTrackerCustomizer(
+		BundleContext bundleContext,
+		HttpServletEndpointController httpServletEndpointController,
+		ContextController contextController) {
+
+		super(bundleContext, contextController, httpServletEndpointController);
+	}
+
+	@Override
+	public AtomicReference<ServletRegistration> addingService(
+		ServiceReference<Servlet> serviceReference) {
+
+		if (Objects.isNull(
+				serviceReference.getProperty(
+					HttpWhiteboardConstants.
+						HTTP_WHITEBOARD_SERVLET_ERROR_PAGE)) &&
+			Objects.isNull(
+				serviceReference.getProperty(
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME)) &&
+			Objects.isNull(
+				serviceReference.getProperty(
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN))) {
+
+			return null;
+		}
+
+		if (!contextController.matches(serviceReference) ||
+			!httpServletEndpointController.matches(serviceReference)) {
+
+			return null;
+		}
+
+		AtomicReference<ServletRegistration> result = new AtomicReference<>();
+
+		try {
+			result.set(
+				contextController.addServletRegistration(serviceReference));
+		}
+		catch (Exception exception) {
+			httpServletEndpointController.log(
+				exception.getMessage(), exception);
+		}
+
+		return result;
+	}
+
+	@Override
+	public void modifiedService(
+		ServiceReference<Servlet> serviceReference,
+		AtomicReference<ServletRegistration> servletReference) {
+
+		removedService(serviceReference, servletReference);
+
+		AtomicReference<ServletRegistration> added = addingService(
+			serviceReference);
+
+		servletReference.set(added.get());
+	}
+
+	@Override
+	public void removedService(
+		ServiceReference<Servlet> serviceReference,
+		AtomicReference<ServletRegistration> servletReference) {
+
+		ServletRegistration registration = servletReference.get();
+
+		if (registration != null) {
+			registration.destroy();
+		}
+	}
+
+}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
@@ -146,8 +146,7 @@ public class ServletServiceTrackerCustomizer
 			return servletRegistration;
 		}
 		catch (Exception exception) {
-			httpServletEndpointController.log(
-				exception.getMessage(), exception);
+			_log.error(exception);
 		}
 
 		return null;
@@ -251,6 +250,6 @@ public class ServletServiceTrackerCustomizer
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		ServletServiceTrackerCustomizer.class);
+		EventListenerServiceTrackerCustomizer.class.getName());
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
@@ -70,18 +70,4 @@ public class ServletServiceTrackerCustomizer
 		return null;
 	}
 
-	@Override
-	public void modifiedService(
-		ServiceReference<Servlet> serviceReference,
-		ServletRegistration servletRegistration) {
-	}
-
-	@Override
-	public void removedService(
-		ServiceReference<Servlet> serviceReference,
-		ServletRegistration servletRegistration) {
-
-		servletRegistration.destroy();
-	}
-
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
@@ -5,13 +5,14 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
+import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
+
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.Servlet;
 
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
-import org.eclipse.equinox.http.servlet.internal.context.ContextController;
 import org.eclipse.equinox.http.servlet.internal.registration.ServletRegistration;
 
 import org.osgi.framework.BundleContext;
@@ -28,9 +29,11 @@ public class ServletServiceTrackerCustomizer
 	public ServletServiceTrackerCustomizer(
 		BundleContext bundleContext,
 		HttpServletEndpointController httpServletEndpointController,
-		ContextController contextController) {
+		LiferayContextController liferayContextController) {
 
-		super(bundleContext, contextController, httpServletEndpointController);
+		super(
+			bundleContext, httpServletEndpointController,
+			liferayContextController);
 	}
 
 	@Override
@@ -51,7 +54,7 @@ public class ServletServiceTrackerCustomizer
 			return null;
 		}
 
-		if (!contextController.matches(serviceReference) ||
+		if (!liferayContextController.matches(serviceReference) ||
 			!httpServletEndpointController.matches(serviceReference)) {
 
 			return null;
@@ -61,7 +64,8 @@ public class ServletServiceTrackerCustomizer
 
 		try {
 			result.set(
-				contextController.addServletRegistration(serviceReference));
+				liferayContextController.addServletRegistration(
+					serviceReference));
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
@@ -8,7 +8,6 @@ package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.Servlet;
 
@@ -23,8 +22,7 @@ import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
  * @author Dante Wang
  */
 public class ServletServiceTrackerCustomizer
-	extends BaseServiceTrackerCustomizer
-		<Servlet, AtomicReference<ServletRegistration>> {
+	extends BaseServiceTrackerCustomizer<Servlet, ServletRegistration> {
 
 	public ServletServiceTrackerCustomizer(
 		BundleContext bundleContext,
@@ -37,7 +35,7 @@ public class ServletServiceTrackerCustomizer
 	}
 
 	@Override
-	public AtomicReference<ServletRegistration> addingService(
+	public ServletRegistration addingService(
 		ServiceReference<Servlet> serviceReference) {
 
 		if (Objects.isNull(
@@ -60,44 +58,30 @@ public class ServletServiceTrackerCustomizer
 			return null;
 		}
 
-		AtomicReference<ServletRegistration> result = new AtomicReference<>();
-
 		try {
-			result.set(
-				liferayContextController.addServletRegistration(
-					serviceReference));
+			return liferayContextController.addServletRegistration(
+				serviceReference);
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(
 				exception.getMessage(), exception);
 		}
 
-		return result;
+		return null;
 	}
 
 	@Override
 	public void modifiedService(
 		ServiceReference<Servlet> serviceReference,
-		AtomicReference<ServletRegistration> servletReference) {
-
-		removedService(serviceReference, servletReference);
-
-		AtomicReference<ServletRegistration> added = addingService(
-			serviceReference);
-
-		servletReference.set(added.get());
+		ServletRegistration servletRegistration) {
 	}
 
 	@Override
 	public void removedService(
 		ServiceReference<Servlet> serviceReference,
-		AtomicReference<ServletRegistration> servletReference) {
+		ServletRegistration servletRegistration) {
 
-		ServletRegistration registration = servletReference.get();
-
-		if (registration != null) {
-			registration.destroy();
-		}
+		servletRegistration.destroy();
 	}
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/context/customizer/ServletServiceTrackerCustomizer.java
@@ -5,17 +5,38 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.context.customizer;
 
+import com.liferay.osgi.util.StringPlus;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.osgi.web.http.servlet.internal.context.LiferayContextController;
+import com.liferay.portal.osgi.web.http.servlet.internal.servlet.ServletContextWrapper;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.servlet.Servlet;
 
 import org.eclipse.equinox.http.servlet.internal.HttpServletEndpointController;
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
+import org.eclipse.equinox.http.servlet.internal.context.ServletContextHelperDataContext;
+import org.eclipse.equinox.http.servlet.internal.registration.EndpointRegistration;
 import org.eclipse.equinox.http.servlet.internal.registration.ServletRegistration;
+import org.eclipse.equinox.http.servlet.internal.servlet.ServletConfigImpl;
+import org.eclipse.equinox.http.servlet.internal.util.ServiceProperties;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.http.context.ServletContextHelper;
+import org.osgi.service.http.runtime.dto.ErrorPageDTO;
+import org.osgi.service.http.runtime.dto.ServletDTO;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 
 /**
@@ -27,11 +48,14 @@ public class ServletServiceTrackerCustomizer
 	public ServletServiceTrackerCustomizer(
 		BundleContext bundleContext,
 		HttpServletEndpointController httpServletEndpointController,
-		LiferayContextController liferayContextController) {
+		LiferayContextController liferayContextController,
+		ServletContextHelperDataContext servletContextHelperDataContext,
+		long servletContextHelperServiceId) {
 
 		super(
 			bundleContext, httpServletEndpointController,
-			liferayContextController);
+			liferayContextController, servletContextHelperDataContext,
+			servletContextHelperServiceId);
 	}
 
 	@Override
@@ -59,8 +83,67 @@ public class ServletServiceTrackerCustomizer
 		}
 
 		try {
-			return liferayContextController.addServletRegistration(
-				serviceReference);
+			liferayContextController.checkShutdown();
+
+			ContextController.ServiceHolder<Servlet> serviceHolder =
+				new ContextController.ServiceHolder<>(
+					bundleContext.getServiceObjects(serviceReference));
+
+			Servlet servlet = serviceHolder.get();
+
+			ServletRegistration servletRegistration = null;
+
+			boolean addedRegisteredObject = false;
+
+			Set<Object> registeredObjects =
+				httpServletEndpointController.getRegisteredObjects();
+
+			try {
+				if (servlet == null) {
+					throw new IllegalArgumentException("Servlet is null");
+				}
+
+				addedRegisteredObject = registeredObjects.add(servlet);
+
+				if (addedRegisteredObject) {
+					ObjectValuePair<ServletDTO, ErrorPageDTO> objectValuePair =
+						_createServletDTOs(serviceReference, servlet);
+
+					ServletDTO servletDTO = objectValuePair.getKey();
+
+					ServletContextHelper servletContextHelper =
+						liferayContextController.getServletContextHelper(
+							serviceHolder.getBundle());
+
+					servletRegistration = new ServletRegistration(
+						serviceHolder, servletDTO, objectValuePair.getValue(),
+						servletContextHelper, liferayContextController, null);
+
+					servletRegistration.init(
+						new ServletConfigImpl(
+							servletDTO.name, servletDTO.initParams,
+							new ServletContextWrapper(
+								serviceHolder.getBundle(),
+								liferayContextController, servletContextHelper,
+								servletContextHelperDataContext)));
+
+					Set<EndpointRegistration<?>> endpointRegistrations =
+						liferayContextController.getEndpointRegistrations();
+
+					endpointRegistrations.add(servletRegistration);
+				}
+			}
+			finally {
+				if (servletRegistration == null) {
+					serviceHolder.release();
+
+					if (addedRegisteredObject) {
+						registeredObjects.remove(servlet);
+					}
+				}
+			}
+
+			return servletRegistration;
 		}
 		catch (Exception exception) {
 			httpServletEndpointController.log(
@@ -69,5 +152,105 @@ public class ServletServiceTrackerCustomizer
 
 		return null;
 	}
+
+	private ObjectValuePair<ServletDTO, ErrorPageDTO> _createServletDTOs(
+		ServiceReference<Servlet> serviceReference, Servlet servlet) {
+
+		String[] servletErrorPages = ArrayUtil.toStringArray(
+			StringPlus.asList(
+				serviceReference.getProperty(
+					HttpWhiteboardConstants.
+						HTTP_WHITEBOARD_SERVLET_ERROR_PAGE)));
+		String servletName = (String)serviceReference.getProperty(
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME);
+		String[] servletPatterns = ArrayUtil.toStringArray(
+			StringPlus.asList(
+				serviceReference.getProperty(
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN)));
+
+		if ((servletErrorPages.length == 0) && (servletName == null) &&
+			(servletPatterns.length == 0)) {
+
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"One of the service properties ",
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_ERROR_PAGE,
+					", ", HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME,
+					", and ",
+					HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN,
+					" must contain a value"));
+		}
+
+		for (String servletPattern : servletPatterns) {
+			ContextController.checkPattern(servletPattern);
+		}
+
+		ServletDTO servletDTO = new ServletDTO();
+
+		servletDTO.asyncSupported = ServiceProperties.parseBoolean(
+			serviceReference,
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_ASYNC_SUPPORTED);
+		servletDTO.initParams = ServiceProperties.parseInitParams(
+			serviceReference,
+			HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_INIT_PARAM_PREFIX);
+		servletDTO.name = ServiceProperties.parseName(servletName, servlet);
+		servletDTO.patterns = sort(servletPatterns);
+		servletDTO.serviceId = (long)serviceReference.getProperty(
+			Constants.SERVICE_ID);
+		servletDTO.servletContextId = servletContextHelperServiceId;
+		servletDTO.servletInfo = servlet.getServletInfo();
+
+		ErrorPageDTO errorPageDTO = null;
+
+		if (servletErrorPages.length > 0) {
+			errorPageDTO = new ErrorPageDTO();
+
+			errorPageDTO.asyncSupported = servletDTO.asyncSupported;
+
+			Set<Long> httpErrorCodes = new LinkedHashSet<>();
+
+			List<String> exceptionErrorPages = new ArrayList<>();
+
+			for (String servletErrorPage : servletErrorPages) {
+				try {
+					if (Objects.equals(servletErrorPage, "4xx")) {
+						for (long code = 400; code < 500; code++) {
+							httpErrorCodes.add(code);
+						}
+					}
+					else if (Objects.equals(servletErrorPage, "5xx")) {
+						for (long code = 500; code < 600; code++) {
+							httpErrorCodes.add(code);
+						}
+					}
+					else {
+						httpErrorCodes.add(Long.parseLong(servletErrorPage));
+					}
+				}
+				catch (NumberFormatException numberFormatException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(numberFormatException);
+					}
+
+					exceptionErrorPages.add(servletErrorPage);
+				}
+			}
+
+			errorPageDTO.errorCodes = TransformUtil.transformToLongArray(
+				httpErrorCodes, errorCode -> errorCode);
+			errorPageDTO.exceptions = exceptionErrorPages.toArray(
+				new String[0]);
+			errorPageDTO.initParams = servletDTO.initParams;
+			errorPageDTO.name = servletDTO.name;
+			errorPageDTO.serviceId = servletDTO.serviceId;
+			errorPageDTO.servletContextId = servletContextHelperServiceId;
+			errorPageDTO.servletInfo = servlet.getServletInfo();
+		}
+
+		return new ObjectValuePair<>(servletDTO, errorPageDTO);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ServletServiceTrackerCustomizer.class);
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/LiferayResponseStateHandler.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/LiferayResponseStateHandler.java
@@ -5,11 +5,34 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.servlet;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterChain;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequestEvent;
+import javax.servlet.ServletRequestListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
 import org.eclipse.equinox.http.servlet.internal.context.DispatchTargets;
+import org.eclipse.equinox.http.servlet.internal.registration.EndpointRegistration;
+import org.eclipse.equinox.http.servlet.internal.registration.FilterRegistration;
+import org.eclipse.equinox.http.servlet.internal.servlet.FilterChainImpl;
+import org.eclipse.equinox.http.servlet.internal.servlet.HttpServletRequestWrapperImpl;
+import org.eclipse.equinox.http.servlet.internal.servlet.HttpServletResponseWrapperImpl;
+import org.eclipse.equinox.http.servlet.internal.servlet.Match;
 import org.eclipse.equinox.http.servlet.internal.servlet.ResponseStateHandler;
+import org.eclipse.equinox.http.servlet.internal.util.EventListeners;
+
+import org.osgi.service.http.context.ServletContextHelper;
 
 /**
  * @author Dante Wang
@@ -22,6 +45,378 @@ public class LiferayResponseStateHandler extends ResponseStateHandler {
 		DispatchTargets dispatchTargets) {
 
 		super(httpServletRequest, httpServletResponse, dispatchTargets);
+
+		_httpServletRequest = httpServletRequest;
+		_httpServletResponse = httpServletResponse;
+		_dispatchTargets = dispatchTargets;
 	}
+
+	@Override
+	public void processRequest() throws IOException, ServletException {
+		ContextController contextController =
+			_dispatchTargets.getContextController();
+
+		EventListeners eventListeners = contextController.getEventListeners();
+
+		List<ServletRequestListener> servletRequestListeners =
+			eventListeners.get(ServletRequestListener.class);
+
+		EndpointRegistration<?> endpointRegistration =
+			_dispatchTargets.getServletRegistration();
+
+		endpointRegistration.addReference();
+
+		List<FilterRegistration> matchingFilterRegistrations =
+			_dispatchTargets.getMatchingFilterRegistrations();
+
+		for (FilterRegistration matchingFilterRegistration :
+				matchingFilterRegistrations) {
+
+			matchingFilterRegistration.addReference();
+		}
+
+		ServletRequestEvent servletRequestEvent = null;
+
+		try {
+			if ((_dispatchTargets.getDispatcherType() ==
+					DispatcherType.REQUEST) &&
+				!servletRequestListeners.isEmpty()) {
+
+				servletRequestEvent = new ServletRequestEvent(
+					endpointRegistration.getServletContext(),
+					_httpServletRequest);
+
+				for (ServletRequestListener servletRequestListener :
+						servletRequestListeners) {
+
+					servletRequestListener.requestInitialized(
+						servletRequestEvent);
+				}
+			}
+
+			ServletContextHelper servletContextHelper =
+				endpointRegistration.getServletContextHelper();
+
+			if (servletContextHelper.handleSecurity(
+					_httpServletRequest, _httpServletResponse)) {
+
+				if (matchingFilterRegistrations.isEmpty()) {
+					endpointRegistration.service(
+						_httpServletRequest, _httpServletResponse);
+				}
+				else {
+					Collections.sort(matchingFilterRegistrations);
+
+					FilterChain filterChain = new FilterChainImpl(
+						matchingFilterRegistrations, endpointRegistration,
+						_dispatchTargets.getDispatcherType());
+
+					filterChain.doFilter(
+						_httpServletRequest, _httpServletResponse);
+				}
+			}
+		}
+		catch (Exception exception) {
+			setException(exception);
+
+			if (_dispatchTargets.getDispatcherType() !=
+					DispatcherType.REQUEST) {
+
+				_throwException(exception);
+			}
+		}
+		finally {
+			endpointRegistration.removeReference();
+
+			for (FilterRegistration filterRegistration :
+					matchingFilterRegistrations) {
+
+				filterRegistration.removeReference();
+			}
+
+			if (_dispatchTargets.getDispatcherType() ==
+					DispatcherType.REQUEST) {
+
+				if (_exception != null) {
+					_handleException();
+				}
+				else {
+					_handleResponseCode();
+				}
+
+				for (ServletRequestListener servletRequestListener :
+						servletRequestListeners) {
+
+					servletRequestListener.requestDestroyed(
+						servletRequestEvent);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void setException(Exception exception) {
+		_exception = exception;
+	}
+
+	private void _handleException() throws IOException, ServletException {
+		if (!(_httpServletResponse instanceof HttpServletResponseWrapper)) {
+			throw new IllegalStateException("Response is not a wrapper");
+		}
+
+		HttpServletResponseWrapper httpServletResponseWrapper =
+			(HttpServletResponseWrapper)_httpServletResponse;
+
+		HttpServletResponseWrapperImpl httpServletResponseWrapperImpl = null;
+
+		while (true) {
+			if (httpServletResponseWrapper instanceof
+					HttpServletResponseWrapperImpl) {
+
+				httpServletResponseWrapperImpl =
+					(HttpServletResponseWrapperImpl)httpServletResponseWrapper;
+			}
+			else if (httpServletResponseWrapper.getResponse() instanceof
+						HttpServletResponseWrapper) {
+
+				httpServletResponseWrapper =
+					(HttpServletResponseWrapper)
+						httpServletResponseWrapper.getResponse();
+
+				continue;
+			}
+
+			break;
+		}
+
+		if (httpServletResponseWrapperImpl == null) {
+			throw new IllegalStateException("Can not locate response");
+		}
+
+		HttpServletResponse httpServletResponse =
+			(HttpServletResponse)httpServletResponseWrapperImpl.getResponse();
+
+		if (httpServletResponse.isCommitted()) {
+			_throwException(_exception);
+		}
+
+		ContextController contextController =
+			_dispatchTargets.getContextController();
+
+		Class<? extends Exception> clazz = _exception.getClass();
+
+		final String className = clazz.getName();
+
+		DispatchTargets errorDispatchTargets =
+			contextController.getDispatchTargets(
+				className, null, null, null, null, null, Match.EXACT);
+
+		if (errorDispatchTargets == null) {
+			_throwException(_exception);
+		}
+
+		HttpServletRequestWrapperImpl httpServletRequestWrapperImpl =
+			HttpServletRequestWrapperImpl.findHttpRuntimeRequest(
+				_httpServletRequest);
+
+		try {
+			errorDispatchTargets.setDispatcherType(DispatcherType.ERROR);
+
+			httpServletRequestWrapperImpl.push(errorDispatchTargets);
+
+			HttpServletRequest httpServletRequest =
+				new HttpServletRequestWrapper(_httpServletRequest) {
+
+					@Override
+					public Object getAttribute(String attributeName) {
+						if (getDispatcherType() == DispatcherType.ERROR) {
+							if (attributeName.equals(
+									RequestDispatcher.ERROR_EXCEPTION)) {
+
+								return _exception;
+							}
+							else if (attributeName.equals(
+										RequestDispatcher.
+											ERROR_EXCEPTION_TYPE)) {
+
+								return className;
+							}
+							else if (attributeName.equals(
+										RequestDispatcher.ERROR_MESSAGE)) {
+
+								return _exception.getMessage();
+							}
+							else if (attributeName.equals(
+										RequestDispatcher.ERROR_REQUEST_URI)) {
+
+								return _httpServletRequest.getRequestURI();
+							}
+							else if (attributeName.equals(
+										RequestDispatcher.ERROR_SERVLET_NAME)) {
+
+								return _dispatchTargets.getServletRegistration(
+								).getName();
+							}
+							else if (attributeName.equals(
+										RequestDispatcher.ERROR_STATUS_CODE)) {
+
+								return HttpServletResponse.
+									SC_INTERNAL_SERVER_ERROR;
+							}
+						}
+
+						return super.getAttribute(attributeName);
+					}
+
+					@Override
+					public DispatcherType getDispatcherType() {
+						return DispatcherType.ERROR;
+					}
+
+				};
+
+			httpServletResponseWrapperImpl = new HttpServletResponseWrapperImpl(
+				httpServletResponse);
+
+			ResponseStateHandler responseStateHandler =
+				new ResponseStateHandler(
+					httpServletRequest, httpServletResponseWrapperImpl,
+					errorDispatchTargets);
+
+			responseStateHandler.processRequest();
+
+			httpServletResponse.setStatus(
+				HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		}
+		finally {
+			httpServletRequestWrapperImpl.pop();
+		}
+	}
+
+	private void _handleResponseCode() throws IOException, ServletException {
+		if (!(_httpServletResponse instanceof HttpServletResponseWrapper)) {
+			throw new IllegalStateException("Response is not a wrapper");
+		}
+
+		HttpServletResponseWrapperImpl httpServletResponseWrapperImpl =
+			HttpServletResponseWrapperImpl.findHttpRuntimeResponse(
+				_httpServletResponse);
+
+		if (httpServletResponseWrapperImpl == null) {
+			throw new IllegalStateException("Can not locate response");
+		}
+
+		int status = httpServletResponseWrapperImpl.getInternalStatus();
+
+		if ((status < HttpServletResponse.SC_BAD_REQUEST) || (status == -1)) {
+			return;
+		}
+
+		HttpServletResponse httpServletResponse =
+			(HttpServletResponse)httpServletResponseWrapperImpl.getResponse();
+
+		if (httpServletResponse.isCommitted()) {
+			return;
+		}
+
+		ContextController contextController =
+			_dispatchTargets.getContextController();
+
+		DispatchTargets errorDispatchTargets =
+			contextController.getDispatchTargets(
+				String.valueOf(status), null, null, null, null, null,
+				Match.EXACT);
+
+		if (errorDispatchTargets == null) {
+			httpServletResponse.sendError(
+				status, httpServletResponseWrapperImpl.getMessage());
+
+			return;
+		}
+
+		HttpServletRequestWrapperImpl httpServletRequestWrapperImpl =
+			HttpServletRequestWrapperImpl.findHttpRuntimeRequest(
+				_httpServletRequest);
+
+		try {
+			errorDispatchTargets.setDispatcherType(DispatcherType.ERROR);
+
+			httpServletRequestWrapperImpl.push(errorDispatchTargets);
+
+			HttpServletRequest httpServletRequest =
+				new HttpServletRequestWrapper(_httpServletRequest) {
+
+					@Override
+					public Object getAttribute(String attributeName) {
+						if (getDispatcherType() == DispatcherType.ERROR) {
+							if (attributeName.equals(
+									RequestDispatcher.ERROR_MESSAGE)) {
+
+								return httpServletResponseWrapperImpl.
+									getMessage();
+							}
+							else if (attributeName.equals(
+										RequestDispatcher.ERROR_REQUEST_URI)) {
+
+								return _httpServletRequest.getRequestURI();
+							}
+							else if (attributeName.equals(
+										RequestDispatcher.ERROR_SERVLET_NAME)) {
+
+								return _dispatchTargets.getServletRegistration(
+								).getName();
+							}
+							else if (attributeName.equals(
+										RequestDispatcher.ERROR_STATUS_CODE)) {
+
+								return status;
+							}
+						}
+
+						return super.getAttribute(attributeName);
+					}
+
+					@Override
+					public DispatcherType getDispatcherType() {
+						return DispatcherType.ERROR;
+					}
+
+				};
+
+			HttpServletResponseWrapper httpServletResponseWrapper =
+				new HttpServletResponseWrapperImpl(httpServletResponse);
+
+			ResponseStateHandler responseStateHandler =
+				new ResponseStateHandler(
+					httpServletRequest, httpServletResponseWrapper,
+					errorDispatchTargets);
+
+			httpServletResponse.setStatus(status);
+
+			responseStateHandler.processRequest();
+		}
+		finally {
+			httpServletRequestWrapperImpl.pop();
+		}
+	}
+
+	private void _throwException(Exception exception)
+		throws IOException, ServletException {
+
+		if (exception instanceof RuntimeException) {
+			throw (RuntimeException)exception;
+		}
+		else if (exception instanceof IOException) {
+			throw (IOException)exception;
+		}
+		else if (exception instanceof ServletException) {
+			throw (ServletException)exception;
+		}
+	}
+
+	private final DispatchTargets _dispatchTargets;
+	private Exception _exception;
+	private final HttpServletRequest _httpServletRequest;
+	private final HttpServletResponse _httpServletResponse;
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/LiferayResponseStateHandler.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/LiferayResponseStateHandler.java
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.osgi.web.http.servlet.internal.servlet;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.equinox.http.servlet.internal.context.DispatchTargets;
+import org.eclipse.equinox.http.servlet.internal.servlet.ResponseStateHandler;
+
+/**
+ * @author Dante Wang
+ */
+public class LiferayResponseStateHandler extends ResponseStateHandler {
+
+	public LiferayResponseStateHandler(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse,
+		DispatchTargets dispatchTargets) {
+
+		super(httpServletRequest, httpServletResponse, dispatchTargets);
+	}
+
+}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/LiferayResponseStateHandler.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/LiferayResponseStateHandler.java
@@ -205,11 +205,9 @@ public class LiferayResponseStateHandler extends ResponseStateHandler {
 
 		Class<? extends Exception> clazz = _exception.getClass();
 
-		final String className = clazz.getName();
-
 		DispatchTargets errorDispatchTargets =
 			contextController.getDispatchTargets(
-				className, null, null, null, null, null, Match.EXACT);
+				clazz.getName(), null, null, null, null, null, Match.EXACT);
 
 		if (errorDispatchTargets == null) {
 			_throwException(_exception);
@@ -239,7 +237,7 @@ public class LiferayResponseStateHandler extends ResponseStateHandler {
 										RequestDispatcher.
 											ERROR_EXCEPTION_TYPE)) {
 
-								return className;
+								return clazz.getName();
 							}
 							else if (attributeName.equals(
 										RequestDispatcher.ERROR_MESSAGE)) {
@@ -275,15 +273,13 @@ public class LiferayResponseStateHandler extends ResponseStateHandler {
 
 				};
 
-			httpServletResponseWrapperImpl = new HttpServletResponseWrapperImpl(
-				httpServletResponse);
-
-			ResponseStateHandler responseStateHandler =
-				new ResponseStateHandler(
-					httpServletRequest, httpServletResponseWrapperImpl,
+			LiferayResponseStateHandler liferayResponseStateHandler =
+				new LiferayResponseStateHandler(
+					httpServletRequest,
+					new HttpServletResponseWrapperImpl(httpServletResponse),
 					errorDispatchTargets);
 
-			responseStateHandler.processRequest();
+			liferayResponseStateHandler.processRequest();
 
 			httpServletResponse.setStatus(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -383,17 +379,15 @@ public class LiferayResponseStateHandler extends ResponseStateHandler {
 
 				};
 
-			HttpServletResponseWrapper httpServletResponseWrapper =
-				new HttpServletResponseWrapperImpl(httpServletResponse);
-
-			ResponseStateHandler responseStateHandler =
-				new ResponseStateHandler(
-					httpServletRequest, httpServletResponseWrapper,
+			LiferayResponseStateHandler liferayResponseStateHandler =
+				new LiferayResponseStateHandler(
+					httpServletRequest,
+					new HttpServletResponseWrapperImpl(httpServletResponse),
 					errorDispatchTargets);
 
 			httpServletResponse.setStatus(status);
 
-			responseStateHandler.processRequest();
+			liferayResponseStateHandler.processRequest();
 		}
 		finally {
 			httpServletRequestWrapperImpl.pop();

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/ServletContextWrapper.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/ServletContextWrapper.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/ServletContextWrapper.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/ServletContextWrapper.java
@@ -24,6 +24,7 @@ import java.util.EventListener;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterRegistration;
@@ -480,26 +481,10 @@ public class ServletContextWrapper implements ServletContext {
 		Dictionary<String, Object> attributes =
 			_servletContextHelperDataContext.getContextAttributes();
 
-		Object attributeValue = attributes.remove(name);
+		Object value = attributes.remove(name);
 
-		EventListeners eventListeners = _contextController.getEventListeners();
-
-		List<ServletContextAttributeListener> servletContextAttributeListeners =
-			eventListeners.get(ServletContextAttributeListener.class);
-
-		if (servletContextAttributeListeners.isEmpty()) {
-			return;
-		}
-
-		ServletContextAttributeEvent servletContextAttributeEvent =
-			new ServletContextAttributeEvent(this, name, attributeValue);
-
-		for (ServletContextAttributeListener servletContextAttributeListener :
-				servletContextAttributeListeners) {
-
-			servletContextAttributeListener.attributeRemoved(
-				servletContextAttributeEvent);
-		}
+		_fireServletContextAttributeEvent(
+			name, value, ServletContextAttributeListener::attributeRemoved);
 	}
 
 	@Override
@@ -513,13 +498,36 @@ public class ServletContextWrapper implements ServletContext {
 		Dictionary<String, Object> attributes =
 			_servletContextHelperDataContext.getContextAttributes();
 
-		boolean added = false;
+		Object oldValue = attributes.put(name, value);
 
-		if (attributes.get(name) == null) {
-			added = true;
+		if (oldValue == null) {
+			_fireServletContextAttributeEvent(
+				name, value, ServletContextAttributeListener::attributeAdded);
 		}
+		else {
+			_fireServletContextAttributeEvent(
+				name, value,
+				ServletContextAttributeListener::attributeReplaced);
+		}
+	}
 
-		attributes.put(name, value);
+	@Override
+	public boolean setInitParameter(String name, String value) {
+		return _servletContext.setInitParameter(name, value);
+	}
+
+	@Override
+	public void setSessionTrackingModes(
+		Set<SessionTrackingMode> sessionTrackingModes) {
+
+		_servletContext.setSessionTrackingModes(sessionTrackingModes);
+	}
+
+	private void _fireServletContextAttributeEvent(
+		String name, Object value,
+		BiConsumer
+			<ServletContextAttributeListener, ServletContextAttributeEvent>
+				biConsumer) {
 
 		EventListeners eventListeners = _contextController.getEventListeners();
 
@@ -536,27 +544,9 @@ public class ServletContextWrapper implements ServletContext {
 		for (ServletContextAttributeListener servletContextAttributeListener :
 				servletContextAttributeListeners) {
 
-			if (added) {
-				servletContextAttributeListener.attributeAdded(
-					servletContextAttributeEvent);
-			}
-			else {
-				servletContextAttributeListener.attributeReplaced(
-					servletContextAttributeEvent);
-			}
+			biConsumer.accept(
+				servletContextAttributeListener, servletContextAttributeEvent);
 		}
-	}
-
-	@Override
-	public boolean setInitParameter(String name, String value) {
-		return _servletContext.setInitParameter(name, value);
-	}
-
-	@Override
-	public void setSessionTrackingModes(
-		Set<SessionTrackingMode> sessionTrackingModes) {
-
-		_servletContext.setSessionTrackingModes(sessionTrackingModes);
 	}
 
 	private final AccessControlContext _accessControlContext;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/ServletContextWrapper.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/ServletContextWrapper.java
@@ -5,14 +5,23 @@
 
 package com.liferay.portal.osgi.web.http.servlet.internal.servlet;
 
+import com.liferay.petra.string.StringPool;
+
+import java.io.IOException;
 import java.io.InputStream;
 
 import java.net.URL;
 
 import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 
+import java.util.Collections;
+import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.EventListener;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -21,6 +30,8 @@ import javax.servlet.FilterRegistration;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
+import javax.servlet.ServletContextAttributeEvent;
+import javax.servlet.ServletContextAttributeListener;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration;
 import javax.servlet.SessionCookieConfig;
@@ -28,10 +39,14 @@ import javax.servlet.SessionTrackingMode;
 import javax.servlet.descriptor.JspConfigDescriptor;
 
 import org.eclipse.equinox.http.servlet.internal.context.ContextController;
+import org.eclipse.equinox.http.servlet.internal.context.DispatchTargets;
 import org.eclipse.equinox.http.servlet.internal.context.ServletContextHelperDataContext;
-import org.eclipse.equinox.http.servlet.internal.servlet.ServletContextAdaptor;
+import org.eclipse.equinox.http.servlet.internal.servlet.Match;
+import org.eclipse.equinox.http.servlet.internal.servlet.RequestDispatcherAdaptor;
+import org.eclipse.equinox.http.servlet.internal.util.EventListeners;
 
 import org.osgi.framework.Bundle;
+import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.service.http.context.ServletContextHelper;
 
 /**
@@ -45,10 +60,16 @@ public class ServletContextWrapper implements ServletContext {
 		ServletContextHelperDataContext servletContextHelperDataContext,
 		AccessControlContext accessControlContext) {
 
-		_servletContextAdaptor = new ServletContextAdaptor(
-			contextController, bundle, servletContextHelper,
-			servletContextHelperDataContext,
-			contextController.getEventListeners(), accessControlContext);
+		_bundle = bundle;
+
+		BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
+
+		_classLoader = bundleWiring.getClassLoader();
+
+		_contextController = contextController;
+		_servletContextHelper = servletContextHelper;
+		_servletContextHelperDataContext = servletContextHelperDataContext;
+		_accessControlContext = accessControlContext;
 
 		_servletContext = servletContextHelperDataContext.getServletContext();
 	}
@@ -57,110 +78,115 @@ public class ServletContextWrapper implements ServletContext {
 	public FilterRegistration.Dynamic addFilter(
 		String filterName, Class<? extends Filter> filterClass) {
 
-		_servletContextAdaptor.addFilter(filterName, filterClass);
-
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public FilterRegistration.Dynamic addFilter(
 		String filterName, Filter filter) {
 
-		_servletContextAdaptor.addFilter(filterName, filter);
-
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public FilterRegistration.Dynamic addFilter(
 		String filterName, String className) {
 
-		_servletContextAdaptor.addFilter(filterName, className);
-
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void addListener(Class<? extends EventListener> listenerClass) {
-		_servletContextAdaptor.addListener(listenerClass);
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void addListener(String className) {
-		_servletContextAdaptor.addListener(className);
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public <T extends EventListener> void addListener(T t) {
-		_servletContextAdaptor.addListener(t);
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public ServletRegistration.Dynamic addServlet(
 		String servletName, Class<? extends Servlet> servletClass) {
 
-		_servletContextAdaptor.addServlet(servletName, servletClass);
-
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public ServletRegistration.Dynamic addServlet(
 		String servletName, Servlet servlet) {
 
-		_servletContextAdaptor.addServlet(servletName, servlet);
-
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public ServletRegistration.Dynamic addServlet(
 		String servletName, String className) {
 
-		_servletContextAdaptor.addServlet(servletName, className);
-
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public <T extends Filter> T createFilter(Class<T> filterClass) {
-		_servletContextAdaptor.createFilter(filterClass);
-
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public <T extends EventListener> T createListener(Class<T> listenerClass) {
-		_servletContextAdaptor.createListener(listenerClass);
-
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public <T extends Servlet> T createServlet(Class<T> servletClass) {
-		_servletContextAdaptor.createServlet(servletClass);
-
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void declareRoles(String... roleNames) {
-		_servletContextAdaptor.declareRoles(roleNames);
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (!(other instanceof ServletContextWrapper)) {
+			return false;
+		}
+
+		ServletContextWrapper otherServletContextWrapper =
+			(ServletContextWrapper)other;
+
+		return _contextController.equals(
+			otherServletContextWrapper._contextController);
 	}
 
 	@Override
 	public Object getAttribute(String name) {
-		return _servletContextAdaptor.getAttribute(name);
+		if (name.equals("osgi-bundlecontext")) {
+			return _bundle.getBundleContext();
+		}
+
+		Dictionary<String, Object> attributes =
+			_servletContextHelperDataContext.getContextAttributes();
+
+		return attributes.get(name);
 	}
 
 	@Override
 	public Enumeration<String> getAttributeNames() {
-		return _servletContextAdaptor.getAttributeNames();
+		Dictionary<String, Object> attributes =
+			_servletContextHelperDataContext.getContextAttributes();
+
+		return attributes.keys();
 	}
 
 	@Override
 	public ClassLoader getClassLoader() {
-		return _servletContextAdaptor.getClassLoader();
+		return _classLoader;
 	}
 
 	@Override
@@ -170,7 +196,7 @@ public class ServletContextWrapper implements ServletContext {
 
 	@Override
 	public String getContextPath() {
-		return _servletContextAdaptor.getContextPath();
+		return _contextController.getFullContextPath();
 	}
 
 	@Override
@@ -205,12 +231,16 @@ public class ServletContextWrapper implements ServletContext {
 
 	@Override
 	public String getInitParameter(String name) {
-		return _servletContextAdaptor.getInitParameter(name);
+		Map<String, String> initParams = _contextController.getInitParams();
+
+		return initParams.get(name);
 	}
 
 	@Override
 	public Enumeration<String> getInitParameterNames() {
-		return _servletContextAdaptor.getInitParameterNames();
+		Map<String, String> initParams = _contextController.getInitParams();
+
+		return Collections.enumeration(initParams.keySet());
 	}
 
 	@Override
@@ -225,7 +255,25 @@ public class ServletContextWrapper implements ServletContext {
 
 	@Override
 	public String getMimeType(String file) {
-		return _servletContextAdaptor.getMimeType(file);
+		String mimeType = null;
+
+		try {
+			mimeType = AccessController.doPrivileged(
+				(PrivilegedExceptionAction<String>)
+					() -> _servletContextHelper.getMimeType(file),
+				_accessControlContext);
+		}
+		catch (PrivilegedActionException privilegedActionException) {
+			Exception exception = privilegedActionException.getException();
+
+			_servletContext.log(exception.getMessage(), exception);
+		}
+
+		if (mimeType != null) {
+			return mimeType;
+		}
+
+		return _servletContext.getMimeType(file);
 	}
 
 	@Override
@@ -235,32 +283,112 @@ public class ServletContextWrapper implements ServletContext {
 
 	@Override
 	public RequestDispatcher getNamedDispatcher(String servletName) {
-		return _servletContextAdaptor.getNamedDispatcher(servletName);
+		DispatchTargets dispatchTargets = _contextController.getDispatchTargets(
+			servletName, null, null, null, null, null, Match.EXACT);
+
+		if (dispatchTargets == null) {
+			return null;
+		}
+
+		return new RequestDispatcherAdaptor(dispatchTargets, servletName);
 	}
 
 	@Override
 	public String getRealPath(String path) {
-		return _servletContextAdaptor.getRealPath(path);
+		try {
+			return AccessController.doPrivileged(
+				(PrivilegedExceptionAction<String>)
+					() -> _servletContextHelper.getRealPath(path),
+				_accessControlContext);
+		}
+		catch (PrivilegedActionException privilegedActionException) {
+			_servletContext.log(
+				privilegedActionException.getException(
+				).getMessage(),
+				privilegedActionException.getException());
+		}
+
+		return null;
 	}
 
 	@Override
 	public RequestDispatcher getRequestDispatcher(String path) {
-		return _servletContextAdaptor.getRequestDispatcher(path);
+		if (!path.startsWith(StringPool.SLASH)) {
+			return null;
+		}
+
+		String fullContextPath = _contextController.getFullContextPath();
+
+		if (path.startsWith(fullContextPath)) {
+			path = path.substring(fullContextPath.length());
+		}
+
+		DispatchTargets dispatchTargets = _contextController.getDispatchTargets(
+			path);
+
+		if (dispatchTargets == null) {
+			return null;
+		}
+
+		return new RequestDispatcherAdaptor(dispatchTargets, path);
 	}
 
 	@Override
 	public URL getResource(String path) {
-		return _servletContextAdaptor.getResource(path);
+		try {
+			return AccessController.doPrivileged(
+				(PrivilegedExceptionAction<URL>)
+					() -> _servletContextHelper.getResource(path),
+				_accessControlContext);
+		}
+		catch (PrivilegedActionException privilegedActionException) {
+			_servletContext.log(
+				privilegedActionException.getException(
+				).getMessage(),
+				privilegedActionException.getException());
+		}
+
+		return null;
 	}
 
 	@Override
 	public InputStream getResourceAsStream(String path) {
-		return _servletContextAdaptor.getResourceAsStream(path);
+		URL url = getResource(path);
+
+		if (url == null) {
+			return null;
+		}
+
+		try {
+			return url.openStream();
+		}
+		catch (IOException ioException) {
+			_servletContext.log(ioException.getMessage(), ioException);
+		}
+
+		return null;
 	}
 
 	@Override
 	public Set<String> getResourcePaths(String path) {
-		return _servletContextAdaptor.getResourcePaths(path);
+		if ((path == null) || !path.startsWith(StringPool.SLASH)) {
+			return null;
+		}
+
+		try {
+			return AccessController.doPrivileged(
+				(PrivilegedExceptionAction<Set<String>>)
+					() -> _servletContextHelper.getResourcePaths(path),
+				_accessControlContext);
+		}
+		catch (PrivilegedActionException privilegedActionException) {
+			_servletContext.log(
+				privilegedActionException.getException(
+				).getMessage(),
+				privilegedActionException.getException());
+		}
+
+		return null;
 	}
 
 	@Override
@@ -279,7 +407,7 @@ public class ServletContextWrapper implements ServletContext {
 
 	@Override
 	public String getServletContextName() {
-		return _servletContextAdaptor.getServletContextName();
+		return _contextController.getContextName();
 	}
 
 	/**
@@ -322,6 +450,11 @@ public class ServletContextWrapper implements ServletContext {
 		return _servletContext.getVirtualServerName();
 	}
 
+	@Override
+	public int hashCode() {
+		return _contextController.hashCode();
+	}
+
 	/**
 	 * @deprecated As of Cavanaugh (7.4.x), Servlet API 2.1, replaced by
 	 * 			{@link #log(String message, Throwable throwable)}
@@ -344,12 +477,74 @@ public class ServletContextWrapper implements ServletContext {
 
 	@Override
 	public void removeAttribute(String name) {
-		_servletContextAdaptor.removeAttribute(name);
+		Dictionary<String, Object> attributes =
+			_servletContextHelperDataContext.getContextAttributes();
+
+		Object attributeValue = attributes.remove(name);
+
+		EventListeners eventListeners = _contextController.getEventListeners();
+
+		List<ServletContextAttributeListener> servletContextAttributeListeners =
+			eventListeners.get(ServletContextAttributeListener.class);
+
+		if (servletContextAttributeListeners.isEmpty()) {
+			return;
+		}
+
+		ServletContextAttributeEvent servletContextAttributeEvent =
+			new ServletContextAttributeEvent(this, name, attributeValue);
+
+		for (ServletContextAttributeListener servletContextAttributeListener :
+				servletContextAttributeListeners) {
+
+			servletContextAttributeListener.attributeRemoved(
+				servletContextAttributeEvent);
+		}
 	}
 
 	@Override
 	public void setAttribute(String name, Object value) {
-		_servletContextAdaptor.setAttribute(name, value);
+		if (value == null) {
+			removeAttribute(name);
+
+			return;
+		}
+
+		Dictionary<String, Object> attributes =
+			_servletContextHelperDataContext.getContextAttributes();
+
+		boolean added = false;
+
+		if (attributes.get(name) == null) {
+			added = true;
+		}
+
+		attributes.put(name, value);
+
+		EventListeners eventListeners = _contextController.getEventListeners();
+
+		List<ServletContextAttributeListener> servletContextAttributeListeners =
+			eventListeners.get(ServletContextAttributeListener.class);
+
+		if (servletContextAttributeListeners.isEmpty()) {
+			return;
+		}
+
+		ServletContextAttributeEvent servletContextAttributeEvent =
+			new ServletContextAttributeEvent(this, name, value);
+
+		for (ServletContextAttributeListener servletContextAttributeListener :
+				servletContextAttributeListeners) {
+
+			if (added) {
+				servletContextAttributeListener.attributeAdded(
+					servletContextAttributeEvent);
+			}
+			else {
+				servletContextAttributeListener.attributeReplaced(
+					servletContextAttributeEvent);
+			}
+		}
 	}
 
 	@Override
@@ -364,7 +559,13 @@ public class ServletContextWrapper implements ServletContext {
 		_servletContext.setSessionTrackingModes(sessionTrackingModes);
 	}
 
+	private final AccessControlContext _accessControlContext;
+	private final Bundle _bundle;
+	private final ClassLoader _classLoader;
+	private final ContextController _contextController;
 	private final ServletContext _servletContext;
-	private final ServletContextAdaptor _servletContextAdaptor;
+	private final ServletContextHelper _servletContextHelper;
+	private final ServletContextHelperDataContext
+		_servletContextHelperDataContext;
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/ServletContextWrapper.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/ServletContextWrapper.java
@@ -12,11 +12,6 @@ import java.io.InputStream;
 
 import java.net.URL;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Enumeration;
@@ -58,8 +53,7 @@ public class ServletContextWrapper implements ServletContext {
 	public ServletContextWrapper(
 		Bundle bundle, ContextController contextController,
 		ServletContextHelper servletContextHelper,
-		ServletContextHelperDataContext servletContextHelperDataContext,
-		AccessControlContext accessControlContext) {
+		ServletContextHelperDataContext servletContextHelperDataContext) {
 
 		_bundle = bundle;
 
@@ -70,7 +64,6 @@ public class ServletContextWrapper implements ServletContext {
 		_contextController = contextController;
 		_servletContextHelper = servletContextHelper;
 		_servletContextHelperDataContext = servletContextHelperDataContext;
-		_accessControlContext = accessControlContext;
 
 		_servletContext = servletContextHelperDataContext.getServletContext();
 	}
@@ -256,19 +249,7 @@ public class ServletContextWrapper implements ServletContext {
 
 	@Override
 	public String getMimeType(String file) {
-		String mimeType = null;
-
-		try {
-			mimeType = AccessController.doPrivileged(
-				(PrivilegedExceptionAction<String>)
-					() -> _servletContextHelper.getMimeType(file),
-				_accessControlContext);
-		}
-		catch (PrivilegedActionException privilegedActionException) {
-			Exception exception = privilegedActionException.getException();
-
-			_servletContext.log(exception.getMessage(), exception);
-		}
+		String mimeType = _servletContextHelper.getMimeType(file);
 
 		if (mimeType != null) {
 			return mimeType;
@@ -296,20 +277,7 @@ public class ServletContextWrapper implements ServletContext {
 
 	@Override
 	public String getRealPath(String path) {
-		try {
-			return AccessController.doPrivileged(
-				(PrivilegedExceptionAction<String>)
-					() -> _servletContextHelper.getRealPath(path),
-				_accessControlContext);
-		}
-		catch (PrivilegedActionException privilegedActionException) {
-			_servletContext.log(
-				privilegedActionException.getException(
-				).getMessage(),
-				privilegedActionException.getException());
-		}
-
-		return null;
+		return _servletContextHelper.getRealPath(path);
 	}
 
 	@Override
@@ -336,20 +304,7 @@ public class ServletContextWrapper implements ServletContext {
 
 	@Override
 	public URL getResource(String path) {
-		try {
-			return AccessController.doPrivileged(
-				(PrivilegedExceptionAction<URL>)
-					() -> _servletContextHelper.getResource(path),
-				_accessControlContext);
-		}
-		catch (PrivilegedActionException privilegedActionException) {
-			_servletContext.log(
-				privilegedActionException.getException(
-				).getMessage(),
-				privilegedActionException.getException());
-		}
-
-		return null;
+		return _servletContextHelper.getResource(path);
 	}
 
 	@Override
@@ -376,20 +331,7 @@ public class ServletContextWrapper implements ServletContext {
 			return null;
 		}
 
-		try {
-			return AccessController.doPrivileged(
-				(PrivilegedExceptionAction<Set<String>>)
-					() -> _servletContextHelper.getResourcePaths(path),
-				_accessControlContext);
-		}
-		catch (PrivilegedActionException privilegedActionException) {
-			_servletContext.log(
-				privilegedActionException.getException(
-				).getMessage(),
-				privilegedActionException.getException());
-		}
-
-		return null;
+		return _servletContextHelper.getResourcePaths(path);
 	}
 
 	@Override
@@ -549,7 +491,6 @@ public class ServletContextWrapper implements ServletContext {
 		}
 	}
 
-	private final AccessControlContext _accessControlContext;
 	private final Bundle _bundle;
 	private final ClassLoader _classLoader;
 	private final ContextController _contextController;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/ServletContextWrapper.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-http-servlet-impl/src/main/java/com/liferay/portal/osgi/web/http/servlet/internal/servlet/ServletContextWrapper.java
@@ -1,0 +1,370 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.osgi.web.http.servlet.internal.servlet;
+
+import java.io.InputStream;
+
+import java.net.URL;
+
+import java.security.AccessControlContext;
+
+import java.util.Enumeration;
+import java.util.EventListener;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterRegistration;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.Servlet;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
+import javax.servlet.SessionCookieConfig;
+import javax.servlet.SessionTrackingMode;
+import javax.servlet.descriptor.JspConfigDescriptor;
+
+import org.eclipse.equinox.http.servlet.internal.context.ContextController;
+import org.eclipse.equinox.http.servlet.internal.context.ServletContextHelperDataContext;
+import org.eclipse.equinox.http.servlet.internal.servlet.ServletContextAdaptor;
+
+import org.osgi.framework.Bundle;
+import org.osgi.service.http.context.ServletContextHelper;
+
+/**
+ * @author Dante Wang
+ */
+public class ServletContextWrapper implements ServletContext {
+
+	public ServletContextWrapper(
+		Bundle bundle, ContextController contextController,
+		ServletContextHelper servletContextHelper,
+		ServletContextHelperDataContext servletContextHelperDataContext,
+		AccessControlContext accessControlContext) {
+
+		_servletContextAdaptor = new ServletContextAdaptor(
+			contextController, bundle, servletContextHelper,
+			servletContextHelperDataContext,
+			contextController.getEventListeners(), accessControlContext);
+
+		_servletContext = servletContextHelperDataContext.getServletContext();
+	}
+
+	@Override
+	public FilterRegistration.Dynamic addFilter(
+		String filterName, Class<? extends Filter> filterClass) {
+
+		_servletContextAdaptor.addFilter(filterName, filterClass);
+
+		return null;
+	}
+
+	@Override
+	public FilterRegistration.Dynamic addFilter(
+		String filterName, Filter filter) {
+
+		_servletContextAdaptor.addFilter(filterName, filter);
+
+		return null;
+	}
+
+	@Override
+	public FilterRegistration.Dynamic addFilter(
+		String filterName, String className) {
+
+		_servletContextAdaptor.addFilter(filterName, className);
+
+		return null;
+	}
+
+	@Override
+	public void addListener(Class<? extends EventListener> listenerClass) {
+		_servletContextAdaptor.addListener(listenerClass);
+	}
+
+	@Override
+	public void addListener(String className) {
+		_servletContextAdaptor.addListener(className);
+	}
+
+	@Override
+	public <T extends EventListener> void addListener(T t) {
+		_servletContextAdaptor.addListener(t);
+	}
+
+	@Override
+	public ServletRegistration.Dynamic addServlet(
+		String servletName, Class<? extends Servlet> servletClass) {
+
+		_servletContextAdaptor.addServlet(servletName, servletClass);
+
+		return null;
+	}
+
+	@Override
+	public ServletRegistration.Dynamic addServlet(
+		String servletName, Servlet servlet) {
+
+		_servletContextAdaptor.addServlet(servletName, servlet);
+
+		return null;
+	}
+
+	@Override
+	public ServletRegistration.Dynamic addServlet(
+		String servletName, String className) {
+
+		_servletContextAdaptor.addServlet(servletName, className);
+
+		return null;
+	}
+
+	@Override
+	public <T extends Filter> T createFilter(Class<T> filterClass) {
+		_servletContextAdaptor.createFilter(filterClass);
+
+		return null;
+	}
+
+	@Override
+	public <T extends EventListener> T createListener(Class<T> listenerClass) {
+		_servletContextAdaptor.createListener(listenerClass);
+
+		return null;
+	}
+
+	@Override
+	public <T extends Servlet> T createServlet(Class<T> servletClass) {
+		_servletContextAdaptor.createServlet(servletClass);
+
+		return null;
+	}
+
+	@Override
+	public void declareRoles(String... roleNames) {
+		_servletContextAdaptor.declareRoles(roleNames);
+	}
+
+	@Override
+	public Object getAttribute(String name) {
+		return _servletContextAdaptor.getAttribute(name);
+	}
+
+	@Override
+	public Enumeration<String> getAttributeNames() {
+		return _servletContextAdaptor.getAttributeNames();
+	}
+
+	@Override
+	public ClassLoader getClassLoader() {
+		return _servletContextAdaptor.getClassLoader();
+	}
+
+	@Override
+	public ServletContext getContext(String path) {
+		return _servletContext.getContext(path);
+	}
+
+	@Override
+	public String getContextPath() {
+		return _servletContextAdaptor.getContextPath();
+	}
+
+	@Override
+	public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
+		return _servletContext.getDefaultSessionTrackingModes();
+	}
+
+	@Override
+	public int getEffectiveMajorVersion() {
+		return _servletContext.getEffectiveMajorVersion();
+	}
+
+	@Override
+	public int getEffectiveMinorVersion() {
+		return _servletContext.getEffectiveMinorVersion();
+	}
+
+	@Override
+	public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
+		return _servletContext.getEffectiveSessionTrackingModes();
+	}
+
+	@Override
+	public FilterRegistration getFilterRegistration(String filterName) {
+		return _servletContext.getFilterRegistration(filterName);
+	}
+
+	@Override
+	public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
+		return _servletContext.getFilterRegistrations();
+	}
+
+	@Override
+	public String getInitParameter(String name) {
+		return _servletContextAdaptor.getInitParameter(name);
+	}
+
+	@Override
+	public Enumeration<String> getInitParameterNames() {
+		return _servletContextAdaptor.getInitParameterNames();
+	}
+
+	@Override
+	public JspConfigDescriptor getJspConfigDescriptor() {
+		return _servletContext.getJspConfigDescriptor();
+	}
+
+	@Override
+	public int getMajorVersion() {
+		return _servletContext.getMajorVersion();
+	}
+
+	@Override
+	public String getMimeType(String file) {
+		return _servletContextAdaptor.getMimeType(file);
+	}
+
+	@Override
+	public int getMinorVersion() {
+		return _servletContext.getMinorVersion();
+	}
+
+	@Override
+	public RequestDispatcher getNamedDispatcher(String servletName) {
+		return _servletContextAdaptor.getNamedDispatcher(servletName);
+	}
+
+	@Override
+	public String getRealPath(String path) {
+		return _servletContextAdaptor.getRealPath(path);
+	}
+
+	@Override
+	public RequestDispatcher getRequestDispatcher(String path) {
+		return _servletContextAdaptor.getRequestDispatcher(path);
+	}
+
+	@Override
+	public URL getResource(String path) {
+		return _servletContextAdaptor.getResource(path);
+	}
+
+	@Override
+	public InputStream getResourceAsStream(String path) {
+		return _servletContextAdaptor.getResourceAsStream(path);
+	}
+
+	@Override
+	public Set<String> getResourcePaths(String path) {
+		return _servletContextAdaptor.getResourcePaths(path);
+	}
+
+	@Override
+	public String getServerInfo() {
+		return _servletContext.getServerInfo();
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), servlet API 2.1, with no replacement
+	 */
+	@Deprecated
+	@Override
+	public Servlet getServlet(String servletName) throws ServletException {
+		return _servletContext.getServlet(servletName);
+	}
+
+	@Override
+	public String getServletContextName() {
+		return _servletContextAdaptor.getServletContextName();
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), servlet API 2.1, with no replacement
+	 */
+	@Deprecated
+	@Override
+	public Enumeration<String> getServletNames() {
+		return _servletContext.getServletNames();
+	}
+
+	@Override
+	public ServletRegistration getServletRegistration(String servletName) {
+		return _servletContext.getServletRegistration(servletName);
+	}
+
+	@Override
+	public Map<String, ? extends ServletRegistration>
+		getServletRegistrations() {
+
+		return _servletContext.getServletRegistrations();
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), servlet API 2.0, with no replacement
+	 */
+	@Deprecated
+	@Override
+	public Enumeration<Servlet> getServlets() {
+		return _servletContext.getServlets();
+	}
+
+	@Override
+	public SessionCookieConfig getSessionCookieConfig() {
+		return _servletContext.getSessionCookieConfig();
+	}
+
+	@Override
+	public String getVirtualServerName() {
+		return _servletContext.getVirtualServerName();
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), Servlet API 2.1, replaced by
+	 * 			{@link #log(String message, Throwable throwable)}
+	 */
+	@Deprecated
+	@Override
+	public void log(Exception exception, String message) {
+		_servletContext.log(exception, message);
+	}
+
+	@Override
+	public void log(String message) {
+		_servletContext.log(message);
+	}
+
+	@Override
+	public void log(String message, Throwable throwable) {
+		_servletContext.log(message, throwable);
+	}
+
+	@Override
+	public void removeAttribute(String name) {
+		_servletContextAdaptor.removeAttribute(name);
+	}
+
+	@Override
+	public void setAttribute(String name, Object value) {
+		_servletContextAdaptor.setAttribute(name, value);
+	}
+
+	@Override
+	public boolean setInitParameter(String name, String value) {
+		return _servletContext.setInitParameter(name, value);
+	}
+
+	@Override
+	public void setSessionTrackingModes(
+		Set<SessionTrackingMode> sessionTrackingModes) {
+
+		_servletContext.setSessionTrackingModes(sessionTrackingModes);
+	}
+
+	private final ServletContext _servletContext;
+	private final ServletContextAdaptor _servletContextAdaptor;
+
+}


### PR DESCRIPTION
- LPD-5681 Create a ServletContextWrapper which delegates to ServletContextAdaptor methods when exists, and to the original ServletContext for the rest, prepare for inlining
- LPD-5681 Inline ServletContextAdaptor logic, throw away Proxy related logic as it's already overriding more than half of ServletContext methods
- LPD-5681 SF, extract method to avoid repeating
- LPD-5681 Clean up, remove AccessController usages
- LPD-5681 Apply and SF
- LPD-5187-next *Customizer: Inline *Customizer and initial SF
- LPD-5187-next *Customizer: Explicitly import LiferayContextController in *Customizer; ContextController will be thrown away after inlining all the classes.
- LPD-5187-next *Customizer: Apply, use the inlined *Customizer classes in LiferayContextController
- LPD-5187-next *Customizer: SF
- LPD-5187-next *Customizer: Remove modified support to simplify handling
- LPD-5187-next *Customizer: SF, simplify, move to base class
- LPD-5187-next *Customizer: SF, move logic from LiferayContextController to *Customizers, no real logic change
- LPD-5187-next *Customizer: SF, use logger in each class
- LPD-5187-next *Customizer: SF
- LPD-5187-next *Customizer: Auto SF
- LPD-5187-next DispatchTargets: create LiferayDispatchTargets that extends DispatchTargets and apply
- LPD-5187-next DispatchTargets: inline logic by overriding and make SF happy
- LPD-5187-next DispatchTargets: use Liferay classes where applicable
- LPD-5187-next ResponseStateHandler: create LiferayResponseStateHandler that extends ResponseStateHandler and apply
- LPD-5187-next ResponseStateHandler: inline logic and make SF happy
- LPD-5187-next ResponseStateHandler: SF
