### PR TITLE
LPD 21827 test

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsCache.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsCache.java
@@ -1,0 +1,149 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.permission;
+
+import com.liferay.portal.kernel.model.ResourceAction;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Dante Wang
+ */
+public class ResourceActionsCache {
+
+	public static Map<String, Double> getModelResourceWeightsMap() {
+		return _modelResourceWeightsMap;
+	}
+
+	public static Set<String> getOrganizationModelResources() {
+		return _organizationModelResources;
+	}
+
+	public static Set<String> getPortalModelResources() {
+		return _portalModelResources;
+	}
+
+	public static Map<String, String> getPortletRootModelResourcesMap() {
+		return _portletRootModelResourcesMap;
+	}
+
+	public static Map<String, ResourceActionsBag> getResourceActionsBagMap() {
+		return _resourceActionsBagsMap;
+	}
+
+	public static Map<String, ResourceAction> getResourceActionsMap() {
+		return _resourceActionsMap;
+	}
+
+	public static Map<String, Set<String>> getResourceReferencesMap() {
+		return _resourceReferencesMap;
+	}
+
+	public static class ResourceActionsBag {
+
+		public Set<String> getGroupDefaultActions() {
+			return _groupDefaultActions;
+		}
+
+		public Set<String> getGuestDefaultActions() {
+			return _guestDefaultActions;
+		}
+
+		public Set<String> getGuestUnsupportedActions() {
+			return _guestUnsupportedActions;
+		}
+
+		public Set<String> getLayoutManagerActions() {
+			return _layoutManagerActions;
+		}
+
+		public Set<String> getOwnerDefaultActions() {
+			return _ownerDefaultActions;
+		}
+
+		public Set<String> getSupportsActions() {
+			return _supportsActions;
+		}
+
+		private final Set<String> _groupDefaultActions = new HashSet<>();
+		private final Set<String> _guestDefaultActions = new HashSet<>();
+		private final Set<String> _guestUnsupportedActions = new HashSet<>();
+		private final Set<String> _layoutManagerActions = new HashSet<>();
+		private final Set<String> _ownerDefaultActions = new HashSet<>();
+		private final Set<String> _supportsActions = new HashSet<>();
+
+	}
+
+	private static final Map<String, Double> _modelResourceWeightsMap =
+		new HashMap<>();
+	private static final Set<String> _organizationModelResources =
+		new HashSet<>();
+	private static final Set<String> _portalModelResources = new HashSet<>();
+	private static final Map<String, String> _portletRootModelResourcesMap =
+		new HashMap<>();
+
+	private static final Map<String, ResourceActionsBag>
+		_resourceActionsBagsMap = new HashMap<String, ResourceActionsBag>() {
+
+			@Override
+			public ResourceActionsBag remove(Object key) {
+				synchronized (_resourceActionsBagsMap) {
+					_modelResourceWeightsMap.remove(key);
+
+					_organizationModelResources.remove((String)key);
+
+					_portalModelResources.remove((String)key);
+
+					_portletRootModelResourcesMap.remove(key);
+
+					_resourceReferencesMap.remove(key);
+
+					return super.remove(key);
+				}
+			}
+
+		};
+
+	private static final Map<String, ResourceAction> _resourceActionsMap =
+		new ConcurrentHashMap<String, ResourceAction>() {
+
+			@Override
+			public ResourceAction remove(Object key) {
+				ResourceAction resourceAction = super.remove(key);
+
+				if (resourceAction == null) {
+					return null;
+				}
+
+				ResourceActionsBag resourceActionsBag =
+					_resourceActionsBagsMap.get(resourceAction.getName());
+
+				if (resourceActionsBag == null) {
+					return resourceAction;
+				}
+
+				Set<String> supportsActions =
+					resourceActionsBag.getSupportsActions();
+
+				supportsActions.remove(resourceAction.getActionId());
+
+				if (supportsActions.isEmpty()) {
+					_resourceActionsBagsMap.remove(resourceAction.getName());
+				}
+
+				return resourceAction;
+			}
+
+		};
+
+	private static final Map<String, Set<String>> _resourceReferencesMap =
+		new HashMap<>();
+
+}

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -206,7 +206,7 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public List<String> getModelResourceActions(String name) {
 		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(modelResourceActionsBag.getSupportsActions());
 	}
