### PR TITLE
LPD 34518 JDK17 CI

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2258,7 +2258,7 @@ war.path=${app.server.portal.dir}/</echo>
 				<then>
 					<local name="poshi.java.jdk.opts" />
 
-					<get-java-jdk-home version="8" />
+					<get-java-jdk-home version="17" />
 
 					<get-poshi-java-jdk-opts />
 

--- a/build.properties
+++ b/build.properties
@@ -524,21 +524,7 @@
 
     junit.code.coverage=false
     junit.halt.on.failure=false
-    junit.java.add.opens[11]=\
-        --add-opens java.base/java.io=ALL-UNNAMED \
-        --add-opens java.base/java.lang=ALL-UNNAMED \
-        --add-opens java.base/java.lang.ref=ALL-UNNAMED \
-        --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
-        --add-opens java.base/java.net=ALL-UNNAMED \
-        --add-opens java.base/java.nio=ALL-UNNAMED \
-        --add-opens java.base/java.nio.charset=ALL-UNNAMED \
-        --add-opens java.base/java.util=ALL-UNNAMED \
-        --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
-        --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED \
-        --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
-        --add-opens java.base/sun.nio.cs=ALL-UNNAMED \
-        --add-opens java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED
-    junit.java.add.opens[21]=\
+    junit.java.add.opens=\
         --add-opens java.base/java.io=ALL-UNNAMED \
         --add-opens java.base/java.lang=ALL-UNNAMED \
         --add-opens java.base/java.lang.invoke=ALL-UNNAMED \

--- a/modules/core/petra/petra-io/src/test/java/com/liferay/petra/io/unsync/UnsyncFilterOutputStreamTest.java
+++ b/modules/core/petra/petra-io/src/test/java/com/liferay/petra/io/unsync/UnsyncFilterOutputStreamTest.java
@@ -59,10 +59,26 @@ public class UnsyncFilterOutputStreamTest {
 		Assert.assertTrue(flushCalled.get());
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void testCloseNull() throws IOException {
 		UnsyncFilterOutputStream unsyncFilterOutputStream =
 			new UnsyncFilterOutputStream(null);
+
+		try {
+			unsyncFilterOutputStream.close();
+
+			Assert.fail();
+		}
+		catch (NullPointerException nullPointerException) {
+		}
+
+		unsyncFilterOutputStream = new UnsyncFilterOutputStream(null) {
+
+			@Override
+			public void flush() throws IOException {
+			}
+
+		};
 
 		unsyncFilterOutputStream.close();
 	}

--- a/test.properties
+++ b/test.properties
@@ -1299,7 +1299,7 @@
     # Default
     #
 
-    test.batch.app.server.tomcat.setenv.gc.new=-verbose:gc -Xloggc:/tmp/tomcat-gc.log -Xms1024m -Xmx4096m -XX:MaxNewSize=32m -XX:MaxMetaspaceSize=1024m -XX:MaxTenuringThreshold=0 -XX:NewSize=32m -XX:ParallelGCThreads=2 -XX:MetaspaceSize=256m -XX:+PrintGCCause -XX:+PrintGCDetails -XX:SurvivorRatio=65536 -XX:TargetSurvivorRatio=0 -XX:+UseParNewGC
+    test.batch.app.server.tomcat.setenv.gc.new=-verbose:gc -Xloggc:/tmp/tomcat-gc.log -Xms1024m -Xmx4096m -XX:MaxNewSize=32m -XX:MaxMetaspaceSize=1024m -XX:MaxTenuringThreshold=0 -XX:NewSize=32m -XX:ParallelGCThreads=2 -XX:MetaspaceSize=256m -XX:+PrintGCCause -XX:+PrintGCDetails -XX:SurvivorRatio=2048 -XX:TargetSurvivorRatio=0 -XX:+UseParNewGC
     test.batch.app.server.tomcat.setenv.gc.new[11]=-Xlog:gc:/tmp/tomcat-gc.log -Xms1024m -Xmx4096m -XX:MaxNewSize=32m -XX:MaxMetaspaceSize=1024m -XX:MaxTenuringThreshold=0 -XX:NewSize=32m -XX:ParallelGCThreads=2 -XX:MetaspaceSize=256m -XX:SurvivorRatio=2048 -XX:TargetSurvivorRatio=0
     test.batch.app.server.tomcat.setenv.gc.new[17]=-Xlog:gc:/tmp/tomcat-gc.log -Xms1024m -Xmx4096m -XX:MaxNewSize=32m -XX:MaxMetaspaceSize=1024m -XX:MaxTenuringThreshold=0 -XX:NewSize=32m -XX:ParallelGCThreads=2 -XX:MetaspaceSize=256m -XX:SurvivorRatio=2048 -XX:TargetSurvivorRatio=0
     test.batch.app.server.tomcat.setenv.gc.new[21]=-Xlog:gc:/tmp/tomcat-gc.log -Xms1024m -Xmx4096m -XX:MaxNewSize=32m -XX:MaxMetaspaceSize=1024m -XX:MaxTenuringThreshold=0 -XX:NewSize=32m -XX:ParallelGCThreads=2 -XX:MetaspaceSize=256m -XX:SurvivorRatio=2048 -XX:TargetSurvivorRatio=0


### PR DESCRIPTION
- **LPD-44184 Fix test coverage for JDK17/21 due to the try-with-resources generated bytecode change.**
- **LPD-X remove branches for junit.java.add.opens**
- **LPD-X change this to 2048, because since we removed the jdk number from the batch name it's not catching the correct ant opts and defaulting to the wrong options**
- **LPD-X set get-java-jdk-home to jdk 17**
