### PR TITLE
LPP 60322 poc additional

### DIFF
--- a/modules/core/portal-jsp-engine/src/main/java/com/liferay/portal/jsp/engine/internal/JSPEngineShieldedContainerInitializer.java
+++ b/modules/core/portal-jsp-engine/src/main/java/com/liferay/portal/jsp/engine/internal/JSPEngineShieldedContainerInitializer.java
@@ -33,10 +33,7 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRegistration;
 import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletRequestWrapper;
 import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletRequestWrapper;
 
 import java.io.File;
 import java.io.IOException;
@@ -174,31 +171,8 @@ public class JSPEngineShieldedContainerInitializer
 							FilterChain filterChain)
 						throws IOException, ServletException {
 
-						if (servletRequest instanceof HttpServletRequest) {
-							portalJSPServlet.service(
-								new HttpServletRequestWrapper(
-									(HttpServletRequest)servletRequest) {
-
-									@Override
-									public ServletContext getServletContext() {
-										return servletContext;
-									}
-
-								},
-								servletResponse);
-						}
-						else {
-							portalJSPServlet.service(
-								new ServletRequestWrapper(servletRequest) {
-
-									@Override
-									public ServletContext getServletContext() {
-										return servletContext;
-									}
-
-								},
-								servletResponse);
-						}
+						portalJSPServlet.service(
+							servletRequest, servletResponse);
 					}
 
 					@Override

--- a/modules/core/portal-jsp-engine/src/main/java/com/liferay/portal/jsp/engine/internal/JSPEngineShieldedContainerInitializer.java
+++ b/modules/core/portal-jsp-engine/src/main/java/com/liferay/portal/jsp/engine/internal/JSPEngineShieldedContainerInitializer.java
@@ -158,28 +158,8 @@ public class JSPEngineShieldedContainerInitializer
 		else {
 			FilterRegistration.Dynamic filterDynamic = servletContext.addFilter(
 				"Portal Jasper Filter",
-				new Filter() {
-
-					@Override
-					public void destroy() {
-					}
-
-					@Override
-					public void doFilter(
-							ServletRequest servletRequest,
-							ServletResponse servletResponse,
-							FilterChain filterChain)
-						throws IOException, ServletException {
-
-						portalJSPServlet.service(
-							servletRequest, servletResponse);
-					}
-
-					@Override
-					public void init(FilterConfig filterConfig) {
-					}
-
-				});
+				(servletRequest, servletResponse, filterChain) ->
+					portalJSPServlet.service(servletRequest, servletResponse));
 
 			filterDynamic.addMappingForUrlPatterns(
 				EnumSet.allOf(DispatcherType.class), true, "*.jsp", "*.jspx");

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/PortalWebShieldedContainerInitializer.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/PortalWebShieldedContainerInitializer.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.PortalSessionListener;
 import com.liferay.portal.servlet.filters.healthcheckdatasource.HealthCheckDataSourceFilter;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.web.internal.jboss.JBossServletContextFilter;
 import com.liferay.portal.web.internal.session.replication.SessionReplicationFilter;
 import com.liferay.shielded.container.Ordered;
 import com.liferay.shielded.container.ShieldedContainerInitializer;
@@ -125,6 +126,17 @@ public class PortalWebShieldedContainerInitializer
 
 			dynamic.addMappingForUrlPatterns(
 				EnumSet.of(DispatcherType.REQUEST), false, "/*");
+		}
+
+		if (ServerDetector.isJBoss() || ServerDetector.isWildfly()) {
+			FilterRegistration.Dynamic dynamic = servletContext.addFilter(
+				JBossServletContextFilter.class.getName(),
+				new JBossServletContextFilter(servletContext));
+
+			dynamic.setAsyncSupported(true);
+
+			dynamic.addMappingForUrlPatterns(
+				EnumSet.allOf(DispatcherType.class), false, "/*");
 		}
 
 		if (PropsValues.HEALTH_CHECK_DATA_SOURCE_ENABLED) {

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/jboss/JBossServletContextFilter.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/jboss/JBossServletContextFilter.java
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.web.internal.jboss;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+import java.io.IOException;
+
+/**
+ * @author Dante Wang
+ */
+public class JBossServletContextFilter implements Filter {
+
+	public JBossServletContextFilter(ServletContext servletContext) {
+		_servletContext = servletContext;
+	}
+
+	@Override
+	public void doFilter(
+			ServletRequest servletRequest, ServletResponse servletResponse,
+			FilterChain filterChain)
+		throws IOException, ServletException {
+
+		if (servletRequest instanceof HttpServletRequest) {
+			servletRequest = _getWrappedHttpServletRequest(
+				(HttpServletRequest)servletRequest);
+		}
+
+		filterChain.doFilter(servletRequest, servletResponse);
+	}
+
+	private HttpServletRequest _getWrappedHttpServletRequest(
+		HttpServletRequest httpServletRequest) {
+
+		HttpServletRequest wrappedHttpServletRequest = httpServletRequest;
+
+		while (wrappedHttpServletRequest instanceof
+					HttpServletRequestWrapper httpServletRequestWrapper) {
+
+			if (httpServletRequestWrapper instanceof
+					JBossServletContextHttpServletRequest) {
+
+				return httpServletRequest;
+			}
+
+			wrappedHttpServletRequest =
+				(HttpServletRequest)httpServletRequestWrapper.getRequest();
+		}
+
+		return new JBossServletContextHttpServletRequest(
+			httpServletRequest, _servletContext);
+	}
+
+	private final ServletContext _servletContext;
+
+}

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/jboss/JBossServletContextHttpServletRequest.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/jboss/JBossServletContextHttpServletRequest.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.web.internal.jboss;
+
+import com.liferay.portal.kernel.servlet.PersistentHttpServletRequestWrapper;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * @author Dante Wang
+ */
+public class JBossServletContextHttpServletRequest
+	extends PersistentHttpServletRequestWrapper {
+
+	public JBossServletContextHttpServletRequest(
+		HttpServletRequest httpServletRequest, ServletContext servletContext) {
+
+		super(httpServletRequest);
+
+		_servletContext = servletContext;
+	}
+
+	@Override
+	public ServletContext getServletContext() {
+		return _servletContext;
+	}
+
+	private final ServletContext _servletContext;
+
+}


### PR DESCRIPTION
- **LPD-X LPP-60322: register the filter that wraps the request to return the shielded container servlet context at a more common place**
- **Revert "LPD-36036 Ensure the shielded container ServletContext proxy is used to avoid conflicts between the app server and Liferay's Jasper JspApplicationContextImpl attribute"**
- **LPD-X SF, Filter is now an interface with only 1 must-implement method, so this impl can be a lambda**
