### PR TITLE
LPD 20946 4

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -206,7 +206,7 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public List<String> getModelResourceActions(String name) {
 		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(modelResourceActionsBag.getSupportsActions());
 	}
@@ -214,7 +214,7 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public List<String> getModelResourceGroupDefaultActions(String name) {
 		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getGroupDefaultActions());
@@ -223,7 +223,7 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public List<String> getModelResourceGuestDefaultActions(String name) {
 		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getGuestDefaultActions());
@@ -232,7 +232,7 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public List<String> getModelResourceGuestUnsupportedActions(String name) {
 		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getGuestUnsupportedActions());
@@ -246,7 +246,7 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public List<String> getModelResourceOwnerDefaultActions(String name) {
 		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getOwnerDefaultActions());
@@ -305,7 +305,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		name = PortletIdCodec.decodePortletName(name);
 
 		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getGroupDefaultActions());
@@ -316,7 +316,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		name = PortletIdCodec.decodePortletName(name);
 
 		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getGuestDefaultActions());
@@ -327,7 +327,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		name = PortletIdCodec.decodePortletName(name);
 
 		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getGuestUnsupportedActions());
@@ -338,7 +338,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		name = PortletIdCodec.decodePortletName(name);
 
 		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getLayoutManagerActions());
@@ -587,7 +587,8 @@ public class ResourceActionsImpl implements ResourceActions {
 			return;
 		}
 
-		ResourceActionsBag resourceActionsBag = _getResourceActionsBag(name);
+		ResourceActionsBag resourceActionsBag = _getResourceActionsBag(
+			name, false);
 
 		Set<String> resourceActions = resourceActionsBag.getSupportsActions();
 
@@ -766,7 +767,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		String name, Portlet portlet) {
 
 		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, true);
 
 		Set<String> portletActions =
 			portletResourceActionsBag.getSupportsActions();
@@ -804,11 +805,17 @@ public class ResourceActionsImpl implements ResourceActions {
 		return new ArrayList<>(portletActions);
 	}
 
-	private ResourceActionsBag _getResourceActionsBag(String name) {
+	private ResourceActionsBag _getResourceActionsBag(
+		String name, boolean create) {
+
 		ResourceActionsBag resourceActionsBag = _resourceActionsBags.get(name);
 
 		if (resourceActionsBag != null) {
 			return resourceActionsBag;
+		}
+
+		if (!create) {
+			return _dummyResourceActionsBag;
 		}
 
 		synchronized (_resourceActionsBags) {
@@ -1141,7 +1148,8 @@ public class ResourceActionsImpl implements ResourceActions {
 			Set<String> defaultResourceActions)
 		throws ResourceActionsException {
 
-		ResourceActionsBag resourceActionsBag = _getResourceActionsBag(name);
+		ResourceActionsBag resourceActionsBag = _getResourceActionsBag(
+			name, true);
 
 		Set<String> resourceActions = resourceActionsBag.getSupportsActions();
 
@@ -1248,6 +1256,9 @@ public class ResourceActionsImpl implements ResourceActions {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ResourceActionsImpl.class);
+
+	private static final ResourceActionsBag _dummyResourceActionsBag =
+		new ResourceActionsBag();
 
 	private final Map<String, Double> _modelResourceWeights = new HashMap<>();
 	private final Set<String> _organizationModelResources = new HashSet<>();

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -29,10 +29,12 @@ import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -460,6 +462,8 @@ public class ResourceActionsImpl implements ResourceActions {
 					getModelResourceActions(modelResourceName),
 					modelResourceName);
 			}
+
+			_initModelResourcePermissions(modelResourceNames);
 		}
 	}
 
@@ -487,6 +491,8 @@ public class ResourceActionsImpl implements ResourceActions {
 			_checkResourceActions(
 				getModelResourceActions(modelResourceName), modelResourceName);
 		}
+
+		_initModelResourcePermissions(modelResourceNames);
 	}
 
 	@Override
@@ -602,11 +608,17 @@ public class ResourceActionsImpl implements ResourceActions {
 		}
 	}
 
+	@BeanReference(type = CompanyLocalService.class)
+	protected CompanyLocalService companyLocalService;
+
 	@BeanReference(type = PortletLocalService.class)
 	protected PortletLocalService portletLocalService;
 
 	@BeanReference(type = ResourceActionLocalService.class)
 	protected ResourceActionLocalService resourceActionLocalService;
