### PR TITLE
LPD 20946 5 17

### DIFF
--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -1361,7 +1361,8 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 		notificationQueueEntryLocalService.deleteNotificationQueueEntry(
 			notificationQueueEntries.get(0));
 
-		objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	private static Map<String, Object> _freeMarkerTermValues;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
@@ -79,7 +79,7 @@ public class ObjectEntryEntityModelTest {
 
 		for (ObjectDefinition objectDefinition : _objectDefinitions) {
 			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition);
+				objectDefinition.getObjectDefinitionId());
 		}
 
 		_serviceTrackerMap.close();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -136,11 +136,11 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		}
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition1);
+			_objectDefinition1.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition2);
+			_objectDefinition2.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition3);
+			_objectDefinition3.getObjectDefinitionId());
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -825,21 +825,21 @@ public class ObjectEntryResourceTest {
 		}
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition1);
+			_objectDefinition1.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition2);
+			_objectDefinition2.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition3);
+			_objectDefinition3.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition4);
+			_objectDefinition4.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition5);
+			_objectDefinition5.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition6);
+			_objectDefinition6.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_siteScopedObjectDefinition1);
+			_siteScopedObjectDefinition1.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_siteScopedObjectDefinition2);
+			_siteScopedObjectDefinition2.getObjectDefinitionId());
 
 		_listTypeDefinitionLocalService.deleteListTypeDefinition(
 			_listTypeDefinition);
@@ -5788,7 +5788,8 @@ public class ObjectEntryResourceTest {
 			PrincipalThreadLocal.setName(originalName);
 		}
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		_listTypeDefinitionLocalService.deleteListTypeDefinition(
 			listTypeDefinition);
@@ -6442,7 +6443,8 @@ public class ObjectEntryResourceTest {
 		_assertItem(1, jsonObject, "autoIncrement", "90-private");
 		_assertItem(2, jsonObject, "autoIncrement", "10-private");
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/model/listener/test/GroupModelListenerTest.java
@@ -85,9 +85,9 @@ public class GroupModelListenerTest {
 			_objectRelationship);
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition1);
+			_objectDefinition1.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition2);
+			_objectDefinition2.getObjectDefinitionId());
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v9_2_0/test/ObjectDefinitionUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v9_2_0/test/ObjectDefinitionUpgradeProcessTest.java
@@ -58,7 +58,8 @@ public class ObjectDefinitionUpgradeProcessTest {
 
 	@After
 	public void tearDown() throws Exception {
-		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			_objectDefinition.getObjectDefinitionId());
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
@@ -441,7 +441,7 @@ public class ObjectRelatedModelsProviderTest {
 			_objectRelationship);
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			scopeSiteObjectDefinition);
+			scopeSiteObjectDefinition.getObjectDefinitionId());
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -197,7 +197,8 @@ public class ObjectActionLocalServiceTest {
 				0, ObjectActionExecutorConstants.KEY_GROOVY),
 			"_objectScriptingExecutor", _originalObjectScriptingExecutor);
 
-		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			_objectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -791,11 +792,11 @@ public class ObjectActionLocalServiceTest {
 				objectDefinitionA.getObjectDefinitionId());
 
 			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinitionA);
+				objectDefinitionA.getObjectDefinitionId());
 			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinitionAA);
+				objectDefinitionAA.getObjectDefinitionId());
 			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinitionAAA);