@@ -214,7 +214,7 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public List<String> getModelResourceGroupDefaultActions(String name) {
 		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getGroupDefaultActions());
@@ -223,7 +223,7 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public List<String> getModelResourceGuestDefaultActions(String name) {
 		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getGuestDefaultActions());
@@ -232,7 +232,7 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public List<String> getModelResourceGuestUnsupportedActions(String name) {
 		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getGuestUnsupportedActions());
@@ -246,7 +246,7 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public List<String> getModelResourceOwnerDefaultActions(String name) {
 		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getOwnerDefaultActions());
@@ -305,7 +305,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		name = PortletIdCodec.decodePortletName(name);
 
 		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getGroupDefaultActions());
@@ -316,7 +316,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		name = PortletIdCodec.decodePortletName(name);
 
 		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getGuestDefaultActions());
@@ -327,7 +327,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		name = PortletIdCodec.decodePortletName(name);
 
 		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getGuestUnsupportedActions());
@@ -338,7 +338,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		name = PortletIdCodec.decodePortletName(name);
 
 		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getLayoutManagerActions());
@@ -587,7 +587,8 @@ public class ResourceActionsImpl implements ResourceActions {
 			return;
 		}
 
-		ResourceActionsBag resourceActionsBag = _getResourceActionsBag(name);
+		ResourceActionsBag resourceActionsBag = _getResourceActionsBag(
+			name, false);
 
 		Set<String> resourceActions = resourceActionsBag.getSupportsActions();
 
@@ -766,7 +767,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		String name, Portlet portlet) {
 
 		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name);
+			name, true);
 
 		Set<String> portletActions =
 			portletResourceActionsBag.getSupportsActions();
@@ -804,11 +805,17 @@ public class ResourceActionsImpl implements ResourceActions {
 		return new ArrayList<>(portletActions);
 	}
 