+
+	@BeanReference(type = ResourcePermissionLocalService.class)
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
 
 	@BeanReference(type = RoleLocalService.class)
 	protected RoleLocalService roleLocalService;
@@ -914,6 +926,19 @@ public class ResourceActionsImpl implements ResourceActions {
 		}
 
 		return types;
+	}
+
+	private void _initModelResourcePermissions(Set<String> modelResourceNames) {
+		try {
+			companyLocalService.forEachCompanyId(
+				companyId ->
+					resourcePermissionLocalService.
+						populateDefaultModelResourcePermissions(
+							companyId, modelResourceNames));
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
 	}
 
 	private void _read(

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -12,7 +12,9 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
+import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.ResourceActionsException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -72,6 +74,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -948,12 +951,24 @@ public class ResourceActionsImpl implements ResourceActions {
 	}
 
 	private void _initModelResourcePermissions(Set<String> modelResourceNames) {
-		try {
+		Callable<?> callable = () -> {
 			companyLocalService.forEachCompanyId(
 				companyId ->
 					resourcePermissionLocalService.
 						populateDefaultModelResourcePermissions(
 							companyId, modelResourceNames));
+
+			return null;
+		};
+
+		if (StartupHelperUtil.isUpgrading()) {
+			DependencyManagerSyncUtil.registerSyncCallable(callable);
+
+			return;
+		}
+
+		try {
+			callable.call();
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -13,11 +13,14 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
+import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.ResourceActionsException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.ResourceAction;
@@ -39,6 +42,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -72,6 +76,9 @@ import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
 /**
  * @author Brian Wing Shun Chan
  * @author Daeyoung Song
@@ -79,9 +86,21 @@ import javax.servlet.http.HttpSession;
  */
 public class ResourceActionsImpl implements ResourceActions {
 
+	public void afterPropertiesSet() {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		_serviceRegistration = bundleContext.registerService(
+			ModelListener.class, new ResourceActionModelListener(),
+			new HashMapDictionary<>());
+	}
+
 	@Override
 	public void check(String portletName) {
 		_check(portletName, getPortletResourceActions(portletName));
+	}
+
+	public void destroy() {
+		_serviceRegistration.unregister();
 	}
 
 	@Override
@@ -1294,6 +1313,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		new HashMap<>();
 	private final Map<String, Set<String>> _resourceReferences =
 		new HashMap<>();
+	private ServiceRegistration<?> _serviceRegistration;
 
 	private static class ResourceActionsBag {
 
@@ -1336,6 +1356,45 @@ public class ResourceActionsImpl implements ResourceActions {
 			_resourceBundleLoaders = ServiceTrackerListFactory.open(
 				SystemBundleUtil.getBundleContext(),
 				ResourceBundleLoader.class);
+
+	}
+
+	private class ResourceActionModelListener
+		extends BaseModelListener<ResourceAction> {
+
+		@Override
+		public void onAfterRemove(ResourceAction resourceAction)
+			throws ModelListenerException {
+
+			ResourceActionsBag resourceActionsBag = _resourceActionsBags.get(
+				resourceAction.getName());
+
+			if (resourceActionsBag == null) {
+				return;
+			}
+
+			Set<String> resourceActions =
+				resourceActionsBag.getSupportsActions();
+
+			resourceActions.remove(resourceAction.getActionId());
+
+			if (resourceActions.isEmpty()) {
+				synchronized (this) {
+					_modelResourceWeights.remove(resourceAction.getName());
+
+					_organizationModelResources.remove(
+						resourceAction.getName());
+
+					_portalModelResources.remove(resourceAction.getName());
+
+					_portletRootModelResources.remove(resourceAction.getName());
+
+					_resourceActionsBags.remove(resourceAction.getName());
+
+					_resourceReferences.remove(resourceAction.getName());
+				}
+			}
+		}
 
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -74,6 +74,7 @@ import com.liferay.portal.kernel.search.facet.faceted.searcher.FacetedSearcherMa
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.EmailAddressValidator;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
@@ -83,6 +84,7 @@ import com.liferay.portal.kernel.service.PasswordPolicyLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
@@ -2175,6 +2177,13 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			_passwordPolicyLocalService.checkDefaultPasswordPolicy(
 				company.getCompanyId());
 
+			// Default Permissions
+
+			_resourcePermissionLocalService.
+				populateDefaultModelResourcePermissions(
+					company.getCompanyId(),
+					ResourceActionsUtil.getModelNames());
+
 			// Portlets
 
 			_portletLocalService.checkPortlets(company.getCompanyId());
@@ -2437,6 +2446,9 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 	@BeanReference(type = ResourceActionLocalService.class)
 	private ResourceActionLocalService _resourceActionLocalService;
+
+	@BeanReference(type = ResourcePermissionLocalService.class)
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 	@BeanReference(type = RoleLocalService.class)
 	private RoleLocalService _roleLocalService;

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
 import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
@@ -2179,10 +2180,12 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 			// Default Permissions
 
-			_resourcePermissionLocalService.
-				populateDefaultModelResourcePermissions(
-					company.getCompanyId(),
-					ResourceActionsUtil.getModelNames());
+			if (!StartupHelperUtil.isUpgrading()) {
+				_resourcePermissionLocalService.
+					populateDefaultModelResourcePermissions(
+						company.getCompanyId(),
+						ResourceActionsUtil.getModelNames());
+			}
 
 			// Portlets
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -8,19 +8,16 @@ package com.liferay.portal.service.impl;
 import com.liferay.admin.kernel.util.PortalMyAccountApplicationType;
 import com.liferay.expando.kernel.model.CustomAttributesDisplay;
 import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.ConfigurationFactoryImpl;
-import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.application.type.ApplicationType;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
-import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.PortletIdException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -58,7 +55,6 @@ import com.liferay.portal.kernel.portlet.PortletQNameUtil;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -2689,22 +2685,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		_updatePortletCategory(portletCategory, companyPortletModel);
 
-		if (StartupHelperUtil.isDBWarmed()) {
-			checkPortlet(companyPortletModel);
-		}
-		else {
-			DependencyManagerSyncUtil.registerSyncCallable(
-				() -> {
-					try (SafeCloseable safeCloseable =
-							CompanyThreadLocal.setWithSafeCloseable(
-								companyId)) {
-
-						portletLocalService.checkPortlet(companyPortletModel);
-					}
-
-					return null;
-				});
-		}
+		checkPortlet(companyPortletModel);
 	}
 
 	private Configuration _getConfiguration(PortletApp portletApp) {

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -1202,11 +1202,6 @@ public class ResourcePermissionLocalServiceImpl
 			portlet.getCompanyId(), portlet.getRootPortletId(), guestRole,
 			ownerRole, siteMemberRole, guestPortletActions,
 			ownerPortletActionIds, groupPortletActionIds);
-
-		populateDefaultModelResourcePermissions(
-			portlet.getCompanyId(),
-			ResourceActionsUtil.getPortletModelResources(
-				portlet.getRootPortletId()));
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -71,7 +71,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -1204,43 +1203,10 @@ public class ResourcePermissionLocalServiceImpl
 			ownerRole, siteMemberRole, guestPortletActions,
 			ownerPortletActionIds, groupPortletActionIds);
 
-		String rootModelResource =
-			ResourceActionsUtil.getPortletRootModelResource(
-				portlet.getRootPortletId());
-
-		List<String> modelResources =
+		populateDefaultModelResourcePermissions(
+			portlet.getCompanyId(),
 			ResourceActionsUtil.getPortletModelResources(
-				portlet.getRootPortletId());
-
-		for (String modelResource : modelResources) {
-			if (Validator.isBlank(modelResource)) {
-				continue;
-			}
-
-			validate(modelResource, false);
-
-			List<String> groupModelActionIds = null;
-
-			if (Objects.equals(rootModelResource, modelResource)) {
-				groupModelActionIds =
-					ResourceActionsUtil.getModelResourceGroupDefaultActions(
-						rootModelResource);
-			}
-
-			List<String> guestModelActionIds =
-				ResourceActionsUtil.getModelResourceGuestDefaultActions(
-					modelResource);
-
-			List<String> ownerModelActionIds =
-				ResourceActionsUtil.getModelResourceActions(modelResource);
-
-			filterOwnerActions(modelResource, ownerModelActionIds);
-
-			_initPortletDefaultPermissions(
-				portlet.getCompanyId(), modelResource, guestRole, ownerRole,
-				siteMemberRole, guestModelActionIds, ownerModelActionIds,
-				groupModelActionIds);
-		}
+				portlet.getRootPortletId()));
 	}
 
 	/**
@@ -1278,6 +1244,48 @@ public class ResourcePermissionLocalServiceImpl
 		}
 
 		_roleLocalService.deleteRole(fromRoleId);
+	}
+
+	public void populateDefaultModelResourcePermissions(
+			long companyId, Collection<String> modelResourceNames)
+		throws PortalException {
+
+		Role guestRole = _roleLocalService.getRole(
+			companyId, RoleConstants.GUEST);
+		Role ownerRole = _roleLocalService.getRole(
+			companyId, RoleConstants.OWNER);
+		Role siteMemberRole = _roleLocalService.getRole(
+			companyId, RoleConstants.SITE_MEMBER);
+
+		for (String modelResourceName : modelResourceNames) {
+			if (Validator.isBlank(modelResourceName)) {
+				continue;
+			}
+
+			validate(modelResourceName, false);
+
+			List<String> groupModelActionIds = null;
+
+			if (_isRootModelResource(modelResourceName)) {
+				groupModelActionIds =
+					ResourceActionsUtil.getModelResourceGroupDefaultActions(
+						modelResourceName);
+			}
+
+			List<String> guestModelActionIds =
+				ResourceActionsUtil.getModelResourceGuestDefaultActions(
+					modelResourceName);
+
+			List<String> ownerModelActionIds =
+				ResourceActionsUtil.getModelResourceActions(modelResourceName);
+
+			filterOwnerActions(modelResourceName, ownerModelActionIds);
+
+			_initPortletDefaultPermissions(
+				companyId, modelResourceName, guestRole, ownerRole,
+				siteMemberRole, guestModelActionIds, ownerModelActionIds,
+				groupModelActionIds);
+		}
 	}
 
 	/**
@@ -2106,6 +2114,22 @@ public class ResourcePermissionLocalServiceImpl
 				IndexWriterHelperUtil.updatePermissionFields(name, name);
 			}
 		}
+	}
+
+	private boolean _isRootModelResource(String modelResourceName) {
+		List<String> portletNames =
+			ResourceActionsUtil.getModelPortletResources(modelResourceName);
+
+		for (String portletName : portletNames) {
+			if (modelResourceName.equals(
+					ResourceActionsUtil.getPortletRootModelResource(
+						portletName))) {
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private boolean _matches(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
@@ -733,6 +733,10 @@ public interface ResourcePermissionLocalService
 	public void mergePermissions(long fromRoleId, long toRoleId)
 		throws PortalException;
 
+	public void populateDefaultModelResourcePermissions(
+			long companyId, Collection<String> modelResourceNames)
+		throws PortalException;
+
 	/**
 	 * Grants the role default permissions to all the resources of the type and
 	 * at the scope stored in the resource permission, deletes the resource

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
@@ -836,6 +836,14 @@ public class ResourcePermissionLocalServiceUtil {
 		getService().mergePermissions(fromRoleId, toRoleId);
 	}
 
+	public static void populateDefaultModelResourcePermissions(
+			long companyId, java.util.Collection<String> modelResourceNames)
+		throws PortalException {
+
+		getService().populateDefaultModelResourcePermissions(
+			companyId, modelResourceNames);
+	}
+
 	/**
 	 * Grants the role default permissions to all the resources of the type and
 	 * at the scope stored in the resource permission, deletes the resource

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
@@ -914,6 +914,15 @@ public class ResourcePermissionLocalServiceWrapper
 		_resourcePermissionLocalService.mergePermissions(fromRoleId, toRoleId);
 	}
 
+	@Override
+	public void populateDefaultModelResourcePermissions(
+			long companyId, java.util.Collection<String> modelResourceNames)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_resourcePermissionLocalService.populateDefaultModelResourcePermissions(
+			companyId, modelResourceNames);
+	}
+
 	/**
 	 * Grants the role default permissions to all the resources of the type and
 	 * at the scope stored in the resource permission, deletes the resource


### PR DESCRIPTION
- **Revert "LPD-20793 For cold db, postpone remote portlet deployment checking to the end of startup."**
- **LPD-X Only create ResourceActionsBag when populating or getting portlet supported actions (for default actions)**
- **LPD-20946 Move logic to a public method and avoid directly using portlet id, prepare for next**
- **LPD-20946 Build service**
- **LPD-20946 Populate model resource permissions during reading from xml documents, after checking the resource actions**
- **LPD-20946 Also populate existing model resource permissions when checking company (model listener is too early)**
- **LPD-20946 No longer need to populate model resource permisssion during portlet deployment**
- **LPD-20946 Bug Fix: listen to ResourceAction removal and clean up the bags, etc. With our current infrastructure, when a resource action is removed via the local service, it's not removed from the bag in ResourceActionsImpl; this is not a problem until we start to iterate resource names in ResourceActionsImpl and insert permissions when creating new company.**
- **LPD-20946 Upgrade fix?**