+				objectDefinitionAAA.getObjectDefinitionId());
 		}
 		finally {
 			PermissionThreadLocal.setPermissionChecker(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -175,7 +175,8 @@ public class ObjectDefinitionLocalServiceTest {
 			ObjectDefinitionNameException.MustNotBeDuplicate.class,
 			"Duplicate name C_Test", () -> _addCustomObjectDefinition("Test"));
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		AssertUtils.assertFailure(
 			ObjectDefinitionNameException.MustNotBeNull.class, "Name is null",
@@ -526,7 +527,8 @@ public class ObjectDefinitionLocalServiceTest {
 				WorkflowConstants.STATUS_APPROVED,
 				nodeObjectDefinition.getStatus()));
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		TreeTestUtil.deleteObjectDefinitionHierarchy(
 			_objectDefinitionLocalService,
@@ -576,7 +578,8 @@ public class ObjectDefinitionLocalServiceTest {
 			_defaultObjectFolder.getObjectFolderId(),
 			objectDefinition.getObjectFolderId());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		// Add object definition to an existing object folder
 
@@ -589,7 +592,8 @@ public class ObjectDefinitionLocalServiceTest {
 			objectFolder.getObjectFolderId(),
 			objectDefinition.getObjectFolderId());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		_objectFolderLocalService.deleteObjectFolder(objectFolder);
 	}
@@ -944,7 +948,8 @@ public class ObjectDefinitionLocalServiceTest {
 				objectDefinition.getObjectDefinitionId(), "updateDeliveryType2",
 				ObjectActionTriggerConstants.KEY_ON_AFTER_ADD));
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -1021,7 +1026,8 @@ public class ObjectDefinitionLocalServiceTest {
 			"Duplicate name Test",
 			() -> _addUnmodifiableSystemObjectDefinition("Test"));
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		AssertUtils.assertFailure(
 			ObjectDefinitionNameException.MustNotBeNull.class, "Name is null",
@@ -1198,7 +1204,8 @@ public class ObjectDefinitionLocalServiceTest {
 
 		Assert.assertTrue(objectDefinition.isApproved());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		// Publish modifiable system object definition
 
@@ -1238,7 +1245,8 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertTrue(
 			_hasTable(objectDefinition.getExtensionDBTableName()));
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		objectDefinition =
 			ObjectDefinitionTestUtil.addUnmodifiableSystemObjectDefinition(
@@ -1265,7 +1273,8 @@ public class ObjectDefinitionLocalServiceTest {
 			Assert.assertNotNull(objectDefinitionStatusException);
 		}
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -1423,7 +1432,7 @@ public class ObjectDefinitionLocalServiceTest {
 			"Object definitions that belong to a hierarchical structure " +
 				"cannot be deleted",
 			() -> _objectDefinitionLocalService.deleteObjectDefinition(
-				finalObjectDefinition));
+				finalObjectDefinition.getObjectDefinitionId()));
 
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
 			TestPropsValues.getUserId(),
@@ -1555,7 +1564,8 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertTrue(objectDefinition.isAccountEntryRestricted());
 		Assert.assertFalse(objectDefinition.isSystem());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		AssertUtils.assertFailure(
 			ObjectDefinitionAccountEntryRestrictedException.class,
@@ -1661,7 +1671,8 @@ public class ObjectDefinitionLocalServiceTest {
 			objectField.getObjectFieldId());
 		Assert.assertTrue(objectDefinition.isAccountEntryRestricted());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -1690,7 +1701,8 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertTrue(objectDefinition.isAccountEntryRestricted());
 		Assert.assertFalse(objectDefinition.isSystem());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		AssertUtils.assertFailure(
 			ObjectDefinitionAccountEntryRestrictedException.class,
@@ -1753,9 +1765,9 @@ public class ObjectDefinitionLocalServiceTest {
 		}
 		finally {
 			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition2);
+				objectDefinition2.getObjectDefinitionId());
 			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition3);
+				objectDefinition3.getObjectDefinitionId());
 		}
 	}
 
@@ -1773,7 +1785,8 @@ public class ObjectDefinitionLocalServiceTest {
 
 		_testSystemObjectFields(objectDefinition);
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		objectDefinition =
 			ObjectDefinitionTestUtil.addUnmodifiableSystemObjectDefinition(
@@ -1787,7 +1800,8 @@ public class ObjectDefinitionLocalServiceTest {
 
 		_testSystemObjectFields(objectDefinition);
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -2025,7 +2039,8 @@ public class ObjectDefinitionLocalServiceTest {
 		_testUpdateCustomObjectDefinitionThrowsObjectFieldRelationshipTypeException(
 			objectDefinition);
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		_objectFolderLocalService.deleteObjectFolder(objectFolder);
 	}
@@ -2060,9 +2075,9 @@ public class ObjectDefinitionLocalServiceTest {
 			"L_TEST_ERC");
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			customObjectDefinition);
+			customObjectDefinition.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			unmodifiableSystemObjectDefinition);
+			unmodifiableSystemObjectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -2084,7 +2099,8 @@ public class ObjectDefinitionLocalServiceTest {
 			objectFolder.getObjectFolderId(),
 			objectDefinition.getObjectFolderId());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		_objectFolderLocalService.deleteObjectFolder(objectFolder);
 	}
@@ -2107,8 +2123,10 @@ public class ObjectDefinitionLocalServiceTest {
 				objectDefinition1.getObjectDefinitionId(),
 				objectDefinition2.getObjectDefinitionId()));
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition2);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition1.getObjectDefinitionId());
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition2.getObjectDefinitionId());
 	}
 
 	@Test
