### PR TITLE
LPD X DispatchTalend JDK21 2

### DIFF
--- a/modules/apps/dispatch/dispatch-talend-test/src/testIntegration/java/com/liferay/dispatch/talend/web/internal/executor/test/TalendDispatchTaskExecutorTest.java
+++ b/modules/apps/dispatch/dispatch-talend-test/src/testIntegration/java/com/liferay/dispatch/talend/web/internal/executor/test/TalendDispatchTaskExecutorTest.java
@@ -82,6 +82,7 @@ public class TalendDispatchTaskExecutorTest {
 		DispatchLog dispatchLog = dispatchLogs.get(0);
 
 		Assert.assertEquals(
+			dispatchLog.getError(),
 			DispatchTaskStatus.SUCCESSFUL,
 			DispatchTaskStatus.valueOf(dispatchLog.getStatus()));
 	}

--- a/modules/apps/dispatch/dispatch-talend-web/src/main/java/com/liferay/dispatch/talend/web/internal/process/TalendProcess.java
+++ b/modules/apps/dispatch/dispatch-talend-web/src/main/java/com/liferay/dispatch/talend/web/internal/process/TalendProcess.java
@@ -119,6 +119,8 @@ public class TalendProcess {
 			processConfigBuilder.setBootstrapClassPath(
 				_getBootstrapClassPath(
 					portalProcessConfig.getBootstrapClassPathHolders()));
+			processConfigBuilder.setJavaExecutable(
+				System.getProperty("java.home") + "/bin/java");
 			processConfigBuilder.setProcessLogConsumer(
 				portalProcessConfig.getProcessLogConsumer());
 			processConfigBuilder.setReactClassLoader(

--- a/modules/apps/dispatch/dispatch-talend-web/src/main/java/com/liferay/dispatch/talend/web/internal/process/TalendProcess.java
+++ b/modules/apps/dispatch/dispatch-talend-web/src/main/java/com/liferay/dispatch/talend/web/internal/process/TalendProcess.java
@@ -109,9 +109,15 @@ public class TalendProcess {
 			ProcessConfig.Builder processConfigBuilder =
 				new ProcessConfig.Builder();
 
+			List<String> arguments = new ArrayList<>();
+
 			if (_jvmOptions != null) {
-				processConfigBuilder.setArguments(_jvmOptions);
+				arguments.addAll(_jvmOptions);
 			}
+
+			arguments.add("-Djava.security.manager=allow");
+
+			processConfigBuilder.setArguments(arguments);
 
 			ProcessConfig portalProcessConfig =
 				PortalClassPathUtil.getPortalProcessConfig();


### PR DESCRIPTION
- LPD-X output for debugging
- LPD-X Force Talend to use the same JVM with portal, following 7d1c74b8
- LPD-X Add -Djava.security.manager=allow for the Talend process