-	private ResourceActionsBag _getResourceActionsBag(String name) {
+	private ResourceActionsBag _getResourceActionsBag(
+		String name, boolean create) {
+
 		ResourceActionsBag resourceActionsBag = _resourceActionsBags.get(name);
 
 		if (resourceActionsBag != null) {
 			return resourceActionsBag;
+		}
+
+		if (!create) {
+			return _dummyResourceActionsBag;
 		}
 
 		synchronized (_resourceActionsBags) {
@@ -1141,7 +1148,8 @@ public class ResourceActionsImpl implements ResourceActions {
 			Set<String> defaultResourceActions)
 		throws ResourceActionsException {
 
-		ResourceActionsBag resourceActionsBag = _getResourceActionsBag(name);
+		ResourceActionsBag resourceActionsBag = _getResourceActionsBag(
+			name, true);
 
 		Set<String> resourceActions = resourceActionsBag.getSupportsActions();
 
@@ -1248,6 +1256,9 @@ public class ResourceActionsImpl implements ResourceActions {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ResourceActionsImpl.class);
+
+	private static final ResourceActionsBag _dummyResourceActionsBag =
+		new ResourceActionsBag();
 
 	private final Map<String, Double> _modelResourceWeights = new HashMap<>();
 	private final Set<String> _organizationModelResources = new HashSet<>();

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -12,7 +12,9 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
+import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.ResourceActionsException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -67,6 +69,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -929,12 +932,24 @@ public class ResourceActionsImpl implements ResourceActions {
 	}
 
 	private void _initModelResourcePermissions(Set<String> modelResourceNames) {
-		try {
+		Callable<?> callable = () -> {
 			companyLocalService.forEachCompanyId(
 				companyId ->
 					resourcePermissionLocalService.
 						populateDefaultModelResourcePermissions(
 							companyId, modelResourceNames));
+
+			return null;
+		};
+
+		if (StartupHelperUtil.isUpgrading()) {
+			DependencyManagerSyncUtil.registerSyncCallable(callable);
+
+			return;
+		}
+
+		try {
+			callable.call();
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -29,10 +29,12 @@ import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -459,6 +461,8 @@ public class ResourceActionsImpl implements ResourceActions {
 					getModelResourceActions(modelResourceName),
 					modelResourceName);
 			}
+
+			_initModelResourcePermissions(modelResourceNames);
 		}
 	}
 
@@ -486,6 +490,8 @@ public class ResourceActionsImpl implements ResourceActions {
 			_checkResourceActions(
 				getModelResourceActions(modelResourceName), modelResourceName);
 		}
+
+		_initModelResourcePermissions(modelResourceNames);
 	}
 
 	@Override
@@ -601,11 +607,17 @@ public class ResourceActionsImpl implements ResourceActions {
 		}
 	}
 
+	@BeanReference(type = CompanyLocalService.class)
+	protected CompanyLocalService companyLocalService;
+
 	@BeanReference(type = PortletLocalService.class)
 	protected PortletLocalService portletLocalService;
 
 	@BeanReference(type = ResourceActionLocalService.class)
 	protected ResourceActionLocalService resourceActionLocalService;
+
+	@BeanReference(type = ResourcePermissionLocalService.class)
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
 
 	@BeanReference(type = RoleLocalService.class)
 	protected RoleLocalService roleLocalService;
@@ -914,6 +926,19 @@ public class ResourceActionsImpl implements ResourceActions {
 		}
 
 		return types;
+	}
+
+	private void _initModelResourcePermissions(Set<String> modelResourceNames) {
+		try {
+			companyLocalService.forEachCompanyId(
+				companyId ->
+					resourcePermissionLocalService.
+						populateDefaultModelResourcePermissions(
+							companyId, modelResourceNames));
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
 	}
 
 	private void _read(

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -56,7 +56,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -205,16 +204,16 @@ public class ResourceActionsImpl implements ResourceActions {
 
 	@Override
 	public List<String> getModelResourceActions(String name) {
-		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name, false);
+		ResourceActionsCache.ResourceActionsBag modelResourceActionsBag =
+			_getResourceActionsBag(name, false);
 
 		return new ArrayList<>(modelResourceActionsBag.getSupportsActions());
 	}
 
 	@Override
 	public List<String> getModelResourceGroupDefaultActions(String name) {
-		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name, false);
+		ResourceActionsCache.ResourceActionsBag modelResourceActionsBag =
+			_getResourceActionsBag(name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getGroupDefaultActions());
@@ -222,8 +221,8 @@ public class ResourceActionsImpl implements ResourceActions {
 
 	@Override
 	public List<String> getModelResourceGuestDefaultActions(String name) {
-		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name, false);
+		ResourceActionsCache.ResourceActionsBag modelResourceActionsBag =
+			_getResourceActionsBag(name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getGuestDefaultActions());
@@ -231,8 +230,8 @@ public class ResourceActionsImpl implements ResourceActions {
 
 	@Override
 	public List<String> getModelResourceGuestUnsupportedActions(String name) {
-		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name, false);
+		ResourceActionsCache.ResourceActionsBag modelResourceActionsBag =
+			_getResourceActionsBag(name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getGuestUnsupportedActions());
@@ -245,8 +244,8 @@ public class ResourceActionsImpl implements ResourceActions {
 
 	@Override
 	public List<String> getModelResourceOwnerDefaultActions(String name) {
-		ResourceActionsBag modelResourceActionsBag = _getResourceActionsBag(
-			name, false);
+		ResourceActionsCache.ResourceActionsBag modelResourceActionsBag =
+			_getResourceActionsBag(name, false);
 
 		return new ArrayList<>(
 			modelResourceActionsBag.getOwnerDefaultActions());
@@ -304,8 +303,8 @@ public class ResourceActionsImpl implements ResourceActions {
 
 		name = PortletIdCodec.decodePortletName(name);
 
-		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name, false);
+		ResourceActionsCache.ResourceActionsBag portletResourceActionsBag =
+			_getResourceActionsBag(name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getGroupDefaultActions());
@@ -315,8 +314,8 @@ public class ResourceActionsImpl implements ResourceActions {
 	public List<String> getPortletResourceGuestDefaultActions(String name) {
 		name = PortletIdCodec.decodePortletName(name);
 
-		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name, false);
+		ResourceActionsCache.ResourceActionsBag portletResourceActionsBag =
+			_getResourceActionsBag(name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getGuestDefaultActions());
@@ -326,8 +325,8 @@ public class ResourceActionsImpl implements ResourceActions {
 	public List<String> getPortletResourceGuestUnsupportedActions(String name) {
 		name = PortletIdCodec.decodePortletName(name);
 
-		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name, false);
+		ResourceActionsCache.ResourceActionsBag portletResourceActionsBag =
+			_getResourceActionsBag(name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getGuestUnsupportedActions());
@@ -337,8 +336,8 @@ public class ResourceActionsImpl implements ResourceActions {
 	public List<String> getPortletResourceLayoutManagerActions(String name) {
 		name = PortletIdCodec.decodePortletName(name);
 
-		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name, false);
+		ResourceActionsCache.ResourceActionsBag portletResourceActionsBag =
+			_getResourceActionsBag(name, false);
 
 		return new ArrayList<>(
 			portletResourceActionsBag.getLayoutManagerActions());
@@ -587,8 +586,8 @@ public class ResourceActionsImpl implements ResourceActions {
 			return;
 		}
 
-		ResourceActionsBag resourceActionsBag = _getResourceActionsBag(
-			name, false);
+		ResourceActionsCache.ResourceActionsBag resourceActionsBag =
+			_getResourceActionsBag(name, false);
 
 		Set<String> resourceActions = resourceActionsBag.getSupportsActions();
 
@@ -766,8 +765,8 @@ public class ResourceActionsImpl implements ResourceActions {
 	private List<String> _getPortletResourceActions(
 		String name, Portlet portlet) {
 
-		ResourceActionsBag portletResourceActionsBag = _getResourceActionsBag(
-			name, true);
+		ResourceActionsCache.ResourceActionsBag portletResourceActionsBag =
+			_getResourceActionsBag(name, true);
 
 		Set<String> portletActions =
 			portletResourceActionsBag.getSupportsActions();
@@ -805,10 +804,11 @@ public class ResourceActionsImpl implements ResourceActions {
 		return new ArrayList<>(portletActions);
 	}
 
-	private ResourceActionsBag _getResourceActionsBag(
+	private ResourceActionsCache.ResourceActionsBag _getResourceActionsBag(
 		String name, boolean create) {
 
-		ResourceActionsBag resourceActionsBag = _resourceActionsBags.get(name);
+		ResourceActionsCache.ResourceActionsBag resourceActionsBag =
+			_resourceActionsBags.get(name);
 
 		if (resourceActionsBag != null) {
 			return resourceActionsBag;
@@ -825,7 +825,7 @@ public class ResourceActionsImpl implements ResourceActions {
 				return resourceActionsBag;
 			}
 
-			resourceActionsBag = new ResourceActionsBag();
+			resourceActionsBag = new ResourceActionsCache.ResourceActionsBag();
 
 			_resourceActionsBags.put(name, resourceActionsBag);
 		}
@@ -1148,8 +1148,8 @@ public class ResourceActionsImpl implements ResourceActions {
 			Set<String> defaultResourceActions)
 		throws ResourceActionsException {
 
-		ResourceActionsBag resourceActionsBag = _getResourceActionsBag(
-			name, true);
+		ResourceActionsCache.ResourceActionsBag resourceActionsBag =
+			_getResourceActionsBag(name, true);
 
 		Set<String> resourceActions = resourceActionsBag.getSupportsActions();
 
@@ -1257,53 +1257,22 @@ public class ResourceActionsImpl implements ResourceActions {
 	private static final Log _log = LogFactoryUtil.getLog(
 		ResourceActionsImpl.class);
 
-	private static final ResourceActionsBag _dummyResourceActionsBag =
-		new ResourceActionsBag();
+	private static final ResourceActionsCache.ResourceActionsBag
+		_dummyResourceActionsBag =
+			new ResourceActionsCache.ResourceActionsBag();
 
-	private final Map<String, Double> _modelResourceWeights = new HashMap<>();
-	private final Set<String> _organizationModelResources = new HashSet<>();
-	private final Set<String> _portalModelResources = new HashSet<>();
+	private final Map<String, Double> _modelResourceWeights =
+		ResourceActionsCache.getModelResourceWeightsMap();
+	private final Set<String> _organizationModelResources =
+		ResourceActionsCache.getOrganizationModelResources();
+	private final Set<String> _portalModelResources =
+		ResourceActionsCache.getPortalModelResources();
 	private final Map<String, String> _portletRootModelResources =
-		new HashMap<>();
-	private final Map<String, ResourceActionsBag> _resourceActionsBags =
-		new HashMap<>();
+		ResourceActionsCache.getPortletRootModelResourcesMap();
+	private final Map<String, ResourceActionsCache.ResourceActionsBag>
+		_resourceActionsBags = ResourceActionsCache.getResourceActionsBagMap();
 	private final Map<String, Set<String>> _resourceReferences =
-		new HashMap<>();
-
-	private static class ResourceActionsBag {
-
-		public Set<String> getGroupDefaultActions() {
-			return _groupDefaultActions;
-		}
-
-		public Set<String> getGuestDefaultActions() {
-			return _guestDefaultActions;
-		}
-
-		public Set<String> getGuestUnsupportedActions() {
-			return _guestUnsupportedActions;
-		}
-
-		public Set<String> getLayoutManagerActions() {
-			return _layoutManagerActions;
-		}
-
-		public Set<String> getOwnerDefaultActions() {
-			return _ownerDefaultActions;
-		}
-
-		public Set<String> getSupportsActions() {
-			return _supportsActions;
-		}
-
-		private final Set<String> _groupDefaultActions = new HashSet<>();
-		private final Set<String> _guestDefaultActions = new HashSet<>();
-		private final Set<String> _guestUnsupportedActions = new HashSet<>();
-		private final Set<String> _layoutManagerActions = new HashSet<>();
-		private final Set<String> _ownerDefaultActions = new HashSet<>();
-		private final Set<String> _supportsActions = new HashSet<>();
-
-	}
+		ResourceActionsCache.getResourceReferencesMap();
 
 	private static class ResourceBundleLoaderListHolder {
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -74,6 +74,7 @@ import com.liferay.portal.kernel.search.facet.faceted.searcher.FacetedSearcherMa
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.EmailAddressValidator;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
@@ -83,6 +84,7 @@ import com.liferay.portal.kernel.service.PasswordPolicyLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
@@ -2175,6 +2177,13 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			_passwordPolicyLocalService.checkDefaultPasswordPolicy(
 				company.getCompanyId());
 
+			// Default Permissions
+
+			_resourcePermissionLocalService.
+				populateDefaultModelResourcePermissions(
+					company.getCompanyId(),
+					ResourceActionsUtil.getModelNames());
+
 			// Portlets
 
 			_portletLocalService.checkPortlets(company.getCompanyId());
@@ -2437,6 +2446,9 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 	@BeanReference(type = ResourceActionLocalService.class)
 	private ResourceActionLocalService _resourceActionLocalService;
+
+	@BeanReference(type = ResourcePermissionLocalService.class)
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 	@BeanReference(type = RoleLocalService.class)
 	private RoleLocalService _roleLocalService;

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
 import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
@@ -2179,10 +2180,12 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 			// Default Permissions
 
-			_resourcePermissionLocalService.
-				populateDefaultModelResourcePermissions(
-					company.getCompanyId(),
-					ResourceActionsUtil.getModelNames());
+			if (!StartupHelperUtil.isUpgrading()) {
+				_resourcePermissionLocalService.
+					populateDefaultModelResourcePermissions(
+						company.getCompanyId(),
+						ResourceActionsUtil.getModelNames());
+			}
 
 			// Portlets
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -8,19 +8,16 @@ package com.liferay.portal.service.impl;
 import com.liferay.admin.kernel.util.PortalMyAccountApplicationType;
 import com.liferay.expando.kernel.model.CustomAttributesDisplay;
 import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.ConfigurationFactoryImpl;
-import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.application.type.ApplicationType;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
-import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.PortletIdException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -58,7 +55,6 @@ import com.liferay.portal.kernel.portlet.PortletQNameUtil;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -2689,22 +2685,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		_updatePortletCategory(portletCategory, companyPortletModel);
 
-		if (StartupHelperUtil.isDBWarmed()) {
-			checkPortlet(companyPortletModel);
-		}
-		else {
-			DependencyManagerSyncUtil.registerSyncCallable(
-				() -> {
-					try (SafeCloseable safeCloseable =
-							CompanyThreadLocal.setWithSafeCloseable(
-								companyId)) {
-
-						portletLocalService.checkPortlet(companyPortletModel);
-					}
-
-					return null;
-				});
-		}
+		checkPortlet(companyPortletModel);
 	}
 
 	private Configuration _getConfiguration(PortletApp portletApp) {

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourceActionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourceActionLocalServiceImpl.java
@@ -30,13 +30,13 @@ import com.liferay.portal.kernel.service.persistence.ResourcePermissionPersisten
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
+import com.liferay.portal.security.permission.ResourceActionsCache;
 import com.liferay.portal.service.base.ResourceActionLocalServiceBaseImpl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Brian Wing Shun Chan
@@ -353,7 +353,7 @@ public class ResourceActionLocalServiceImpl
 		ResourceActionLocalServiceImpl.class);
 
 	private static final Map<String, ResourceAction> _resourceActions =
-		new ConcurrentHashMap<>();
+		ResourceActionsCache.getResourceActionsMap();
 
 	@BeanReference(type = CompanyLocalService.class)
 	private CompanyLocalService _companyLocalService;

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -1202,11 +1202,6 @@ public class ResourcePermissionLocalServiceImpl
 			portlet.getCompanyId(), portlet.getRootPortletId(), guestRole,
 			ownerRole, siteMemberRole, guestPortletActions,
 			ownerPortletActionIds, groupPortletActionIds);
-
-		populateDefaultModelResourcePermissions(
-			portlet.getCompanyId(),
-			ResourceActionsUtil.getPortletModelResources(
-				portlet.getRootPortletId()));
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -71,7 +71,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -1204,43 +1203,10 @@ public class ResourcePermissionLocalServiceImpl
 			ownerRole, siteMemberRole, guestPortletActions,
 			ownerPortletActionIds, groupPortletActionIds);
 
-		String rootModelResource =
-			ResourceActionsUtil.getPortletRootModelResource(
-				portlet.getRootPortletId());
-
-		List<String> modelResources =
+		populateDefaultModelResourcePermissions(
+			portlet.getCompanyId(),
 			ResourceActionsUtil.getPortletModelResources(
-				portlet.getRootPortletId());
-
-		for (String modelResource : modelResources) {
-			if (Validator.isBlank(modelResource)) {
-				continue;
-			}
-
-			validate(modelResource, false);
-
-			List<String> groupModelActionIds = null;
-
-			if (Objects.equals(rootModelResource, modelResource)) {
-				groupModelActionIds =
-					ResourceActionsUtil.getModelResourceGroupDefaultActions(
-						rootModelResource);
-			}
-
-			List<String> guestModelActionIds =
-				ResourceActionsUtil.getModelResourceGuestDefaultActions(
-					modelResource);
-
-			List<String> ownerModelActionIds =
-				ResourceActionsUtil.getModelResourceActions(modelResource);
-
-			filterOwnerActions(modelResource, ownerModelActionIds);
-
-			_initPortletDefaultPermissions(
-				portlet.getCompanyId(), modelResource, guestRole, ownerRole,
-				siteMemberRole, guestModelActionIds, ownerModelActionIds,
-				groupModelActionIds);
-		}
+				portlet.getRootPortletId()));
 	}
 
 	/**
@@ -1278,6 +1244,48 @@ public class ResourcePermissionLocalServiceImpl
 		}
 
 		_roleLocalService.deleteRole(fromRoleId);
+	}
+
+	public void populateDefaultModelResourcePermissions(
+			long companyId, Collection<String> modelResourceNames)
+		throws PortalException {
+
+		Role guestRole = _roleLocalService.getRole(
+			companyId, RoleConstants.GUEST);
+		Role ownerRole = _roleLocalService.getRole(
+			companyId, RoleConstants.OWNER);
+		Role siteMemberRole = _roleLocalService.getRole(
+			companyId, RoleConstants.SITE_MEMBER);
+
+		for (String modelResourceName : modelResourceNames) {
+			if (Validator.isBlank(modelResourceName)) {
+				continue;
+			}
+
+			validate(modelResourceName, false);
+
+			List<String> groupModelActionIds = null;
+
+			if (_isRootModelResource(modelResourceName)) {
+				groupModelActionIds =
+					ResourceActionsUtil.getModelResourceGroupDefaultActions(
+						modelResourceName);
+			}
+
+			List<String> guestModelActionIds =
+				ResourceActionsUtil.getModelResourceGuestDefaultActions(
+					modelResourceName);
+
+			List<String> ownerModelActionIds =
+				ResourceActionsUtil.getModelResourceActions(modelResourceName);
+
+			filterOwnerActions(modelResourceName, ownerModelActionIds);
+
+			_initPortletDefaultPermissions(
+				companyId, modelResourceName, guestRole, ownerRole,
+				siteMemberRole, guestModelActionIds, ownerModelActionIds,
+				groupModelActionIds);
+		}
 	}
 
 	/**
@@ -2106,6 +2114,22 @@ public class ResourcePermissionLocalServiceImpl
 				IndexWriterHelperUtil.updatePermissionFields(name, name);
 			}
 		}
+	}
+
+	private boolean _isRootModelResource(String modelResourceName) {
+		List<String> portletNames =
+			ResourceActionsUtil.getModelPortletResources(modelResourceName);
+
+		for (String portletName : portletNames) {
+			if (modelResourceName.equals(
+					ResourceActionsUtil.getPortletRootModelResource(
+						portletName))) {
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private boolean _matches(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
@@ -733,6 +733,10 @@ public interface ResourcePermissionLocalService
 	public void mergePermissions(long fromRoleId, long toRoleId)
 		throws PortalException;
 
+	public void populateDefaultModelResourcePermissions(
+			long companyId, Collection<String> modelResourceNames)
+		throws PortalException;
+
 	/**
 	 * Grants the role default permissions to all the resources of the type and
 	 * at the scope stored in the resource permission, deletes the resource

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
@@ -836,6 +836,14 @@ public class ResourcePermissionLocalServiceUtil {
 		getService().mergePermissions(fromRoleId, toRoleId);
 	}
 
+	public static void populateDefaultModelResourcePermissions(
+			long companyId, java.util.Collection<String> modelResourceNames)
+		throws PortalException {
+
+		getService().populateDefaultModelResourcePermissions(
+			companyId, modelResourceNames);
+	}
+
 	/**
 	 * Grants the role default permissions to all the resources of the type and
 	 * at the scope stored in the resource permission, deletes the resource

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
@@ -914,6 +914,15 @@ public class ResourcePermissionLocalServiceWrapper
 		_resourcePermissionLocalService.mergePermissions(fromRoleId, toRoleId);
 	}
 
+	@Override
+	public void populateDefaultModelResourcePermissions(
+			long companyId, java.util.Collection<String> modelResourceNames)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_resourcePermissionLocalService.populateDefaultModelResourcePermissions(
+			companyId, modelResourceNames);
+	}
+
 	/**
 	 * Grants the role default permissions to all the resources of the type and
 	 * at the scope stored in the resource permission, deletes the resource


### PR DESCRIPTION
- **LPD-21621 Only create ResourceActionsBag when populating or getting portlet supported actions (for default actions)**
- **LPD-21827 Centralize all the in-memory maps for resource actions to implement cascade removal. When an action is removed from the DB cache map, it should also be removed from the bag map.**
- **Revert "LPD-20793 For cold db, postpone remote portlet deployment checking to the end of startup."**
- **LPD-20946 Move logic to a public method and avoid directly using portlet id, prepare for next**
- **LPD-20946 Build service**
- **LPD-20946 Populate model resource permissions during reading from xml documents, after checking the resource actions**
- **LPD-20946 Also populate existing model resource permissions when checking company (model listener is too early)**
- **LPD-20946 No longer need to populate model resource permisssion during portlet deployment**
- **LPD-20946 Avoid populating permissions when upgrade process is running**