@@ -2184,7 +2202,8 @@ public class ObjectDefinitionLocalServiceTest {
 				null, false, null, ObjectDefinitionConstants.SCOPE_SITE,
 				objectDefinition1.getStatus()));
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition1.getObjectDefinitionId());
 
 		// After update, a modifiable system object definition check its
 		// properties
@@ -2232,7 +2251,8 @@ public class ObjectDefinitionLocalServiceTest {
 			LocalizedMapUtil.getLocalizedMap("Charlies"),
 			objectDefinition2.getPluralLabelMap());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition2);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition2.getObjectDefinitionId());
 
 		// After update, an unmodifiable system object definition check its
 		// properties
@@ -2280,7 +2300,8 @@ public class ObjectDefinitionLocalServiceTest {
 			objectField.getObjectFieldId(),
 			objectDefinition2.getTitleObjectFieldId());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition2);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition2.getObjectDefinitionId());
 
 		_objectFolderLocalService.deleteObjectFolder(objectFolder);
 	}
@@ -2326,7 +2347,8 @@ public class ObjectDefinitionLocalServiceTest {
 			objectField.getObjectFieldId(),
 			objectDefinition.getTitleObjectFieldId());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	private ObjectDefinition _addCustomObjectDefinition(String name)
@@ -2554,7 +2576,8 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_DRAFT, objectDefinition.getStatus());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		_objectFolderLocalService.deleteObjectFolder(objectFolder);
 	}
@@ -2798,7 +2821,7 @@ public class ObjectDefinitionLocalServiceTest {
 			//	objectRelationship);
 
 			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition2);
+				objectDefinition2.getObjectDefinitionId());
 		}
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionServiceTest.java
@@ -418,7 +418,7 @@ public class ObjectDefinitionServiceTest {
 		finally {
 			if (objectDefinition != null) {
 				_objectDefinitionLocalService.deleteObjectDefinition(
-					objectDefinition);
+					objectDefinition.getObjectDefinitionId());
 			}
 		}
 	}
@@ -437,7 +437,7 @@ public class ObjectDefinitionServiceTest {
 		finally {
 			if (objectDefinition != null) {
 				_objectDefinitionLocalService.deleteObjectDefinition(
-					objectDefinition);
+					objectDefinition.getObjectDefinitionId());
 			}
 		}
 	}
@@ -455,7 +455,7 @@ public class ObjectDefinitionServiceTest {
 		finally {
 			if (objectDefinition != null) {
 				_objectDefinitionLocalService.deleteObjectDefinition(
-					objectDefinition);
+					objectDefinition.getObjectDefinitionId());
 			}
 		}
 	}
@@ -476,7 +476,7 @@ public class ObjectDefinitionServiceTest {
 		finally {
 			if (deleteObjectDefinition == null) {
 				_objectDefinitionLocalService.deleteObjectDefinition(
-					objectDefinition);
+					objectDefinition.getObjectDefinitionId());
 			}
 		}
 	}
@@ -494,7 +494,7 @@ public class ObjectDefinitionServiceTest {
 		finally {
 			if (objectDefinition != null) {
 				_objectDefinitionLocalService.deleteObjectDefinition(
-					objectDefinition);
+					objectDefinition.getObjectDefinitionId());
 			}
 		}
 	}
@@ -513,7 +513,7 @@ public class ObjectDefinitionServiceTest {
 		finally {
 			if (objectDefinition != null) {
 				_objectDefinitionLocalService.deleteObjectDefinition(
-					objectDefinition);
+					objectDefinition.getObjectDefinitionId());
 			}
 		}
 	}
@@ -537,7 +537,7 @@ public class ObjectDefinitionServiceTest {
 		finally {
 			if (objectDefinition != null) {
 				_objectDefinitionLocalService.deleteObjectDefinition(
-					objectDefinition);
+					objectDefinition.getObjectDefinitionId());
 			}
 		}
 	}
@@ -561,7 +561,7 @@ public class ObjectDefinitionServiceTest {
 						objectDefinition.getObjectDefinitionId(), 0);
 
 				_objectDefinitionLocalService.deleteObjectDefinition(
-					objectDefinition);
+					objectDefinition.getObjectDefinitionId());
 			}
 		}
 	}
@@ -582,7 +582,7 @@ public class ObjectDefinitionServiceTest {
 		finally {
 			if (objectDefinition != null) {
 				_objectDefinitionLocalService.deleteObjectDefinition(
-					objectDefinition);
+					objectDefinition.getObjectDefinitionId());
 			}
 		}
 	}
