### PR TITLE
LPD 25857 temp

### DIFF
--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/DefaultJarInstaller.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/DefaultJarInstaller.java
@@ -120,13 +120,17 @@ public class DefaultJarInstaller implements FileInstaller, ManagedService {
 
 	@Override
 	public void updated(Dictionary<String, ?> dictionary) {
-		if (dictionary != null) {
-			_atomicReference.set(
-				SetUtil.fromArray(
-					(String[])dictionary.get("blacklistBundleSymbolicNames")));
+		_blacklistedFiles.clear();
+
+		if (dictionary == null) {
+			_atomicReference.set(Collections.emptySet());
+
+			return;
 		}
 
-		_blacklistedFiles.clear();
+		_atomicReference.set(
+			SetUtil.fromArray(
+				(String[])dictionary.get("blacklistBundleSymbolicNames")));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/DefaultJarInstaller.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/DefaultJarInstaller.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -61,7 +62,7 @@ public class DefaultJarInstaller implements FileInstaller, ManagedService {
 	public boolean canTransformURL(File artifact) {
 		String name = artifact.getName();
 
-		if (!name.endsWith(".jar")) {
+		if (!name.endsWith(".jar") || _blacklistedFiles.contains(artifact)) {
 			return false;
 		}
 
@@ -93,6 +94,8 @@ public class DefaultJarInstaller implements FileInstaller, ManagedService {
 								bundleSymbolicName);
 					}
 
+					_blacklistedFiles.add(artifact);
+
 					return false;
 				}
 			}
@@ -122,6 +125,8 @@ public class DefaultJarInstaller implements FileInstaller, ManagedService {
 				SetUtil.fromArray(
 					(String[])dictionary.get("blacklistBundleSymbolicNames")));
 		}
+
+		_blacklistedFiles.clear();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -129,5 +134,7 @@ public class DefaultJarInstaller implements FileInstaller, ManagedService {
 
 	private final AtomicReference<Set<String>> _atomicReference =
 		new AtomicReference<>(Collections.emptySet());
+	private final Set<File> _blacklistedFiles = Collections.newSetFromMap(
+		new ConcurrentHashMap<>());
 
 }

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/DefaultJarInstaller.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/DefaultJarInstaller.java
@@ -5,27 +5,103 @@
 
 package com.liferay.portal.file.install.internal;
 
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.file.install.FileInstaller;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 
 import java.io.File;
+import java.io.IOException;
 
 import java.net.URI;
 import java.net.URL;
 
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ManagedService;
+
 /**
  * @author Matthew Tambara
  */
-public class DefaultJarInstaller implements FileInstaller {
+public class DefaultJarInstaller implements FileInstaller, ManagedService {
+
+	public DefaultJarInstaller(ConfigurationAdmin configurationAdmin) {
+		try {
+			Configuration configuration = configurationAdmin.getConfiguration(
+				"com.liferay.portal.bundle.blacklist.internal.configuration." +
+					"BundleBlacklistConfiguration",
+				StringPool.QUESTION);
+
+			Dictionary<String, ?> dictionary = configuration.getProperties();
+
+			if (dictionary != null) {
+				_atomicReference.set(
+					SetUtil.fromArray(
+						(String[])dictionary.get(
+							"blacklistBundleSymbolicNames")));
+			}
+		}
+		catch (IOException ioException) {
+			ReflectionUtil.throwException(ioException);
+		}
+	}
 
 	@Override
 	public boolean canTransformURL(File artifact) {
 		String name = artifact.getName();
 
-		if (name.endsWith(".jar")) {
+		if (!name.endsWith(".jar")) {
+			return false;
+		}
+
+		Set<String> blacklistBundleSymbolicNames = _atomicReference.get();
+
+		if (blacklistBundleSymbolicNames.isEmpty()) {
 			return true;
 		}
 
-		return false;
+		try (JarFile jarFile = new JarFile(artifact)) {
+			Manifest manifest = jarFile.getManifest();
+
+			Attributes attributes = manifest.getMainAttributes();
+
+			String bundleSymbolicName = attributes.getValue(
+				"Bundle-SymbolicName");
+
+			if (bundleSymbolicName != null) {
+				int index = bundleSymbolicName.indexOf(CharPool.SEMICOLON);
+
+				if (index != -1) {
+					bundleSymbolicName = bundleSymbolicName.substring(0, index);
+				}
+
+				if (blacklistBundleSymbolicNames.contains(bundleSymbolicName)) {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							"Skipping blacklisted bundle " +
+								bundleSymbolicName);
+					}
+
+					return false;
+				}
+			}
+		}
+		catch (IOException ioException) {
+			ReflectionUtil.throwException(ioException);
+		}
+
+		return true;
 	}
 
 	@Override
@@ -38,5 +114,20 @@ public class DefaultJarInstaller implements FileInstaller {
 	@Override
 	public void uninstall(File file) {
 	}
+
+	@Override
+	public void updated(Dictionary<String, ?> dictionary) {
+		if (dictionary != null) {
+			_atomicReference.set(
+				SetUtil.fromArray(
+					(String[])dictionary.get("blacklistBundleSymbolicNames")));
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DefaultJarInstaller.class);
+
+	private final AtomicReference<Set<String>> _atomicReference =
+		new AtomicReference<>(Collections.emptySet());
 
 }

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/activator/FileInstallImplBundleActivator.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/activator/FileInstallImplBundleActivator.java
@@ -36,9 +36,6 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 	public void start(BundleContext bundleContext) throws Exception {
 		_bundleContext = bundleContext;
 
-		_jarFileInstallerServiceRegistration = _bundleContext.registerService(
-			FileInstaller.class, new DefaultJarInstaller(), null);
-
 		_serviceTracker = new ServiceTracker<>(
 			bundleContext, ConfigurationAdmin.class.getName(),
 			new ServiceTrackerCustomizer
@@ -52,6 +49,9 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 						bundleContext.getService(serviceReference);
 
 					return Arrays.asList(
+						_bundleContext.registerService(
+							FileInstaller.class,
+							new DefaultJarInstaller(configurationAdmin), null),
 						_bundleContext.registerService(
 							FileInstaller.class.getName(),
 							new ConfigurationFileInstaller(
@@ -103,8 +103,6 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 		_directoryWatcher.close();
 
 		_serviceTracker.close();
-
-		_jarFileInstallerServiceRegistration.unregister();
 	}
 
 	public void updateChecksum(File file) {
@@ -115,8 +113,6 @@ public class FileInstallImplBundleActivator implements BundleActivator {
 
 	private BundleContext _bundleContext;
 	private DirectoryWatcher _directoryWatcher;
-	private ServiceRegistration<FileInstaller>
-		_jarFileInstallerServiceRegistration;
 	private ServiceTracker<ConfigurationAdmin, List<ServiceRegistration<?>>>
 		_serviceTracker;
 

--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ReleaseInfo;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.module.framework.ModuleFramework;
@@ -89,6 +90,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.jar.Attributes;
+import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 import java.util.zip.CRC32;
@@ -936,7 +938,7 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 
 	private void _installBundlesFromDir(
 			String dirPath, Map<Long, Long> checksums,
-			Set<String> fragmentHosts)
+			Set<String> blacklistBundleSymbolicNames, Set<String> fragmentHosts)
 		throws Exception {
 
 		BundleContext bundleContext = _framework.getBundleContext();
@@ -958,7 +960,40 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 				continue;
 			}
 
-			try (InputStream inputStream = new FileInputStream(file)) {
+			try (InputStream inputStream = new FileInputStream(file);
+				JarFile jarFile = new JarFile(file)) {
+
+				if (!blacklistBundleSymbolicNames.isEmpty()) {
+					Manifest manifest = jarFile.getManifest();
+
+					Attributes attributes = manifest.getMainAttributes();
+
+					String bundleSymbolicName = attributes.getValue(
+						"Bundle-SymbolicName");
+
+					if (bundleSymbolicName != null) {
+						int index = bundleSymbolicName.indexOf(
+							CharPool.SEMICOLON);
+
+						if (index != -1) {
+							bundleSymbolicName = bundleSymbolicName.substring(
+								0, index);
+						}
+
+						if (blacklistBundleSymbolicNames.contains(
+								bundleSymbolicName)) {
+
+							if (_log.isInfoEnabled()) {
+								_log.info(
+									"Skipping blacklisted bundle " +
+										bundleSymbolicName);
+							}
+
+							continue;
+						}
+					}
+				}
+
 				Bundle bundle = bundleContext.installBundle(
 					location, inputStream);
 
@@ -1057,15 +1092,45 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 
 		Set<String> fragmentHosts = new HashSet<>();
 
+		BundleContext bundleContext = _framework.getBundleContext();
+
+		Object configurationAdmin = bundleContext.getService(
+			bundleContext.getServiceReference(
+				"org.osgi.service.cm.ConfigurationAdmin"));
+
+		Method getConfigurationMethod = ReflectionUtil.getDeclaredMethod(
+			configurationAdmin.getClass(), "getConfiguration", String.class,
+			String.class);
+
+		Object configuration = getConfigurationMethod.invoke(
+			configurationAdmin,
+			"com.liferay.portal.bundle.blacklist.internal.configuration." +
+				"BundleBlacklistConfiguration",
+			StringPool.QUESTION);
+
+		Method getPropertiesMethod = ReflectionUtil.getDeclaredMethod(
+			configuration.getClass(), "getProperties");
+
+		Dictionary<String, Object> dictionary =
+			(Dictionary<String, Object>)getPropertiesMethod.invoke(
+				configuration);
+
+		Set<String> blacklistBundleSymbolicNames = Collections.emptySet();
+
+		if (dictionary != null) {
+			blacklistBundleSymbolicNames = SetUtil.fromArray(
+				(String[])dictionary.get("blacklistBundleSymbolicNames"));
+		}
+
 		_installBundlesFromDir(
-			PropsValues.MODULE_FRAMEWORK_PORTAL_DIR, checksums, fragmentHosts);
+			PropsValues.MODULE_FRAMEWORK_PORTAL_DIR, checksums,
+			blacklistBundleSymbolicNames, fragmentHosts);
 		_installBundlesFromDir(
-			PropsValues.MODULE_FRAMEWORK_MODULES_DIR, checksums, fragmentHosts);
+			PropsValues.MODULE_FRAMEWORK_MODULES_DIR, checksums,
+			blacklistBundleSymbolicNames, fragmentHosts);
 
 		if (!fragmentHosts.isEmpty()) {
 			List<Bundle> refreshBundles = new ArrayList<>();
-
-			BundleContext bundleContext = _framework.getBundleContext();
 
 			for (Bundle bundle : bundleContext.getBundles()) {
 				if (fragmentHosts.remove(bundle.getSymbolicName())) {

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RequiredCompanyException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.instance.lifecycle.PortalInstanceLifecycleManager;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -1473,6 +1474,12 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		String[] systemGroups = PortalUtil.getSystemGroups();
 
 		for (String groupName : systemGroups) {
+			if (groupName.equals(GroupConstants.CMS) &&
+				!FeatureFlagManagerUtil.isEnabled("LPD-17809")) {
+
+				continue;
+			}
+
 			deleteGroupActionableDynamicQuery.deleteGroup(
 				_groupLocalService.getGroup(companyId, groupName));
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/bundleblacklist/BundleBlacklist.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/bundleblacklist/BundleBlacklist.testcase
@@ -164,7 +164,7 @@ definition {
 		property test.run.type = "single";
 
 		task ("Given a portlet's jar is blacklisted") {
-			AssertConsoleTextPresent(value1 = "Stopping blacklisted bundle com.liferay.frontend.taglib.clay.sample.web");
+			AssertConsoleTextPresent(value1 = "Skipping blacklisted bundle com.liferay.frontend.taglib.clay.sample.web");
 		}
 
 		task ("When the jar is removed from the blacklist after shutdown") {
@@ -444,7 +444,7 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		AssertConsoleTextPresent(value1 = "Stopping blacklisted bundle com.liferay.gogo.shell.web");
+		AssertConsoleTextPresent(value1 = "Skipping blacklisted bundle com.liferay.gogo.shell.web");
 
 		SystemSettings.openSystemSettingsAdmin();
 
@@ -487,7 +487,7 @@ definition {
 
 		BundleBlacklist.viewProductMenuBlacklistedModule(
 			category = "System",
-			consoleText = "Stopping blacklisted bundle com.liferay.gogo.shell.web",
+			consoleText = "Skipping blacklisted bundle com.liferay.gogo.shell.web",
 			panel = "Control Panel",
 			portlet = "Gogo Shell");
 


### PR DESCRIPTION
- **LPD-25857 Skip installing blacklisted bundles during module framework initialization**
- **LPD-25857 Skip installing blacklisted bundles when a jar is scanned by FileInstall**
- **LPD-25857 Assert updated log during startup**
- **LPD-25857 Add a simple cache to avoid processing the file repeatedly, unless the configuration is updated**
- **LPD-25857 If the incoming dictionary is null, we should set the cached bundle blacklist symbolic name set back to an empty one**
- **LPD-26027 If the feature flag is disable there is no group to delate**
