### PR TITLE
LPD 38922 10 14

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/servicebuilder/ServiceBuilder.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/servicebuilder/ServiceBuilder.testcase
@@ -59,7 +59,7 @@ definition {
 		var projectDir = PropsUtil.get("project.dir");
 		var testServiceDir = "/modules/test/external-data-source-test-service";
 
-		FileUtil.copyDirectory("${projectDir}/modules/test/external-data-source-test-controller-test/src/testIntegration/resources/META-INF/services", "${projectDir}/${testServiceDir}/src/main/resources/META-INF");
+		FileUtil.copyDirectory("${projectDir}/modules/test/external-data-source-test-controller-test/src/testIntegration/resources/META-INF/services", "${projectDir}/${testServiceDir}/src/main/resources/META-INF/service");
 
 		AntCommands.runCommand("build-test.xml", "build-service -Dgradle.file.path=${testServiceDir}");
 

--- a/test.properties
+++ b/test.properties
@@ -4746,36 +4746,7 @@
             (database.types ~ mysql)\
         ) AND \
         (\
-            (testray.main.component.name == "Bean Portlet") OR \
-            (testray.main.component.name == "Bundle Blacklist") OR \
-            (testray.main.component.name == "Clustering") OR \
-            (testray.main.component.name == "Custom Fields") OR \
-            (testray.main.component.name == "Deployment") OR \
-            (testray.main.component.name == "Document Library Stores") OR \
-            (testray.main.component.name == "Ext") OR \
-            (testray.main.component.name == "File Install") OR \
-            (testray.main.component.name == "Gogo Shell") OR \
-            (testray.main.component.name == "IP Address") OR \
-            (testray.main.component.name == "JSP Compiler") OR \
-            (testray.main.component.name == "License") OR \
-            (testray.main.component.name == "Liferay Faces") OR \
-            (testray.main.component.name == "Locale") OR \
-            (testray.main.component.name == "Logging") OR \
-            (testray.main.component.name == "Mobile Device Rules") OR \
-            (testray.main.component.name == "Module Framework Servlet") OR \
-            (testray.main.component.name == "Portal Configuration") OR \
-            (testray.main.component.name == "Portal Services") OR \
-            (testray.main.component.name == "Rolling Restart") OR \
-            (testray.main.component.name == "Scheduler") OR \
-            (testray.main.component.name == "Server Administration") OR \
-            (testray.main.component.name == "Service Builder") OR \
-            (testray.main.component.name == "Setup Wizard") OR \
-            (testray.main.component.name == "Smoke") OR \
-            (testray.main.component.name == "TCK") OR \
-            (testray.main.component.name == "Templates Engine") OR \
-            (testray.main.component.name == "Test Plugins") OR \
-            (testray.main.component.name == "User Tracker") OR \
-            (testray.main.component.name == "Virtual Instances")\
+            (testray.main.component.name == "Service Builder")\
         )
 
     #


### PR DESCRIPTION
- **LPD-38922 Fix ServiceBuilder#ExternalDataSourceSmoke by fixing the usage of FileUtil#copyDirectory. This method delegates to org.apache.commons.io.FileUtils#copyDirectory, whose JavaDoc states: "This method copies the specified directory and all its child directories and files to the specified destination. The destination is the new location and name of the directory".**
- **LPD-38922 service builder only**