@@ -615,7 +615,7 @@ public class ObjectDefinitionServiceTest {
 		finally {
 			if (objectDefinition != null) {
 				_objectDefinitionLocalService.deleteObjectDefinition(
-					objectDefinition);
+					objectDefinition.getObjectDefinitionId());
 			}
 		}
 	}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
@@ -582,7 +582,7 @@ public class ObjectEntryLocalServiceSearchObjectEntriesTest {
 	private void _testAttachment(ObjectField objectField) throws Exception {
 		if (_objectDefinition != null) {
 			_objectDefinitionLocalService.deleteObjectDefinition(
-				_objectDefinition);
+				_objectDefinition.getObjectDefinitionId());
 		}
 
 		_addObjectDefinition(objectField);
@@ -620,7 +620,7 @@ public class ObjectEntryLocalServiceSearchObjectEntriesTest {
 
 		if (_objectDefinition != null) {
 			_objectDefinitionLocalService.deleteObjectDefinition(
-				_objectDefinition);
+				_objectDefinition.getObjectDefinitionId());
 		}
 
 		_addObjectDefinition(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -437,7 +437,8 @@ public class ObjectEntryLocalServiceTest {
 		// reference a required list type entry cannot be deleted before it is
 		// unreferenced
 
-		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			_objectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -822,7 +823,8 @@ public class ObjectEntryLocalServiceTest {
 					).build()
 				).build()));
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -2309,9 +2311,9 @@ public class ObjectEntryLocalServiceTest {
 		_assertCount(0);
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			draftObjectDefinition);
+			draftObjectDefinition.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			publishedObjectDefinition);
+			publishedObjectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -3830,7 +3832,8 @@ public class ObjectEntryLocalServiceTest {
 			Assert.assertEquals(1, baseModelSearchResult.getLength());
 		}
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	private void _testUpdateObjectEntryExternalReferenceCode()

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -466,8 +466,10 @@ public class ObjectFieldLocalServiceTest {
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition2);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition1.getObjectDefinitionId());
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition2.getObjectDefinitionId());
 
 		String[] reservedNames = {
 			"actions", "companyId", "createDate", "creator", "dateCreated",
@@ -990,9 +992,10 @@ public class ObjectFieldLocalServiceTest {
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			relatedObjectDefinition);
+			objectDefinition.getObjectDefinitionId());
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			relatedObjectDefinition.getObjectDefinitionId());
 
 		objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
 			_objectRelationshipLocalService,
@@ -1108,7 +1111,7 @@ public class ObjectFieldLocalServiceTest {
 		}
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			modifiableSystemObjectDefinition);
+			modifiableSystemObjectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -1292,7 +1295,7 @@ public class ObjectFieldLocalServiceTest {
 				"able", Collections.emptyList()));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			modifiableSystemObjectDefinition);
+			modifiableSystemObjectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -1512,9 +1515,9 @@ public class ObjectFieldLocalServiceTest {
 		_assertDeleteObjectField(true, systemObjectDefinition, "baker");
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			customObjectDefinition);
+			customObjectDefinition.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			systemObjectDefinition);
+			systemObjectDefinition.getObjectDefinitionId());
 
 		// Delete system object field from modifiable system object definition
 
@@ -1567,7 +1570,7 @@ public class ObjectFieldLocalServiceTest {
 			true, modifiableSystemObjectDefinition, "able");
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			modifiableSystemObjectDefinition);
+			modifiableSystemObjectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -1774,7 +1777,8 @@ public class ObjectFieldLocalServiceTest {
 						"-private"
 					).build())));
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		// Business type integer
 
@@ -1975,7 +1979,8 @@ public class ObjectFieldLocalServiceTest {
 				ObjectFieldSettingConstants.NAME_SHOW_COUNTER, "false"
 			).build());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	@Test
