### PR TITLE
LPD X unify jackson dataformat cbor

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -4005,18 +4005,6 @@
 				</licenses>
 			</library>
 			<library>
-				<file-name>com.liferay.portal.vulcan.impl.jar!classmate.jar</file-name>
-				<version>1.4.0</version>
-				<project-name>ClassMate</project-name>
-				<project-url>http://github.com/FasterXML/java-classmate</project-url>
-				<licenses>
-					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
 				<file-name>com.liferay.portal.vulcan.impl.jar!commons-lang3.jar</file-name>
 				<version>3.8</version>
 				<project-name>Apache Commons Lang</project-name>

--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -3512,13 +3512,13 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.store.s3.jar!jackson-dataformat-cbor.jar</file-name>
-				<version>2.12.6</version>
+				<version>2.18.2</version>
 				<project-name>Jackson dataformat: CBOR</project-name>
-				<project-url>http://github.com/FasterXML/jackson-dataformats-binary</project-url>
+				<project-url>https://github.com/FasterXML/jackson-dataformats-binary</project-url>
 				<licenses>
 					<license>
 						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
+						<license-url>https://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
 					</license>
 				</licenses>
 			</library>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -2097,12 +2097,6 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.portal.vulcan.impl.jar!classmate.jar</td><td nowrap="nowrap">1.4.0</td><td nowrap="nowrap"><a href="http://github.com/FasterXML/java-classmate">ClassMate</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
-                        <br>
-                    </td><td></td>
-                </tr>
-                			
-                <tr>
                     <td nowrap="nowrap">com.liferay.portal.vulcan.impl.jar!commons-lang3.jar</td><td nowrap="nowrap">3.8</td><td nowrap="nowrap"><a href="http://commons.apache.org/proper/commons-lang/">Apache Commons Lang</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
                         <br>
                     </td><td></td>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -1845,7 +1845,7 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.portal.store.s3.jar!jackson-dataformat-cbor.jar</td><td nowrap="nowrap">2.12.6</td><td nowrap="nowrap"><a href="http://github.com/FasterXML/jackson-dataformats-binary">Jackson dataformat: CBOR</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.portal.store.s3.jar!jackson-dataformat-cbor.jar</td><td nowrap="nowrap">2.18.2</td><td nowrap="nowrap"><a href="https://github.com/FasterXML/jackson-dataformats-binary">Jackson dataformat: CBOR</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>

--- a/modules/apps/portal-store/portal-store-s3/bnd.bnd
+++ b/modules/apps/portal-store/portal-store-s3/bnd.bnd
@@ -21,3 +21,4 @@ Import-Package:\
 	!software.amazon.ion.*,\
 	\
 	*
+-fixupmessages: Classes found in the wrong directory: ...;is:=ignore

--- a/modules/apps/portal-store/portal-store-s3/build.gradle
+++ b/modules/apps/portal-store/portal-store-s3/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 	compileInclude group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.12.719"
 	compileInclude group: "com.amazonaws", name: "aws-java-sdk-kms", version: "1.12.719"
 	compileInclude group: "com.amazonaws", name: "aws-java-sdk-s3", version: "1.12.719"
