### PR TITLE
LPD 33553 8 13

### DIFF
--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/jgroups/JGroupsClusterChannel.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/jgroups/JGroupsClusterChannel.java
@@ -81,7 +81,9 @@ public class JGroupsClusterChannel extends BaseClusterChannel {
 			}
 
 			_jChannel.setReceiver(
-				new JGroupsReceiver(clusterReceiver, classLoaders));
+				new JGroupsReceiver(
+					clusterReceiver, classLoaders,
+					clusterExecutorConfiguration.debugEnabled()));
 
 			_jChannel.connect(_clusterName);
 

--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/jgroups/JGroupsReceiver.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/jgroups/JGroupsReceiver.java
@@ -9,6 +9,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.lang.ThreadContextClassLoaderUtil;
 import com.liferay.portal.cluster.multiple.internal.ClusterReceiver;
 import com.liferay.portal.kernel.cluster.Address;
+import com.liferay.portal.kernel.io.ClassLoaderNotFoundException;
 import com.liferay.portal.kernel.io.Deserializer;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -31,7 +32,7 @@ public class JGroupsReceiver extends ReceiverAdapter {
 
 	public JGroupsReceiver(
 		ClusterReceiver clusterReceiver,
-		Map<ClassLoader, ClassLoader> classLoaders) {
+		Map<ClassLoader, ClassLoader> classLoaders, boolean debugEnabled) {
 
 		if (clusterReceiver == null) {
 			throw new NullPointerException("Cluster receiver is null");
@@ -39,6 +40,7 @@ public class JGroupsReceiver extends ReceiverAdapter {
 
 		_clusterReceiver = clusterReceiver;
 		_classLoaders = classLoaders;
+		_debugEnabled = debugEnabled;
 	}
 
 	@Override
@@ -72,6 +74,13 @@ public class JGroupsReceiver extends ReceiverAdapter {
 
 			_clusterReceiver.receive(
 				deserializer.readObject(), new AddressImpl(message.getSrc()));
+		}
+		catch (ClassLoaderNotFoundException classLoaderNotFoundException) {
+			if (_debugEnabled && _log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to deserialize message payload",
+					classLoaderNotFoundException);
+			}
 		}
 		catch (ClassNotFoundException classNotFoundException) {
 			if (_log.isWarnEnabled()) {
@@ -113,5 +122,6 @@ public class JGroupsReceiver extends ReceiverAdapter {
 
 	private final Map<ClassLoader, ClassLoader> _classLoaders;
 	private final ClusterReceiver _clusterReceiver;
+	private final boolean _debugEnabled;
 
 }

--- a/modules/core/petra/petra-lang/src/main/java/com/liferay/petra/lang/ClassLoaderPool.java
+++ b/modules/core/petra/petra-lang/src/main/java/com/liferay/petra/lang/ClassLoaderPool.java
@@ -74,9 +74,13 @@ public class ClassLoaderPool {
 					}
 				}
 			}
+
+			if (strict && (classLoader == null)) {
+				return null;
+			}
 		}
 
-		if (!strict && (classLoader == null)) {
+		if (classLoader == null) {
 			Thread currentThread = Thread.currentThread();
 
 			classLoader = currentThread.getContextClassLoader();

--- a/modules/core/petra/petra-lang/src/main/java/com/liferay/petra/lang/ClassLoaderPool.java
+++ b/modules/core/petra/petra-lang/src/main/java/com/liferay/petra/lang/ClassLoaderPool.java
@@ -32,6 +32,25 @@ public class ClassLoaderPool {
 	 * @return the class loader associated with the context name
 	 */
 	public static ClassLoader getClassLoader(String contextName) {
+		return getClassLoader(contextName, false);
+	}
+
+	/**
+	 * Returns the class loader associated with the context name.
+	 *
+	 * <p>
+	 * If no class loader is found for the context name, and strict is false,
+	 * the thread's context class loader is returned as a fallback. Otherwise,
+	 * null is returned.
+	 * </p>
+	 *
+	 * @param  contextName the servlet context's name
+	 * @param  strict whether to fall back to the context class loader
+	 * @return the class loader associated with the context name, or null
+	 */
+	public static ClassLoader getClassLoader(
+		String contextName, boolean strict) {
+
 		ClassLoader classLoader = null;
 
 		if ((contextName != null) && !contextName.equals("null")) {
@@ -57,7 +76,7 @@ public class ClassLoaderPool {
 			}
 		}
 
-		if (classLoader == null) {
+		if (!strict && (classLoader == null)) {
 			Thread currentThread = Thread.currentThread();
 
 			classLoader = currentThread.getContextClassLoader();

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 147.0.1
+Bundle-Version: 148.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/io/ClassLoaderNotFoundException.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/io/ClassLoaderNotFoundException.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.io;
+
+/**
+ * @author Dante Wang
+ */
+public class ClassLoaderNotFoundException extends ClassNotFoundException {
+
+	public ClassLoaderNotFoundException(String message) {
+		super(message);
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/io/ProtectedAnnotatedObjectInputStream.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/io/ProtectedAnnotatedObjectInputStream.java
@@ -30,6 +30,13 @@ public class ProtectedAnnotatedObjectInputStream
 
 		String contextName = readUTF();
 
+		ClassLoader classLoader = ClassLoaderPool.getClassLoader(
+			contextName, true);
+
+		if (classLoader == null) {
+			throw new ClassLoaderNotFoundException(contextName);
+		}
+
 		String className = objectStreamClass.getName();
 
 		return ClassResolverUtil.resolve(

--- a/portal-kernel/src/com/liferay/portal/kernel/io/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/io/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.1.0


### PR DESCRIPTION
- **LPD-33553 Add overloading method to ClassLoaderPool to control whether to fall back to context class loader**
- **LPD-33553 Throw a specific exception when the class loader is strictly not found**
- **LPD-33553 Separately log the class loader not found exception in JGroupsReceiver, controlled by ClusterExecutorConfiguration.debugEnabled()**