@@ -2039,8 +2044,10 @@ public class ObjectFieldLocalServiceTest {
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition2);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition1.getObjectDefinitionId());
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition2.getObjectDefinitionId());
 	}
 
 	private void _addCustomObjectDefinitionWithAutoIncrementObjectField(
@@ -2725,7 +2732,8 @@ public class ObjectFieldLocalServiceTest {
 					objectDefinition1.getObjectDefinitionId(),
 					ObjectFieldConstants.READ_ONLY_TRUE, null)));
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition1.getObjectDefinitionId());
 	}
 
 	private void _testAddOrUpdateCustomObjectField(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFolderItemLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFolderItemLocalServiceTest.java
@@ -154,7 +154,8 @@ public class ObjectFolderItemLocalServiceTest {
 			new Long[] {objectDefinition.getObjectDefinitionId()},
 			objectFolder.getObjectFolderId());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		_objectFolderLocalService.deleteObjectFolder(objectFolder);
 
@@ -194,7 +195,8 @@ public class ObjectFolderItemLocalServiceTest {
 			},
 			objectFolder.getObjectFolderId());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 
 		_objectFolderLocalService.deleteObjectFolder(objectFolder);
 	}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -99,7 +99,7 @@ public class ObjectRelationshipLocalServiceTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_systemObjectDefinition1);
+			_systemObjectDefinition1.getObjectDefinitionId());
 	}
 
 	@Before
@@ -1093,7 +1093,7 @@ public class ObjectRelationshipLocalServiceTest {
 		Assert.assertFalse(_hasTable(objectRelationship.getDBTableName()));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			relatedObjectDefinition);