-	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-cbor", version: "2.12.6"
+	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-cbor", version: "2.18.2"
 	compileInclude group: "com.ibm.cos", name: "ibm-cos-java-sdk-core", version: "2.9.0"
 	compileInclude group: "com.ibm.cos", name: "ibm-cos-java-sdk-kms", version: "2.9.0"
 	compileInclude group: "com.ibm.cos", name: "ibm-cos-java-sdk-s3", version: "2.9.0"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -7,7 +7,6 @@ import java.util.jar.Manifest
 task jarManifest
 
 dependencies {
-	compileInclude group: "com.fasterxml", name: "classmate", version: "1.5.1"
 	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-xml", version: "2.10.3"
 	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-yaml", version: "2.14.2"
 	compileInclude group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jdk8", version: "2.9.8"
@@ -29,6 +28,7 @@ dependencies {
 	compileInclude group: "org.reflections", name: "reflections", version: "0.10.2"
 	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.3"
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "6.4.0"
+	compileOnly group: "com.fasterxml", name: "classmate", version: "1.5.1"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.16.1"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.16.1"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.16.1"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -7,7 +7,7 @@ import java.util.jar.Manifest
 task jarManifest
 
 dependencies {
-	compileInclude group: "com.fasterxml", name: "classmate", version: "1.4.0"
+	compileInclude group: "com.fasterxml", name: "classmate", version: "1.5.1"
 	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-xml", version: "2.10.3"
 	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-yaml", version: "2.14.2"
 	compileInclude group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jdk8", version: "2.9.8"

--- a/modules/core/portal-bootstrap/system.packages.extra.bnd
+++ b/modules/core/portal-bootstrap/system.packages.extra.bnd
@@ -91,6 +91,11 @@ Export-Package:\
 	\
 	!unicode-license.txt,\
 	\
+	com.fasterxml.classmate;version='1.5.1',\
+	com.fasterxml.classmate.members;version='1.5.1',\
+	com.fasterxml.classmate.types;version='1.5.1',\
+	com.fasterxml.classmate.util;version='1.5.1',\
+	\
 	com.ibm.crypto.provider,\
 	\
 	com.sun.security.auth.module,\

--- a/modules/util/portal-tools-sample-sql-builder/build.gradle
+++ b/modules/util/portal-tools-sample-sql-builder/build.gradle
@@ -29,7 +29,6 @@ classes {
 dependencies {
 	api group: "com.liferay.portal", name: "com.liferay.util.java", version: "default"
 	api group: "javax.portlet", name: "portlet-api", transitive: false, version: "3.0.1"
-
 	compileInclude project(":apps:account:account-api")
 	compileInclude project(":apps:account:account-service")
 	compileInclude project(":apps:application-list:application-list-api")
@@ -90,7 +89,6 @@ dependencies {
 	compileInclude project(":apps:view-count:view-count-service")
 	compileInclude project(":apps:wiki:wiki-api")
 	compileInclude project(":apps:wiki:wiki-service")
-
 	compileOnly group: "com.liferay", name: "org.freemarker", version: "2.3.33.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -641,6 +641,7 @@
         com.amazonaws:aws-java-sdk-kms:1.12.719,\
         com.amazonaws:aws-java-sdk-s3:1.12.719,\
         com.beust:jcommander:1.82,\
+        com.fasterxml:classmate:1.5.1,\
         com.fasterxml.jackson-dataformat:jackson-dataformat-cbor:2.12.6,\
         com.fasterxml.jackson.core:jackson-annotations:2.16.1,\
         com.fasterxml.jackson.core:jackson-core:2.16.1,\

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -642,7 +642,7 @@
         com.amazonaws:aws-java-sdk-s3:1.12.719,\
         com.beust:jcommander:1.82,\
         com.fasterxml:classmate:1.5.1,\
-        com.fasterxml.jackson-dataformat:jackson-dataformat-cbor:2.12.6,\
+        com.fasterxml.jackson-dataformat:jackson-dataformat-cbor:2.18.2,\
         com.fasterxml.jackson.core:jackson-annotations:2.16.1,\
         com.fasterxml.jackson.core:jackson-core:2.16.1,\
         com.fasterxml.jackson.core:jackson-databind:2.16.1,\

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/TrialRestController.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/TrialRestController.java
@@ -475,16 +475,6 @@ public class TrialRestController extends BaseRestController {
 		return string;
 	}
 
-	private String[] _toStringArray(JSONArray jsonArray) {
-		List<String> list = new ArrayList<>();
-
-		for (int i = 0; i < jsonArray.length(); i++) {
-			list.add(jsonArray.getString(i));
-		}
-
-		return list.toArray(new String[0]);
-	}
-
 	private void _rollBackTrial(
 			String errorMessage, long orderId, PortalInstance portalInstance)
 		throws Exception {
@@ -509,6 +499,16 @@ public class TrialRestController extends BaseRestController {
 				"trial-virtualhost", portalInstance.getVirtualHost()
 			).build(),
 			orderId, MarketplaceConstants.ORDER_STATUS_CANCELLED);
+	}
+
+	private String[] _toStringArray(JSONArray jsonArray) {
+		List<String> list = new ArrayList<>();
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			list.add(jsonArray.getString(i));
+		}
+
+		return list.toArray(new String[0]);
 	}
 
 	private static final int _TRIAL_MAX_INSTANCES = GetterUtil.getInteger(


### PR DESCRIPTION
- **LPD-47174 Enforce com.fasterxml:classmate version to 1.5.1, as it's the version used by Hibernate libraries:**
- **LPD-47174 Auto SF**
- **LPD-47174 Export classmate packages from system bundle, and use compileOnly for classmate in portal-vulcan-impl**
- **LPD-47174 other Auto SF changes**
- **LPD-47174 Build-lib-versions**
- **LPD-X Enforce and apply jackson-dataformat-cbor 2.18.2**
- **LPD-X Build-lib-versions**
- **LPD-X Fix bnd**