+			relatedObjectDefinition.getObjectDefinitionId());
 	}
 
 	private void _testSystemObjectRelationshipOneToMany() throws Exception {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
@@ -789,7 +789,8 @@ public class ObjectViewLocalServiceTest {
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship.getObjectRelationshipId());
 
-		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition1.getObjectDefinitionId());
 	}
 
 	@Inject

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -734,8 +734,16 @@ public class ResourceActionsImpl implements ResourceActions {
 		Set<String> modelResourceNames) {
 
 		for (String modelResourceName : modelResourceNames) {
-			_checkResourceActions(
-				getModelResourceActions(modelResourceName), modelResourceName);
+			try {
+				DBPartitionUtil.forEachCompanyId(
+					companyId ->
+						resourceActionLocalService.checkResourceActions(
+							modelResourceName,
+							getModelResourceActions(modelResourceName)));
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -13,6 +13,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.ResourceActionsException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -21,6 +22,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
@@ -598,7 +600,7 @@ public class ResourceActionsImpl implements ResourceActions {
 	}
 
 	@Override
-	public void removeModelResources(Document document) {
+	public void removeModelResources(Document document) throws PortalException {
 		Element rootElement = document.getRootElement();
 
 		for (Element modelResourceElement :
@@ -659,6 +661,14 @@ public class ResourceActionsImpl implements ResourceActions {
 			_modelResourceWeights.remove(modelName);
 
 			_portalModelResources.remove(modelName);
+
+			String permissionName = modelName;
+
+			companyLocalService.forEachCompanyId(
+				companyId ->
+					resourcePermissionLocalService.deleteResourcePermissions(
+						companyId, permissionName,
+						ResourceConstants.SCOPE_INDIVIDUAL, permissionName));
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -455,11 +455,7 @@ public class ResourceActionsImpl implements ResourceActions {
 		}
 
 		if (checkResourceActions) {
-			for (String modelResourceName : modelResourceNames) {
-				_checkResourceActions(
-					getModelResourceActions(modelResourceName),
-					modelResourceName);
-			}
+			_checkModelResourcesResourceActions(modelResourceNames);
 		}
 	}
 
@@ -483,10 +479,7 @@ public class ResourceActionsImpl implements ResourceActions {
 
 		_readModelResources(document.getRootElement(), modelResourceNames);
 
-		for (String modelResourceName : modelResourceNames) {
-			_checkResourceActions(
-				getModelResourceActions(modelResourceName), modelResourceName);
-		}
+		_checkModelResourcesResourceActions(modelResourceNames);
 	}
 
 	@Override
@@ -734,6 +727,15 @@ public class ResourceActionsImpl implements ResourceActions {
 			if (guestUnsupportedActions.contains(actionId)) {
 				iterator.remove();
 			}
+		}
+	}
+
+	private void _checkModelResourcesResourceActions(
+		Set<String> modelResourceNames) {
+
+		for (String modelResourceName : modelResourceNames) {
+			_checkResourceActions(
+				getModelResourceActions(modelResourceName), modelResourceName);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -29,10 +29,12 @@ import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -683,11 +685,17 @@ public class ResourceActionsImpl implements ResourceActions {
 		}
 	}
 
+	@BeanReference(type = CompanyLocalService.class)
+	protected CompanyLocalService companyLocalService;
+
 	@BeanReference(type = PortletLocalService.class)
 	protected PortletLocalService portletLocalService;
 
 	@BeanReference(type = ResourceActionLocalService.class)
 	protected ResourceActionLocalService resourceActionLocalService;
+
+	@BeanReference(type = ResourcePermissionLocalService.class)
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
 
 	@BeanReference(type = RoleLocalService.class)
 	protected RoleLocalService roleLocalService;
@@ -742,6 +750,12 @@ public class ResourceActionsImpl implements ResourceActions {
 							getModelResourceActions(modelResourceName));
 					}
 				});
+
+			companyLocalService.forEachCompanyId(
+				companyId ->
+					resourcePermissionLocalService.
+						populateDefaultModelResourcePermissions(
+							companyId, modelResourceNames));
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -733,17 +733,18 @@ public class ResourceActionsImpl implements ResourceActions {
 	private void _checkModelResourcesResourceActions(
 		Set<String> modelResourceNames) {
 
-		for (String modelResourceName : modelResourceNames) {
-			try {
-				DBPartitionUtil.forEachCompanyId(
-					companyId ->
+		try {
+			DBPartitionUtil.forEachCompanyId(
+				companyId -> {
+					for (String modelResourceName : modelResourceNames) {
 						resourceActionLocalService.checkResourceActions(
 							modelResourceName,
-							getModelResourceActions(modelResourceName)));
-			}
-			catch (Exception exception) {
-				throw new RuntimeException(exception);
-			}
+							getModelResourceActions(modelResourceName));
+					}
+				});
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -12,8 +12,10 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.ResourceActionsException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -70,6 +72,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -761,11 +764,23 @@ public class ResourceActionsImpl implements ResourceActions {
 					}
 				});
 
-			companyLocalService.forEachCompanyId(
-				companyId ->
-					resourcePermissionLocalService.
-						populateDefaultModelResourcePermissions(
-							companyId, modelResourceNames));
+			Callable<?> callable = () -> {
+				companyLocalService.forEachCompanyId(
+					companyId ->
+						resourcePermissionLocalService.
+							populateDefaultModelResourcePermissions(
+								companyId, modelResourceNames));
+
+				return null;
+			};
+
+			if (StartupHelperUtil.isUpgrading()) {
+				DependencyManagerSyncUtil.registerSyncCallable(callable);
+
+				return;
+			}
+
+			callable.call();
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -74,6 +74,7 @@ import com.liferay.portal.kernel.search.facet.faceted.searcher.FacetedSearcherMa
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.EmailAddressValidator;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
@@ -83,6 +84,7 @@ import com.liferay.portal.kernel.service.PasswordPolicyLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
@@ -2177,6 +2179,13 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			_passwordPolicyLocalService.checkDefaultPasswordPolicy(
 				company.getCompanyId());
 
+			// Default Permissions
+
+			_resourcePermissionLocalService.
+				populateDefaultModelResourcePermissions(
+					company.getCompanyId(),
+					ResourceActionsUtil.getModelNames());
+
 			// Portlets
 
 			_portletLocalService.checkPortlets(company.getCompanyId());
@@ -2439,6 +2448,9 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 	@BeanReference(type = ResourceActionLocalService.class)
 	private ResourceActionLocalService _resourceActionLocalService;
+
+	@BeanReference(type = ResourcePermissionLocalService.class)
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 	@BeanReference(type = RoleLocalService.class)
 	private RoleLocalService _roleLocalService;

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
 import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
@@ -2181,10 +2182,12 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 			// Default Permissions
 
-			_resourcePermissionLocalService.
-				populateDefaultModelResourcePermissions(
-					company.getCompanyId(),
-					ResourceActionsUtil.getModelNames());
+			if (!StartupHelperUtil.isUpgrading()) {
+				_resourcePermissionLocalService.
+					populateDefaultModelResourcePermissions(
+						company.getCompanyId(),
+						ResourceActionsUtil.getModelNames());
+			}
 
 			// Portlets
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RequiredCompanyException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.instance.lifecycle.PortalInstanceLifecycleManager;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -1476,6 +1477,12 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		String[] systemGroups = PortalUtil.getSystemGroups();
 
 		for (String groupName : systemGroups) {
+			if (groupName.equals(GroupConstants.CMS) &&
+				!FeatureFlagManagerUtil.isEnabled("LPD-17809")) {
+
+				continue;
+			}
+
 			deleteGroupActionableDynamicQuery.deleteGroup(
 				_groupLocalService.getGroup(companyId, groupName));
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -8,19 +8,16 @@ package com.liferay.portal.service.impl;
 import com.liferay.admin.kernel.util.PortalMyAccountApplicationType;
 import com.liferay.expando.kernel.model.CustomAttributesDisplay;
 import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.ConfigurationFactoryImpl;
-import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.application.type.ApplicationType;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
-import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.PortletIdException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -58,7 +55,6 @@ import com.liferay.portal.kernel.portlet.PortletQNameUtil;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -2689,22 +2685,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		_updatePortletCategory(portletCategory, companyPortletModel);
 
-		if (StartupHelperUtil.isDBWarmed()) {
-			checkPortlet(companyPortletModel);
-		}
-		else {
-			DependencyManagerSyncUtil.registerSyncCallable(
-				() -> {
-					try (SafeCloseable safeCloseable =
-							CompanyThreadLocal.setWithSafeCloseable(
-								companyId)) {
-
-						portletLocalService.checkPortlet(companyPortletModel);
-					}
-
-					return null;
-				});
-		}
+		checkPortlet(companyPortletModel);
 	}
 
 	private Configuration _getConfiguration(PortletApp portletApp) {

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -1202,11 +1202,6 @@ public class ResourcePermissionLocalServiceImpl
 			portlet.getCompanyId(), portlet.getRootPortletId(), guestRole,
 			ownerRole, siteMemberRole, guestPortletActions,
 			ownerPortletActionIds, groupPortletActionIds);
-
-		populateDefaultModelResourcePermissions(
-			portlet.getCompanyId(),
-			ResourceActionsUtil.getPortletModelResources(
-				portlet.getRootPortletId()));
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -71,7 +71,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -1204,10 +1203,6 @@ public class ResourcePermissionLocalServiceImpl
 			ownerRole, siteMemberRole, guestPortletActions,
 			ownerPortletActionIds, groupPortletActionIds);
 
-		String rootModelResource =
-			ResourceActionsUtil.getPortletRootModelResource(
-				portlet.getRootPortletId());
-
 		List<String> modelResources =
 			ResourceActionsUtil.getPortletModelResources(
 				portlet.getRootPortletId());
@@ -1221,10 +1216,10 @@ public class ResourcePermissionLocalServiceImpl
 
 			List<String> groupModelActionIds = null;
 
-			if (Objects.equals(rootModelResource, modelResource)) {
+			if (ResourceActionsUtil.isRootModelResource(modelResource)) {
 				groupModelActionIds =
 					ResourceActionsUtil.getModelResourceGroupDefaultActions(
-						rootModelResource);
+						modelResource);
 			}
 
 			List<String> guestModelActionIds =

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -1203,39 +1203,10 @@ public class ResourcePermissionLocalServiceImpl
 			ownerRole, siteMemberRole, guestPortletActions,
 			ownerPortletActionIds, groupPortletActionIds);
 
-		List<String> modelResources =
+		populateDefaultModelResourcePermissions(
+			portlet.getCompanyId(),
 			ResourceActionsUtil.getPortletModelResources(
-				portlet.getRootPortletId());
-
-		for (String modelResource : modelResources) {
-			if (Validator.isBlank(modelResource)) {
-				continue;
-			}
-
-			validate(modelResource, false);
-
-			List<String> groupModelActionIds = null;
-
-			if (ResourceActionsUtil.isRootModelResource(modelResource)) {
-				groupModelActionIds =
-					ResourceActionsUtil.getModelResourceGroupDefaultActions(
-						modelResource);
-			}
-
-			List<String> guestModelActionIds =
-				ResourceActionsUtil.getModelResourceGuestDefaultActions(
-					modelResource);
-
-			List<String> ownerModelActionIds =
-				ResourceActionsUtil.getModelResourceActions(modelResource);
-
-			filterOwnerActions(modelResource, ownerModelActionIds);
-
-			_initPortletDefaultPermissions(
-				portlet.getCompanyId(), modelResource, guestRole, ownerRole,
-				siteMemberRole, guestModelActionIds, ownerModelActionIds,
-				groupModelActionIds);
-		}
+				portlet.getRootPortletId()));
 	}
 
 	/**
@@ -1273,6 +1244,48 @@ public class ResourcePermissionLocalServiceImpl
 		}
 
 		_roleLocalService.deleteRole(fromRoleId);
+	}
+
+	@Override
+	public void populateDefaultModelResourcePermissions(
+			long companyId, Collection<String> modelResources)
+		throws PortalException {
+
+		Role guestRole = _roleLocalService.getRole(
+			companyId, RoleConstants.GUEST);
+		Role ownerRole = _roleLocalService.getRole(
+			companyId, RoleConstants.OWNER);
+		Role siteMemberRole = _roleLocalService.getRole(
+			companyId, RoleConstants.SITE_MEMBER);
+
+		for (String modelResource : modelResources) {
+			if (Validator.isBlank(modelResource)) {
+				continue;
+			}
+
+			validate(modelResource, false);
+
+			List<String> groupModelActionIds = null;
+
+			if (ResourceActionsUtil.isRootModelResource(modelResource)) {
+				groupModelActionIds =
+					ResourceActionsUtil.getModelResourceGroupDefaultActions(
+						modelResource);
+			}
+
+			List<String> guestModelActionIds =
+				ResourceActionsUtil.getModelResourceGuestDefaultActions(
+					modelResource);
+
+			List<String> ownerModelActionIds =
+				ResourceActionsUtil.getModelResourceActions(modelResource);
+
+			filterOwnerActions(modelResource, ownerModelActionIds);
+
+			_initPortletDefaultPermissions(
+				companyId, modelResource, guestRole, ownerRole, siteMemberRole,
+				guestModelActionIds, ownerModelActionIds, groupModelActionIds);
+		}
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.kernel.security.permission;
 
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.ResourceActionsException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
@@ -121,7 +122,7 @@ public interface ResourceActions {
 
 	public void removeModelResource(String name, String action);
 
-	public void removeModelResources(Document document);
+	public void removeModelResources(Document document) throws PortalException;
 
 	public void removePortletResources(Document document);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
@@ -733,6 +733,10 @@ public interface ResourcePermissionLocalService
 	public void mergePermissions(long fromRoleId, long toRoleId)
 		throws PortalException;
 
+	public void populateDefaultModelResourcePermissions(
+			long companyId, Collection<String> modelResources)
+		throws PortalException;
+
 	/**
 	 * Grants the role default permissions to all the resources of the type and
 	 * at the scope stored in the resource permission, deletes the resource

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
@@ -836,6 +836,14 @@ public class ResourcePermissionLocalServiceUtil {
 		getService().mergePermissions(fromRoleId, toRoleId);
 	}
 
+	public static void populateDefaultModelResourcePermissions(
+			long companyId, java.util.Collection<String> modelResources)
+		throws PortalException {
+
+		getService().populateDefaultModelResourcePermissions(
+			companyId, modelResources);
+	}
+
 	/**
 	 * Grants the role default permissions to all the resources of the type and
 	 * at the scope stored in the resource permission, deletes the resource

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
@@ -914,6 +914,15 @@ public class ResourcePermissionLocalServiceWrapper
 		_resourcePermissionLocalService.mergePermissions(fromRoleId, toRoleId);
 	}
 
+	@Override
+	public void populateDefaultModelResourcePermissions(
+			long companyId, java.util.Collection<String> modelResources)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_resourcePermissionLocalService.populateDefaultModelResourcePermissions(
+			companyId, modelResources);
+	}
+
 	/**
 	 * Grants the role default permissions to all the resources of the type and
 	 * at the scope stored in the resource permission, deletes the resource


### PR DESCRIPTION
- **Revert "LPD-20793 For cold db, postpone remote portlet deployment checking to the end of startup."**
- **LPD-20946 Use ResourceActions api to check if it is root module resource to decouple from portlet id, prepare for next**
- **LPD-20946 Extract logic to a public method, prepare for next**
- **LPD-20946 Auto generated**
- **LPD-20946 SF, extract common logic into private method**
- **LPD-20946 SF, inline private method logic, prepare for next**
- **LPD-20946 SF, move for loop into for each company**
- **LPD-20946 Populate model resource permissions into database while checking resource actions**
- **LPD-20946 Also populate existing model resource permissions when checking company (model listener is too early)**
- **LPD-20946 No longer need to populate model resource permisssion during portlet deployment**
- **LPD-20946 Pass id when explicitly calling deleteObjectDefinition() in integration tests, to avoid the cases where an object definition is created, assigned to a variable, and then published but not re-assigned to that variable, causing a incomplete deletion using an out-dated instance.**
- **LPD-20946 Remove permission when removing model resources via document, since they are populated with this**
- **LPD-20946 Skip or postpone the permission population during upgrade to avoid conflicts. For per-module population, if it populates a permission first, and then an upgrade process tries to upgrade an old permission to this one, a duplicate entry error will be thrown because of the index constraint; for check company, it should only populate when creating new company, which won't happen during upgrade.**
